### PR TITLE
fixed USE with bq catalog

### DIFF
--- a/src/storage/bigquery_catalog.cpp
+++ b/src/storage/bigquery_catalog.cpp
@@ -70,7 +70,7 @@ optional_ptr<SchemaCatalogEntry> BigqueryCatalog::GetSchema(CatalogTransaction t
                                                             OnEntryNotFound if_not_found,
                                                             QueryErrorContext error_context) {
     auto schema_entry = schemas.GetEntry(transaction.GetContext(), schema_name);
-    if (!schema_entry && if_not_found == OnEntryNotFound::RETURN_NULL) {
+    if (!schema_entry && if_not_found != OnEntryNotFound::RETURN_NULL) {
         throw BinderException("Schema with name \"%s\" not found", schema_name);
     }
     return reinterpret_cast<SchemaCatalogEntry *>(schema_entry.get());

--- a/test/sql/bigquery/attach_use_logic.test
+++ b/test/sql/bigquery/attach_use_logic.test
@@ -1,0 +1,18 @@
+# name: test/sql/bigquery/attach_use_logic.test
+# description: Test the use logic
+# group: [bigquery]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
+
+statement ok
+USE bq.${BQ_TEST_DATASET};
+
+statement ok
+SHOW ALL TABLES;


### PR DESCRIPTION
This MR fixes `USE`-statements in combination with attached BigQuery catalogs. 

Example:
```
ATTACH 'project=my_gcp_project dataset=my_dataset' AS bq (TYPE bigquery);
USE bq.my_dataset;
```  