### PR TITLE
Improve write stream handling

### DIFF
--- a/src/include/bigquery_proto_writer.hpp
+++ b/src/include/bigquery_proto_writer.hpp
@@ -47,6 +47,7 @@ private:
 
     unique_ptr<google::cloud::bigquery_storage_v1::BigQueryWriteClient> write_client;
     google::cloud::bigquery::storage::v1::WriteStream write_stream;
+    std::unique_ptr<google::cloud::AsyncStreamingReadWriteRpc<google::cloud::bigquery::storage::v1::AppendRowsRequest, google::cloud::bigquery::storage::v1::AppendRowsResponse>> grpc_stream;
     // google::cloud::bigquery::storage::v1::AppendRowsRequest append_request;
 };
 

--- a/src/include/bigquery_proto_writer.hpp
+++ b/src/include/bigquery_proto_writer.hpp
@@ -35,6 +35,7 @@ public:
                     const duckdb::LogicalType &col_type,
                     const duckdb::Value &val);
 
+    void Finalize();
 
 private:
     string table_string;

--- a/src/include/storage/bigquery_insert.hpp
+++ b/src/include/storage/bigquery_insert.hpp
@@ -34,6 +34,8 @@ public:
     // Sink interface
     unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
     SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
+    SinkFinalizeType Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                              OperatorSinkFinalizeInput &input) const override;
 
     bool IsSink() const override {
         return true;

--- a/src/storage/bigquery_insert.cpp
+++ b/src/storage/bigquery_insert.cpp
@@ -120,6 +120,14 @@ SourceResultType BigqueryInsert::GetData(ExecutionContext &context,
     return SourceResultType::FINISHED;
 }
 
+// ### FINALIZE
+SinkFinalizeType BigqueryInsert::Finalize(Pipeline &pipeline, Event &event, ClientContext &context,
+                                          OperatorSinkFinalizeInput &input) const {
+    auto &gstate = sink_state->Cast<BigqueryInsertGlobalState>();
+    gstate.writer->Finalize();
+    return SinkFinalizeType::READY;
+}
+
 // ### HELPERS
 string BigqueryInsert::GetName() const {
     return table ? "BIGQUERY_INSERT" : "BIGQUERY_CREATE_TABLE_AS";


### PR DESCRIPTION
Some improvements to how the write streams are handled:

1. Reuse gRPC streams across calls to WriteChunk for better throughput
2. Implement `Finalize` for cleanup (finish/close the gRPC stream, and finalize the write stream)
3. Use Pending stream type for atomic writes
