### PR TITLE
Fix race condition in loading BigQuery catalog entries

### DIFF
--- a/src/include/storage/bigquery_catalog.hpp
+++ b/src/include/storage/bigquery_catalog.hpp
@@ -74,6 +74,7 @@ public:
 private:
     BigquerySchemaSet schemas;
     unique_ptr<BigquerySchemaEntry> default_dataset;
+    mutex default_dataset_lock;
 };
 
 } // namespace bigquery

--- a/src/include/storage/bigquery_catalog_set.hpp
+++ b/src/include/storage/bigquery_catalog_set.hpp
@@ -30,8 +30,11 @@ protected:
     Catalog &catalog;
 
 private:
-    bool is_loaded = false;
+    void TryLoadEntries(ClientContext &context);
+
+    atomic<bool> is_loaded = false;
     mutex entry_lock;
+    mutex load_lock;
     case_insensitive_map_t<unique_ptr<CatalogEntry>> entries;
 };
 

--- a/src/storage/bigquery_catalog.cpp
+++ b/src/storage/bigquery_catalog.cpp
@@ -39,6 +39,7 @@ void BigqueryCatalog::Initialize(bool load_builtin) {
 
 void BigqueryCatalog::ScanSchemas(ClientContext &context, std::function<void(SchemaCatalogEntry &)> callback) {
     if (!config.dataset_id.empty()) {
+        lock_guard<mutex> lock(default_dataset_lock);
         if (!default_dataset) {
             auto bq_transaction = dynamic_cast<BigqueryTransaction *>(GetCatalogTransaction(context).transaction.get());
             auto bq_client = bq_transaction->GetBigqueryClient();

--- a/test/sql/bigquery/attach_default.test
+++ b/test/sql/bigquery/attach_default.test
@@ -12,6 +12,9 @@ statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
 statement ok
+SHOW ALL TABLES;
+
+statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.defaults_table;
 
 statement ok


### PR DESCRIPTION
`BigqueryCatalog::ScanSchemas` can be called from multiple threads simultaneously. This was not handled properly, causing segfaults due to concurrent access to shared state.