### PR TITLE
Add the possibility to fetch results of arbitrary SQL queries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,16 @@ D CALL bigquery_execute('bq', '
 ');
 ```
 
+### `bigquery_query` Function
+
+The `bigquery_query` function is similar to `bigquery_scan`, but it allows you to specify a SQL query string to be executed directly in BigQuery. This function is especially useful to get around the limitations of the BigQuery Storage Read API, such as reading from views or external tables.
+
+```sql
+D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT * FROM `my_gcp_project.quacking_dataset.duck_tbl`');
+```
+
+It executes the query without further analyzing it in BigQuery. BigQuery transparently creates a temporary result table, which is fetched in exactly the same way as with `bigquery_scan`. The result table is a temporary table which will be deleted shortly after the query is executed.
+
 ### `bigquery_clear_cache` Function
 
 DuckDB caches schema metadata, such as datasets and table structures, to avoid repeated fetches from BigQuery. If the schema changes externally, use `bigquery_clear_cache` to update the cache and retrieve the latest schema information:

--- a/README.md
+++ b/README.md
@@ -173,12 +173,12 @@ D CALL bigquery_execute('bq', '
 ');
 ```
 
-### `bigquery_query` Function
+### `bigquery_select` Function
 
-The `bigquery_query` function is similar to `bigquery_scan`, but it allows you to specify a SQL query string to be executed directly in BigQuery. This function is especially useful to get around the limitations of the BigQuery Storage Read API, such as reading from views or external tables.
+The `bigquery_select` function is similar to `bigquery_scan`, but it allows you to specify a SQL query string to be executed directly in BigQuery. This function is especially useful to get around the limitations of the BigQuery Storage Read API, such as reading from views or external tables.
 
 ```sql
-D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT * FROM `my_gcp_project.quacking_dataset.duck_tbl`');
+D SELECT * FROM bigquery_select('my_gcp_project', 'SELECT * FROM `my_gcp_project.quacking_dataset.duck_tbl`');
 ```
 
 It executes the query without further analyzing it in BigQuery. BigQuery transparently creates a temporary result table, which is fetched in exactly the same way as with `bigquery_scan`. The result table is a temporary table which will be deleted shortly after the query is executed.
@@ -226,6 +226,8 @@ D SELECT * FROM bigquery_scan('bigquery-public-data.geo_us_boundaries.cnecta', b
 There are some limitations that arise from the combination of DuckDB and BigQuery. These include:
 
 * **Reading from Views**: This DuckDB extension utilizes the BigQuery Storage Read API to optimize reading results. However, this approach has limitations (see [here](https://cloud.google.com/bigquery/docs/reference/storage#limitations) for more information). First, the Storage Read API does not support direct reading from logical or materialized views. Second, reading external tables is not supported.
+
+To mitigate these limitations, you can use the `bigquery_select` function to execute the query directly in BigQuery.
 
 * **Propagation Delay**: After creating a table in BigQuery, there might be a brief propagation delay before the table becomes fully "visible". Therefore, be aware of potential delays when executing `CREATE TABLE ... AS` or `CREATE OR REPLACE TABLE ...` statements followed by immediate inserts. This delay is usually just a matter of seconds, but in rare cases, it can take up to a minute.
 

--- a/src/bigquery_arrow_reader.cpp
+++ b/src/bigquery_arrow_reader.cpp
@@ -643,5 +643,9 @@ int64_t BigqueryArrowReader::GetEstimatedRowCount() {
     return read_session->estimated_row_count();
 }
 
+BigqueryTableRef BigqueryArrowReader::GetTableRef() const {
+    return table_ref;
+}
+
 } // namespace bigquery
 } // namespace duckdb

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -415,6 +415,12 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
     return *response;
 }
 
+google::cloud::bigquery::v2::Job BigqueryClient::GetJob(google::cloud::bigquery::v2::QueryResponse &query_response) 
+{
+    auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+    auto job = GetJob(client, query_response.job_reference().job_id(), query_response.job_reference().location().value());
+    return job.value();
+}
 
 google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::GetJob(
     google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -30,8 +30,8 @@ static void LoadInternal(DatabaseInstance &instance) {
     bigquery::BigqueryScanFunction bigquery_scan_function;
     ExtensionUtil::RegisterFunction(instance, bigquery_scan_function);
 
-    bigquery::BigqueryQueryFunction bigquery_query_function;
-    ExtensionUtil::RegisterFunction(instance, bigquery_query_function);
+    bigquery::BigquerySelectFunction bigquery_select_function;
+    ExtensionUtil::RegisterFunction(instance, bigquery_select_function);
 
     bigquery::BigqueryClearCacheFunction clear_cache_function;
     ExtensionUtil::RegisterFunction(instance, clear_cache_function);

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -30,6 +30,9 @@ static void LoadInternal(DatabaseInstance &instance) {
     bigquery::BigqueryScanFunction bigquery_scan_function;
     ExtensionUtil::RegisterFunction(instance, bigquery_scan_function);
 
+    bigquery::BigqueryQueryFunction bigquery_query_function;
+    ExtensionUtil::RegisterFunction(instance, bigquery_query_function);
+
     bigquery::BigqueryClearCacheFunction clear_cache_function;
     ExtensionUtil::RegisterFunction(instance, clear_cache_function);
 

--- a/src/bigquery_scan.cpp
+++ b/src/bigquery_scan.cpp
@@ -111,6 +111,41 @@ private:
     }
 };
 
+static void SetFromNamedParameters(const TableFunctionBindInput &input, 
+                                  string &billing_project_id, 
+                                  string &api_endpoint, 
+                                  string &grpc_endpoint) 
+{
+    for (auto &kv : input.named_parameters) {
+        auto loption = StringUtil::Lower(kv.first);
+        if (loption == "billing_project") {
+            billing_project_id = kv.second.GetValue<string>();
+        } else if (loption == "api_endpoint") {
+            api_endpoint = kv.second.GetValue<string>();
+        } else if (loption == "grpc_endpoint") {
+            grpc_endpoint = kv.second.GetValue<string>();
+        }
+    }
+}
+
+static void ExtractTableInfo(shared_ptr<BigqueryArrowReader> arrow_reader,
+                             vector<string> &names,
+                             vector<LogicalType> &return_types) 
+{
+    ColumnList columns;
+    vector<unique_ptr<Constraint>> constraints;
+    arrow_reader->MapTableInfo(columns, constraints);   
+
+    for (auto &column : columns.Logical()) {
+        names.push_back(column.GetName());
+        return_types.push_back(column.GetType());
+    }       
+
+    if (names.empty()) {
+        auto table_ref = arrow_reader->GetTableRef();
+        throw std::runtime_error("no columns for table " + table_ref.table_id);
+    }
+}
 
 static unique_ptr<FunctionData> BigqueryBind(ClientContext &context,
                                              TableFunctionBindInput &input,
@@ -123,37 +158,15 @@ static unique_ptr<FunctionData> BigqueryBind(ClientContext &context,
     }
 
     string billing_project_id, api_endpoint, grpc_endpoint;
-    for (auto &kv : input.named_parameters) {
-        auto loption = StringUtil::Lower(kv.first);
-        if (loption == "billing_project") {
-            billing_project_id = kv.second.GetValue<string>();
-        } else if (loption == "api_endpoint") {
-            api_endpoint = kv.second.GetValue<string>();
-        } else if (loption == "grpc_endpoint") {
-            grpc_endpoint = kv.second.GetValue<string>();
-        }
-    }
+    SetFromNamedParameters(input, billing_project_id, api_endpoint, grpc_endpoint);
 
     auto result = make_uniq<BigqueryBindData>();
     result->table_ref = table_ref;
-    result->config =
-        BigqueryConfig(table_ref.project_id, table_ref.dataset_id, billing_project_id, api_endpoint, grpc_endpoint);
+    result->config = BigqueryConfig(table_ref.project_id, table_ref.dataset_id, billing_project_id, api_endpoint, grpc_endpoint);
     result->bq_client = make_shared_ptr<BigqueryClient>(result->config);
 
     auto arrow_reader = result->bq_client->CreateArrowReader(table_ref.dataset_id, table_ref.table_id, 1);
-
-    // Get the table info (columns, constraints, etc.)
-    ColumnList columns;
-    vector<unique_ptr<Constraint>> constraints;
-    arrow_reader->MapTableInfo(columns, constraints);
-
-    for (auto &column : columns.Logical()) {
-        names.push_back(column.GetName());
-        return_types.push_back(column.GetType());
-    }
-    if (names.empty()) {
-        throw std::runtime_error("no columns for table " + table_ref.table_id);
-    }
+    ExtractTableInfo(arrow_reader, names, return_types);
 
     // TODO GetMaxRowId
     result->estimated_row_count = idx_t(arrow_reader->GetEstimatedRowCount());
@@ -162,6 +175,42 @@ static unique_ptr<FunctionData> BigqueryBind(ClientContext &context,
     return std::move(result);
 }
 
+
+static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
+                                                 TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types,
+                                                 vector<string> &names) 
+{
+    auto project_id = input.inputs[0].GetValue<string>();
+    auto query_string = input.inputs[1].GetValue<string>();
+
+    string billing_project_id, api_endpoint, grpc_endpoint;
+    SetFromNamedParameters(input, billing_project_id, api_endpoint, grpc_endpoint);
+
+    auto bq_config = BigqueryConfig(project_id, "", billing_project_id, api_endpoint, grpc_endpoint);
+    auto bq_client = make_shared_ptr<BigqueryClient>(bq_config);
+
+    auto query_response = bq_client->ExecuteQuery(query_string);
+    auto job = bq_client->GetJob(query_response);
+    auto destination_table = job.configuration().query().destination_table();
+    auto table_ref = BigqueryTableRef(destination_table.project_id(), 
+                                      destination_table.dataset_id(), 
+                                      destination_table.table_id());
+    
+    auto result = make_uniq<BigqueryBindData>();
+    result->config = bq_config;
+    result->bq_client = bq_client;
+    result->table_ref = table_ref;
+
+    auto arrow_reader = result->bq_client->CreateArrowReader(table_ref.dataset_id, table_ref.table_id, 1);
+    ExtractTableInfo(arrow_reader, names, return_types);
+
+    result->estimated_row_count = idx_t(arrow_reader->GetEstimatedRowCount());
+    result->names = names;
+    result->types = return_types;
+
+    return std::move(result);
+}
 
 static unique_ptr<GlobalTableFunctionState> BigqueryInitGlobalState(ClientContext &context,
                                                                     TableFunctionInitInput &input) {
@@ -289,6 +338,24 @@ BigqueryScanFunction::BigqueryScanFunction()
     named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
 }
 
+BigqueryQueryFunction::BigqueryQueryFunction()
+    : TableFunction("bigquery_query",
+                    {LogicalType::VARCHAR, LogicalType::VARCHAR},
+                    BigqueryScan,
+                    BigqueryQueryBind,
+                    BigqueryInitGlobalState,
+                    BigqueryInitLocalState) 
+{
+    to_string = BigqueryToString;
+    cardinality = BigqueryScanCardinality;
+    table_scan_progress = BigqueryScanProgress;
+    projection_pushdown = true;
+    filter_pushdown = true;
+
+    named_parameters["billing_project"] = LogicalType::VARCHAR;
+    named_parameters["api_endpoint"] = LogicalType::VARCHAR;
+    named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
+}
 
 } // namespace bigquery
 } // namespace duckdb

--- a/src/bigquery_scan.cpp
+++ b/src/bigquery_scan.cpp
@@ -176,10 +176,10 @@ static unique_ptr<FunctionData> BigqueryBind(ClientContext &context,
 }
 
 
-static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
-                                                 TableFunctionBindInput &input,
-                                                 vector<LogicalType> &return_types,
-                                                 vector<string> &names) 
+static unique_ptr<FunctionData> BigquerySelectBind(ClientContext &context,
+                                                   TableFunctionBindInput &input,
+                                                   vector<LogicalType> &return_types,
+                                                   vector<string> &names) 
 {
     auto project_id = input.inputs[0].GetValue<string>();
     auto query_string = input.inputs[1].GetValue<string>();
@@ -338,11 +338,11 @@ BigqueryScanFunction::BigqueryScanFunction()
     named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
 }
 
-BigqueryQueryFunction::BigqueryQueryFunction()
-    : TableFunction("bigquery_query",
+BigquerySelectFunction::BigquerySelectFunction()
+    : TableFunction("bigquery_select",
                     {LogicalType::VARCHAR, LogicalType::VARCHAR},
                     BigqueryScan,
-                    BigqueryQueryBind,
+                    BigquerySelectBind,
                     BigqueryInitGlobalState,
                     BigqueryInitLocalState) 
 {

--- a/src/include/bigquery_arrow_reader.hpp
+++ b/src/include/bigquery_arrow_reader.hpp
@@ -41,6 +41,8 @@ public:
     std::shared_ptr<arrow::Schema> ReadSchema(const google::cloud::bigquery::storage::v1::ArrowSchema &schema);
     std::shared_ptr<arrow::RecordBatch> ReadBatch(const google::cloud::bigquery::storage::v1::ArrowRecordBatch &batch);
 
+    BigqueryTableRef GetTableRef() const;
+
 private:
     void ReadSimpleColumn(const std::shared_ptr<arrow::Array> &column, Vector &out_vec);
     void ReadListColumn(const std::shared_ptr<arrow::ListArray> &list_array, Vector &out_vec);

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -53,6 +53,7 @@ public:
                       vector<unique_ptr<Constraint>> &res_constraints);
 
     google::cloud::bigquery::v2::QueryResponse ExecuteQuery(const string &query, const string &location = "");
+    google::cloud::bigquery::v2::Job GetJob(google::cloud::bigquery::v2::QueryResponse &query_response);
 
     shared_ptr<BigqueryArrowReader> CreateArrowReader(const string &dataset_id,
                                                       const string &table_id,

--- a/src/include/bigquery_scan.hpp
+++ b/src/include/bigquery_scan.hpp
@@ -39,9 +39,9 @@ public:
     BigqueryScanFunction();
 };
 
-class BigqueryQueryFunction : public TableFunction {
+class BigquerySelectFunction : public TableFunction {
 public:
-    BigqueryQueryFunction();
+    BigquerySelectFunction();
 };
 
 } // namespace bigquery

--- a/src/include/bigquery_scan.hpp
+++ b/src/include/bigquery_scan.hpp
@@ -39,5 +39,10 @@ public:
     BigqueryScanFunction();
 };
 
+class BigqueryQueryFunction : public TableFunction {
+public:
+    BigqueryQueryFunction();
+};
+
 } // namespace bigquery
 } // namespace duckdb

--- a/test/sql/bigquery/bigquery_select_simple.test
+++ b/test/sql/bigquery/bigquery_select_simple.test
@@ -1,0 +1,64 @@
+# name: test/sql/bigquery/bigquery_select_simple.test
+# description: Test selecting from a few simple tables
+# group: [bigquery]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+SET bq_debug_show_queries = true;
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.test_cities;
+
+statement ok
+DROP VIEW IF EXISTS bq.${BQ_TEST_DATASET}.test_cities_view;
+
+statement ok
+CREATE TABLE bq.${BQ_TEST_DATASET}.test_cities AS
+SELECT *
+FROM (
+    VALUES 
+    ('Amsterdam', 1000, 'NL'), 
+    ('London', 2000, 'GB'),
+    ('New York', 3000, 'US'),
+    ('Paris', 4000, 'FR'),
+    ('Tokyo', 5000, 'JP'),
+    ('Sydney', 6000, 'AU'),
+    ('Cape Town', 7000, 'ZA'),
+    ('Rio de Janeiro', 8000, 'BR'),
+    ('Cairo', 9000, 'EG'),
+    ('Mumbai', 10000, 'IN'),
+    ('Beijing', 11000, 'CN'),
+    ('Mexico City', 12000, 'MX'),
+    ('Lima', 13000, 'PE'),
+    ('Santiago', 14000, 'CL'),
+) 
+cities(name, id, country_code);
+
+statement ok
+CALL bigquery_execute('bq', 'CREATE VIEW ${BQ_TEST_DATASET}.test_cities_view AS SELECT * FROM ${BQ_TEST_DATASET}.test_cities');
+
+query I
+SELECT count(*) FROM bigquery_select('${BQ_TEST_PROJECT}', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view');
+----
+14
+
+query I
+SELECT name FROM bigquery_select('${BQ_TEST_PROJECT}', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view ORDER BY name ASC LIMIT 1');
+----
+Amsterdam
+
+statement ok
+CALL bigquery_execute('bq', 'DROP VIEW ${BQ_TEST_DATASET}.test_cities_view;');
+
+statement ok
+DROP TABLE bq.${BQ_TEST_DATASET}.test_cities;
+
+


### PR DESCRIPTION
This simple addition makes minimal changes to the `bigquery_scan` function. 

- It combines the already existing functionality for query execution with the scan functionality
- It executes a BigQuery statement, typically `SELECT`, and get the temporary destination table from the job.
- Then it executes exactly the same logic as a normal table scan

This makes it possible to also read from views. (It is a workaround to query arbitrary BigQuery objects also used e.g. by the Spark BQ connector).

Open points: 
- [x]  Not sure how to handle testing? Can you maybe give advice.
- [x]  The destination table is temporary. However, should there be cleanup with explicit delete happening after the scan?