### PR TITLE
Fix concurrency issues + minor improvements

### DIFF
--- a/src/bigquery_proto_writer.cpp
+++ b/src/bigquery_proto_writer.cpp
@@ -288,8 +288,6 @@ void BigqueryProtoWriter::WriteChunk(DataChunk &chunk, const std::map<std::strin
         delete msg;
     }
 
-    lock_guard<mutex> lock(write_lock);
-
     if (!grpc_stream) {
         return InitAppendStream(request);
     }

--- a/src/bigquery_sql.cpp
+++ b/src/bigquery_sql.cpp
@@ -118,9 +118,10 @@ string BigquerySQL::AlterTableInfoToSQL(const string &project_id, const AlterTab
 	if (info.schema.empty()) {
 		throw BinderException("Schema not specified for AlterTableInfo");
 	}
+	auto table_string = BigqueryUtils::FormatTableStringSimple(project_id, info.schema, info.name);
 	std::stringstream stmt;
 	stmt << "ALTER TABLE ";
-	stmt << BigqueryUtils::FormatTableStringSimple(project_id, info.schema, info.name) << " ";
+	stmt << BigqueryUtils::WriteQuotedIdentifier(table_string) << " ";
 
 	switch (info.alter_table_type) {
 		case AlterTableType::RENAME_COLUMN: {
@@ -223,7 +224,8 @@ string BigquerySQL::CreateTableInfoToSQL(const string &project_id, const CreateT
         stmt << "IF NOT EXISTS ";
     }
     // Append the table name
-    stmt << BigqueryUtils::FormatTableStringSimple(project_id, info.schema, info.table) << " ";
+    auto table_string = BigqueryUtils::FormatTableStringSimple(project_id, info.schema, info.table);
+    stmt << BigqueryUtils::WriteQuotedIdentifier(table_string) << " ";
     stmt << BigqueryColumnsToSQL(info.columns, info.constraints);
     return stmt.str();
 }
@@ -242,7 +244,8 @@ string BigquerySQL::CreateViewInfoToSQL(const string &project_id, const CreateVi
         stmt << "IF NOT EXISTS ";
     }
     // Append the view name
-    stmt << BigqueryUtils::FormatTableStringSimple(info.catalog, info.schema, info.view_name) << " ";
+    auto table_string = BigqueryUtils::FormatTableStringSimple(info.catalog, info.schema, info.view_name);
+    stmt << BigqueryUtils::WriteQuotedIdentifier(table_string) << " ";
     if (!info.aliases.empty()) {
         stmt << "(";
         for (size_t i = 0; i < info.aliases.size(); i++) {

--- a/src/include/bigquery_proto_writer.hpp
+++ b/src/include/bigquery_proto_writer.hpp
@@ -14,6 +14,7 @@ public:
     ~BigqueryProtoWriter();
 
     void InitMessageDescriptor(BigqueryTableEntry *entry);
+    void InitAppendStream(google::cloud::bigquery::storage::v1::AppendRowsRequest &request);
     void CreateNestedMessage(google::protobuf::DescriptorProto *desc_proto,
                              const string &name,
                              const vector<pair<string, LogicalType>> &child_types);

--- a/src/include/bigquery_proto_writer.hpp
+++ b/src/include/bigquery_proto_writer.hpp
@@ -34,6 +34,7 @@ public:
                     const google::protobuf::FieldDescriptor *field,
                     const duckdb::LogicalType &col_type,
                     const duckdb::Value &val);
+    void Finalize();
 
 
 private:
@@ -46,8 +47,10 @@ private:
 
 
     unique_ptr<google::cloud::bigquery_storage_v1::BigQueryWriteClient> write_client;
+    std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<google::cloud::bigquery::storage::v1::AppendRowsRequest, google::cloud::bigquery::storage::v1::AppendRowsResponse>> grpc_stream;
     google::cloud::bigquery::storage::v1::WriteStream write_stream;
-    // google::cloud::bigquery::storage::v1::AppendRowsRequest append_request;
+    mutex write_lock;
+    atomic<int> write_count;
 };
 
 } // namespace bigquery

--- a/src/include/bigquery_proto_writer.hpp
+++ b/src/include/bigquery_proto_writer.hpp
@@ -50,8 +50,7 @@ private:
     unique_ptr<google::cloud::bigquery_storage_v1::BigQueryWriteClient> write_client;
     std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<google::cloud::bigquery::storage::v1::AppendRowsRequest, google::cloud::bigquery::storage::v1::AppendRowsResponse>> grpc_stream;
     google::cloud::bigquery::storage::v1::WriteStream write_stream;
-    mutex write_lock;
-    atomic<int> write_count;
+    int write_count;
 };
 
 } // namespace bigquery

--- a/src/include/storage/bigquery_catalog.hpp
+++ b/src/include/storage/bigquery_catalog.hpp
@@ -74,6 +74,7 @@ public:
 private:
     BigquerySchemaSet schemas;
     unique_ptr<BigquerySchemaEntry> default_dataset;
+    mutex default_dataset_lock;
 };
 
 } // namespace bigquery

--- a/src/include/storage/bigquery_catalog_set.hpp
+++ b/src/include/storage/bigquery_catalog_set.hpp
@@ -30,8 +30,11 @@ protected:
     Catalog &catalog;
 
 private:
-    bool is_loaded = false;
+    void TryLoadEntries(ClientContext &context);
+
+    atomic<bool> is_loaded = false;
     mutex entry_lock;
+    mutex load_lock;
     case_insensitive_map_t<unique_ptr<CatalogEntry>> entries;
 };
 

--- a/src/include/storage/bigquery_insert.hpp
+++ b/src/include/storage/bigquery_insert.hpp
@@ -42,7 +42,7 @@ public:
     }
 
     bool ParallelSink() const override {
-        return true;
+        return false;
     }
 
     string GetName() const override;

--- a/src/include/storage/bigquery_insert.hpp
+++ b/src/include/storage/bigquery_insert.hpp
@@ -34,6 +34,8 @@ public:
     // Sink interface
     unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
     SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
+    SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                      OperatorSinkFinalizeInput &input) const override;
 
     bool IsSink() const override {
         return true;

--- a/src/storage/bigquery_catalog.cpp
+++ b/src/storage/bigquery_catalog.cpp
@@ -39,6 +39,7 @@ void BigqueryCatalog::Initialize(bool load_builtin) {
 
 void BigqueryCatalog::ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) {
     if (!config.dataset_id.empty()) {
+        lock_guard<mutex> lock(default_dataset_lock);
         if (!default_dataset) {
             auto bq_transaction = dynamic_cast<BigqueryTransaction *>(GetCatalogTransaction(context).transaction.get());
             auto bq_client = bq_transaction->GetBigqueryClient();

--- a/src/storage/bigquery_insert.cpp
+++ b/src/storage/bigquery_insert.cpp
@@ -109,6 +109,14 @@ SinkResultType BigqueryInsert::Sink(ExecutionContext &context, DataChunk &chunk,
     return SinkResultType::NEED_MORE_INPUT;
 }
 
+// ### FINALIZE
+SinkFinalizeType BigqueryInsert::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                          OperatorSinkFinalizeInput &input) const {
+    auto &gstate = sink_state->Cast<BigqueryInsertGlobalState>();
+    gstate.writer->Finalize();
+    return SinkFinalizeType::READY;
+}
+
 // ### GET DATA
 SourceResultType BigqueryInsert::GetData(ExecutionContext &context,
                                          DataChunk &chunk,

--- a/test/sql/bigquery/attach_create_table.test
+++ b/test/sql/bigquery/attach_create_table.test
@@ -29,4 +29,12 @@ SELECT * FROM bq.${BQ_TEST_DATASET}.my_fancy_test_table;
 42
 
 statement ok
+DELETE FROM bq.${BQ_TEST_DATASET}.my_fancy_test_table WHERE i > 24;
+
+query I
+SELECT COUNT(*) FROM bq.${BQ_TEST_DATASET}.my_fancy_test_table;
+----
+0
+
+statement ok
 DROP TABLE bq.${BQ_TEST_DATASET}.my_fancy_test_table;

--- a/test/sql/bigquery/attach_default.test
+++ b/test/sql/bigquery/attach_default.test
@@ -12,6 +12,9 @@ statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
 statement ok
+SHOW ALL TABLES;
+
+statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.defaults_table;
 
 statement ok


### PR DESCRIPTION
I ran into some issues while using this extension, and made some changes to accommodate my use case. In summary:

1. Fixes a concurrency issue in loading the catalog entries which caused a segfault on running `show all tables` immediately after `attach`.
2. Quote table strings in BigQuery SQL for insert queries
3. Fixes a concurrency issue when performing inserts, which caused some writes to be dropped. Also increases throughput by several orders of magnitude.

Are you interested in adopting these changes? I can split it up into separate pull requests if you like, but wanted to check first before I put a lot of effort in that. Let me know!