### PR TITLE
Fix attach default schema issue with main

### DIFF
--- a/src/include/storage/bigquery_catalog_set.hpp
+++ b/src/include/storage/bigquery_catalog_set.hpp
@@ -22,6 +22,7 @@ public:
 
     void Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback);
     optional_ptr<CatalogEntry> GetEntry(ClientContext &context, const string &name);
+	optional_ptr<CatalogEntry> GetFirstEntry(ClientContext &context);
 
 protected:
     virtual void LoadEntries(ClientContext &context) = 0;

--- a/src/storage/bigquery_catalog_set.cpp
+++ b/src/storage/bigquery_catalog_set.cpp
@@ -58,6 +58,16 @@ optional_ptr<CatalogEntry> BigqueryCatalogSet::GetEntry(ClientContext &context, 
     return entry->second.get();
 }
 
+optional_ptr<CatalogEntry> BigqueryCatalogSet::GetFirstEntry(ClientContext &context) {
+	TryLoadEntries(context);
+
+	lock_guard<mutex> lock(entry_lock);
+	if (entries.empty()) {
+		return nullptr;
+	}
+	return entries.begin()->second.get();
+}
+
 void BigqueryCatalogSet::ClearEntries() {
     lock_guard<mutex> lock(entry_lock);
     entries.clear();

--- a/test/sql/bigquery/attach_use_logic.test
+++ b/test/sql/bigquery/attach_use_logic.test
@@ -12,7 +12,30 @@ statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
 statement ok
+USE bq;
+
+statement error
+SET schema='some_schema'
+----
+Catalog Error: SET schema: No catalog + schema named "some_schema" found.
+
+statement ok
+SET schema='${BQ_TEST_DATASET}'
+
+statement ok
+DROP TABLE IF EXISTS use_logic_table;
+
+statement ok
+CREATE TABLE use_logic_table (i INTEGER);
+
+statement ok
 USE bq.${BQ_TEST_DATASET};
 
 statement ok
-SHOW ALL TABLES;
+SELECT * FROM use_logic_table;
+
+statement ok
+SELECT * FROM bq.${BQ_TEST_DATASET}.use_logic_table;
+
+statement ok
+DROP TABLE use_logic_table;


### PR DESCRIPTION
Fixing issues with the DEFAULT_SCHEMA which is by default main. Now it considers either the set `dataset=` as the default schema or the first in the dataset (for convenience).