### PR TITLE
Enhancing BigQuery NUMERIC and BIGNUMERIC Support 

### DIFF
--- a/src/bigquery_utils.cpp
+++ b/src/bigquery_utils.cpp
@@ -290,19 +290,20 @@ LogicalType BigqueryUtils::ArrowTypeToLogicalType(const std::shared_ptr<arrow::D
         return LogicalType::DECIMAL(precision, scale);
     }
     case arrow::Type::DECIMAL256: {
-        auto decimal_type = std::static_pointer_cast<arrow::Decimal256Type>(arrow_type);
-        int32_t precision = decimal_type->precision();
-        int32_t scale = decimal_type->scale();
+        // auto decimal_type = std::static_pointer_cast<arrow::Decimal256Type>(arrow_type);
+        // int32_t precision = decimal_type->precision();
+        // int32_t scale = decimal_type->scale();
 
-        // DuckDB only supports up to DECIMAL(38,scale). So we need to convert DECIMAL256 to
-        // DECIMAL(38,scale) if precision is greater than 38.
-        if (precision > 38) {
-            precision = 38;
-            // Adjust the scale if necessary, ensuring it remains within practical limits.
-            // This adjustment strategy for the scale is simplistic.
-            scale = std::min(scale, precision - 1);
-        }
-        return LogicalType::DECIMAL(precision, scale);
+        // // DuckDB only supports up to DECIMAL(38,scale). So we need to convert DECIMAL256 to
+        // // DECIMAL(38,scale) if precision is greater than 38.
+        // if (precision > 38) {
+        //     precision = 38;
+        //     // Adjust the scale if necessary, ensuring it remains within practical limits.
+        //     // This adjustment strategy for the scale is simplistic.
+        //     scale = std::min(scale, precision - 1);
+        // }
+        // return LogicalType::DECIMAL(precision, scale);
+        throw InternalException("BIGNUMERIC precision of 76 exceeds the maximum supported precision of 38 in DuckDB.");
     }
     case arrow::Type::LIST: {
         auto list_type = std::static_pointer_cast<arrow::ListType>(arrow_type);

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -179,8 +179,12 @@ public:
 
     static string LogicalTypeToBigquerySQL(const LogicalType &type);
 	static LogicalType BigquerySQLToLogicalType(const string &type);
+	static LogicalType BigqueryNumericSQLToLogicalType(const string &type);
 
     static string IntervalToBigqueryIntervalString(const interval_t &interval);
+
+	static string DecimalToString(const hugeint_t &value, const LogicalType &type);
+	static pair<int, int> ParseNumericPrecisionAndScale(const string &type);
 
 private:
 	static vector<string> SplitStructFields(const string &struct_field_str);

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -21,19 +21,19 @@ struct BigqueryUtils;
 
 struct BigqueryConfig {
 public:
-	BigqueryConfig() = default;
+    BigqueryConfig() = default;
 
-	explicit BigqueryConfig(const string &project_id) : project_id(project_id) {
-		if (project_id.empty()) {
-			throw std::invalid_argument("Project ID is required and cannot be empty.");
-		}
-	}
+    explicit BigqueryConfig(const string &project_id) : project_id(project_id) {
+        if (project_id.empty()) {
+            throw std::invalid_argument("Project ID is required and cannot be empty.");
+        }
+    }
 
     BigqueryConfig(const BigqueryConfig &other) = default;
     BigqueryConfig &operator=(const BigqueryConfig &other) = default;
     ~BigqueryConfig() = default;
 
-    BigqueryConfig& SetProjectId(const std::string &project_id) {
+    BigqueryConfig &SetProjectId(const std::string &project_id) {
         if (project_id.empty()) {
             throw std::invalid_argument("Project ID is required and cannot be empty.");
         }
@@ -41,22 +41,22 @@ public:
         return *this;
     }
 
-    BigqueryConfig& SetDatasetId(const std::string &dataset_id) {
+    BigqueryConfig &SetDatasetId(const std::string &dataset_id) {
         this->dataset_id = dataset_id;
         return *this;
     }
 
-    BigqueryConfig& SetBillingProjectId(const std::string &billing_project_id) {
+    BigqueryConfig &SetBillingProjectId(const std::string &billing_project_id) {
         this->billing_project_id = billing_project_id;
         return *this;
     }
 
-    BigqueryConfig& SetApiEndpoint(const std::string &api_endpoint) {
+    BigqueryConfig &SetApiEndpoint(const std::string &api_endpoint) {
         this->api_endpoint = api_endpoint;
         return *this;
     }
 
-    BigqueryConfig& SetGrpcEndpoint(const std::string &grpc_endpoint) {
+    BigqueryConfig &SetGrpcEndpoint(const std::string &grpc_endpoint) {
         this->grpc_endpoint = grpc_endpoint;
         return *this;
     }
@@ -102,10 +102,10 @@ public:
 };
 
 struct BigqueryDatasetRef {
-	BigqueryDatasetRef() = default;
-	BigqueryDatasetRef(const string &project_id, const string &dataset_id)
-		: project_id(project_id), dataset_id(dataset_id) {
-	}
+    BigqueryDatasetRef() = default;
+    BigqueryDatasetRef(const string &project_id, const string &dataset_id)
+        : project_id(project_id), dataset_id(dataset_id) {
+    }
 
     const bool has_dataset_id() const {
         return dataset_id != "";
@@ -175,20 +175,21 @@ public:
 
     static LogicalType CastToBigqueryType(const LogicalType &type);
     static LogicalType FieldSchemaToLogicalType(const google::cloud::bigquery::v2::TableFieldSchema &field);
+    static LogicalType FieldSchemaNumericToLogicalType(const google::cloud::bigquery::v2::TableFieldSchema &field);
     static LogicalType ArrowTypeToLogicalType(const std::shared_ptr<arrow::DataType> &arrow_type);
 
     static string LogicalTypeToBigquerySQL(const LogicalType &type);
-	static LogicalType BigquerySQLToLogicalType(const string &type);
-	static LogicalType BigqueryNumericSQLToLogicalType(const string &type);
+    static LogicalType BigquerySQLToLogicalType(const string &type);
+    static LogicalType BigqueryNumericSQLToLogicalType(const string &type);
 
     static string IntervalToBigqueryIntervalString(const interval_t &interval);
 
-	static string DecimalToString(const hugeint_t &value, const LogicalType &type);
-	static pair<int, int> ParseNumericPrecisionAndScale(const string &type);
+    static string DecimalToString(const hugeint_t &value, const LogicalType &type);
+    static pair<int, int> ParseNumericPrecisionAndScale(const string &type);
 
 private:
-	static vector<string> SplitStructFields(const string &struct_field_str);
-	static string StructRemoveWhitespaces(const string &struct_str);
+    static vector<string> SplitStructFields(const string &struct_field_str);
+    static string StructRemoveWhitespaces(const string &struct_str);
 };
 
 

--- a/test/sql/bigquery/attach_types_numeric.test
+++ b/test/sql/bigquery/attach_types_numeric.test
@@ -44,10 +44,44 @@ statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table;
 
 statement ok
+CREATE OR REPLACE TABLE bq.${BQ_TEST_DATASET}.numeric_table (
+	numeric_column DECIMAL(38, 9),
+	numeric_list DECIMAL(38, 9)[]
+);
+
+statement ok
+INSERT INTO bq.${BQ_TEST_DATASET}.numeric_table
+VALUES (
+    CAST(12345.678901234 AS DECIMAL(38, 9)),
+    [
+        CAST(123.45 AS DECIMAL(38, 9)),
+        CAST(6789.01 AS DECIMAL(38, 9)),
+        CAST(234.56 AS DECIMAL(38, 9))
+    ]
+);
+
+query II
+SELECT * FROM bq.${BQ_TEST_DATASET}.numeric_table;
+----
+12345.678901234	[123.450000000, 6789.010000000, 234.560000000]
+
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table;
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.bignumeric_table;
+
+statement ok
 CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.numeric_table` AS
 SELECT
     CAST(12345.678901234 AS NUMERIC) AS numeric_column,
     [CAST(123.45 AS NUMERIC), CAST(6789.01 AS NUMERIC), CAST(234.56 AS NUMERIC)] AS numeric_list');
+
+statement ok
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.bignumeric_table` AS
+SELECT
+    CAST(12345.678901234 AS BIGNUMERIC) AS numeric_column');
 
 statement ok
 CALL bigquery_clear_cache();
@@ -57,5 +91,13 @@ SELECT * FROM bq.${BQ_TEST_DATASET}.numeric_table;
 ----
 12345.678901234	[123.450000000, 6789.010000000, 234.560000000]
 
+query I
+SELECT table_name FROM information_schema.tables WHERE table_schema='${BQ_TEST_DATASET}' AND table_name='bignumeric_table';
+----
+
+
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table;
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.bignumeric_table;

--- a/test/sql/bigquery/attach_types_numeric.test
+++ b/test/sql/bigquery/attach_types_numeric.test
@@ -39,3 +39,23 @@ NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
 
 statement ok
 DROP TABLE bq.${BQ_TEST_DATASET}.table_numerics;
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table;
+
+statement ok
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.numeric_table` AS
+SELECT
+    CAST(12345.678901234 AS NUMERIC) AS numeric_column,
+    [CAST(123.45 AS NUMERIC), CAST(6789.01 AS NUMERIC), CAST(234.56 AS NUMERIC)] AS numeric_list');
+
+statement ok
+CALL bigquery_clear_cache();
+
+query II
+SELECT * FROM bq.${BQ_TEST_DATASET}.numeric_table;
+----
+12345.678901234	[123.450000000, 6789.010000000, 234.560000000]
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table;

--- a/test/sql/bigquery/attach_types_numeric.test
+++ b/test/sql/bigquery/attach_types_numeric.test
@@ -73,13 +73,13 @@ statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.bignumeric_table;
 
 statement ok
-CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.numeric_table` AS
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.numeric_table` AS
 SELECT
     CAST(12345.678901234 AS NUMERIC) AS numeric_column,
     [CAST(123.45 AS NUMERIC), CAST(6789.01 AS NUMERIC), CAST(234.56 AS NUMERIC)] AS numeric_list');
 
 statement ok
-CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.bignumeric_table` AS
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.bignumeric_table` AS
 SELECT
     CAST(12345.678901234 AS BIGNUMERIC) AS numeric_column');
 


### PR DESCRIPTION
This PR introduces enhancements and fixes for handling NUMERIC and BIGNUMERIC values in DuckDB:

- Support for NUMERIC values: Reading and writing NUMERIC values is now fully implemented.
- Partial support for BIGNUMERIC values: BIGNUMERIC values are supported up to the maximum precision and scale allowed by DuckDB.
- Precision and scale parsing: Parameterized NUMERIC types now correctly parse and utilize precision and scale values.
- Validation of precision and scale: Columns with unsupported precision or scale are skipped during catalog fetching, ensuring consistent behavior and avoiding runtime errors.

Fixes #54