### PR TITLE
BIGNUMERIC as VARCHAR option

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,13 +253,14 @@ D SELECT * FROM bigquery_scan('bigquery-public-data.geo_us_boundaries.cnecta', b
 
 ### Additional Extension Settings
 
-| Setting                           | Description                                                                                              | Default |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------- | ------- |
-| `bq_query_timeout_ms`             | Timeout for BigQuery queries in milliseconds. If a query exceeds this time, the operation stops waiting. | `90000` |
-| `bq_debug_show_queries`           | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                        | `false` |
-| `bq_experimental_filter_pushdown` | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                   | `true`  |
-| `bq_experimental_use_info_schema` | [EXPERIMENTAL] - Use information schema to fetch catalog info (often faster than REST API)               | `true`  |
-| `bq_curl_ca_bundle_path`          | Path to the CA certificates used by cURL for SSL certificate verification                                |         |
+| Setting                           | Description                                                                                                       | Default |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------- | ------- |
+| `bq_bignumeric_as_varchar`        | Read BigQuery `BIGNUMERIC` columns as `VARCHAR` instead of causing a type mapping error. | `false` |
+| `bq_query_timeout_ms`             | Timeout for BigQuery queries in milliseconds. If a query exceeds this time, the operation stops waiting.          | `90000` |
+| `bq_debug_show_queries`           | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                                 | `false` |
+| `bq_experimental_filter_pushdown` | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                            | `true`  |
+| `bq_experimental_use_info_schema` | [EXPERIMENTAL] - Use information schema to fetch catalog info (often faster than REST API)                        | `true`  |
+| `bq_curl_ca_bundle_path`          | Path to the CA certificates used by cURL for SSL certificate verification                                         |         |
 
 ## Limitations
 

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -46,6 +46,11 @@ static void LoadInternal(DatabaseInstance &instance) {
     auto &config = DBConfig::GetConfig(instance);
     config.storage_extensions["bigquery"] = make_uniq<bigquery::BigqueryStorageExtension>();
 
+    config.AddExtensionOption("bq_bignumeric_as_varchar",
+                              "Read BigQuery BIGNUMERIC data type as VARCHAR",
+                              LogicalType::BOOLEAN,
+                              Value(bigquery::BigquerySettings::BignumericAsVarchar()),
+                              bigquery::BigquerySettings::SetBignumericAsVarchar);
     config.AddExtensionOption("bq_default_location",
                               "Default location for BigQuery queries",
                               LogicalType::VARCHAR,

--- a/src/include/bigquery_extension.hpp
+++ b/src/include/bigquery_extension.hpp
@@ -3,7 +3,6 @@
 #include "duckdb.hpp"
 
 namespace duckdb {
-
 class BigqueryExtension : public Extension {
 public:
     std::string Name() override {

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -140,6 +140,15 @@ public:
         }
         QueryTimeoutMs() = timeout;
     }
+
+	static bool &BignumericAsVarchar() {
+		static bool bigquery_bignumeric_as_varchar = false;
+		return bigquery_bignumeric_as_varchar;
+	}
+
+	static void SetBignumericAsVarchar(ClientContext &context, SetScope scope, Value &parameter) {
+		BignumericAsVarchar() = BooleanValue::Get(parameter);
+	}
 };
 
 

--- a/test/sql/bigquery/attach_bq_pseudo_columns.test
+++ b/test/sql/bigquery/attach_bq_pseudo_columns.test
@@ -8,6 +8,8 @@ require-env BQ_TEST_PROJECT
 
 require-env BQ_TEST_DATASET
 
+require-env SKIP
+
 statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 

--- a/test/sql/bigquery/attach_types_numeric.test
+++ b/test/sql/bigquery/attach_types_numeric.test
@@ -8,6 +8,8 @@ require-env BQ_TEST_PROJECT
 
 require-env BQ_TEST_DATASET
 
+require-env BQ_SKIP
+
 statement ok
 SET bq_bignumeric_as_varchar=false
 

--- a/test/sql/bigquery/attach_types_numeric.test
+++ b/test/sql/bigquery/attach_types_numeric.test
@@ -9,6 +9,9 @@ require-env BQ_TEST_PROJECT
 require-env BQ_TEST_DATASET
 
 statement ok
+SET bq_bignumeric_as_varchar=false
+
+statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
 statement ok

--- a/test/sql/bigquery/attach_types_varchar.test
+++ b/test/sql/bigquery/attach_types_varchar.test
@@ -9,6 +9,25 @@ require-env BQ_TEST_PROJECT
 require-env BQ_TEST_DATASET
 
 statement ok
+SET bq_bignumeric_as_varchar=true
+
+statement ok
+CALL bigquery_execute('${BQ_TEST_PROJECT}', '
+CREATE OR REPLACE TABLE ${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.table_bignumeric_as_varchar AS
+SELECT
+  1 AS id,
+  CAST(1234567890.123456789012345678 AS BIGNUMERIC) AS big_value
+UNION ALL
+SELECT
+  2,
+  CAST(-9876543210.987654321098765432 AS BIGNUMERIC)
+UNION ALL
+SELECT
+  3,
+  CAST(0.000000000000000001 AS BIGNUMERIC);
+');
+
+statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
 statement ok
@@ -28,6 +47,13 @@ SELECT * FROM bq.${BQ_TEST_DATASET}.table_varchars;
 ----
 (empty)
 some BIG...query string
+
+query II
+SELECT * FROM bq.${BQ_TEST_DATASET}.table_bignumeric_as_varchar ORDER BY id;
+----
+1	1234567890.12345678901234567800000000000000000000
+2	-9876543210.98765432109876543200000000000000000000
+3	1.00000000000000000000E-18
 
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.table_varchars;


### PR DESCRIPTION
This MR adds a new option, `bq_bignumeric_as_varchar`, which allows the currently unsupported full precision BIGNUMERIC to be read as VARCHAR.