### PR TITLE
Remove inconsistent support for HUGEINT and UHUGEINT

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -12,6 +12,25 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
+    skip-push-if-pr-exists:
+        if: github.event_name == 'push'
+        runs-on: ubuntu-latest
+        outputs:
+            should_continue: ${{ steps.check.outputs.should_continue }}
+        steps:
+          - name: Check if push is part of an open PR
+            id: check
+            uses: actions/github-script@v7
+            with:
+                script: |
+                    const prs = await github.rest.pulls.list({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        head: `${context.repo.owner}:${context.ref.replace('refs/heads/', '')}`,
+                        state: 'open'
+                    });
+                    core.setOutput('should_continue', prs.data.length === 0 ? 'true' : 'false');
+
     duckdb-stable-build:
         name: Build extension binaries
         uses: ./.github/workflows/_extension_distribution.yml

--- a/src/bigquery_utils.cpp
+++ b/src/bigquery_utils.cpp
@@ -587,12 +587,16 @@ string BigqueryUtils::LogicalTypeToBigquerySQL(const LogicalType &type) {
     case LogicalTypeId::INTEGER:
     case LogicalTypeId::BIGINT:
         return "INT64";
+	case LogicalTypeId::HUGEINT:
+        throw NotImplementedException("HUGEINT not supported in BigQuery.");
     case LogicalTypeId::UTINYINT:
     case LogicalTypeId::USMALLINT:
     case LogicalTypeId::UINTEGER:
         return "INT64"; // BigQuery does not differentiate unsigned types
     case LogicalTypeId::UBIGINT:
-        return "STRING";
+        throw NotImplementedException("UBIGINT not supported in BigQuery.");
+	case LogicalTypeId::UHUGEINT:
+		throw NotImplementedException("UHUGEINT not supported in BigQuery.");
     case LogicalTypeId::FLOAT:
     case LogicalTypeId::DOUBLE:
         return "FLOAT64";
@@ -602,8 +606,6 @@ string BigqueryUtils::LogicalTypeToBigquerySQL(const LogicalType &type) {
         return "DATE";
     case LogicalTypeId::DECIMAL:
         return "NUMERIC";
-    case LogicalTypeId::HUGEINT:
-        return "BIGNUMERIC";
     case LogicalTypeId::TIME:
         return "TIME";
     case LogicalTypeId::TIMESTAMP:

--- a/test/sql/bigquery/attach_types_numeric.test
+++ b/test/sql/bigquery/attach_types_numeric.test
@@ -8,18 +8,18 @@ require-env BQ_TEST_PROJECT
 
 require-env BQ_TEST_DATASET
 
-require-env BQ_SKIP
-
 statement ok
 SET bq_bignumeric_as_varchar=false
 
 statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
+###########################################
+# test multiple numeric types
+###########################################
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.table_numerics;
 
-# test multiple types
 statement ok
 CREATE TABLE bq.${BQ_TEST_DATASET}.table_numerics AS
 SELECT
@@ -45,6 +45,28 @@ NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL
 statement ok
 DROP TABLE bq.${BQ_TEST_DATASET}.table_numerics;
 
+###########################################
+# HUGEINT, UHUGEINT, UBIGINT (not supported)
+###########################################
+statement error
+CREATE TABLE bq.${BQ_TEST_DATASET}.hugeint_table (h HUGEINT);
+----
+Not implemented Error: HUGEINT not supported in BigQuery.
+
+statement error
+CREATE TABLE bq.${BQ_TEST_DATASET}.uhugeint_table (h UHUGEINT);
+----
+Not implemented Error: UHUGEINT not supported in BigQuery.
+
+statement error
+CREATE TABLE bq.${BQ_TEST_DATASET}.ubigint_table (h UHUGEINT);
+----
+Not implemented Error: UBIGINT not supported in BigQuery.
+
+
+###########################################
+# NUMERIC test
+###########################################
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table;
 
@@ -70,18 +92,35 @@ SELECT * FROM bq.${BQ_TEST_DATASET}.numeric_table;
 ----
 12345.678901234	[123.450000000, 6789.010000000, 234.560000000]
 
-
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table;
 
 statement ok
-DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.bignumeric_table;
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table2;
 
 statement ok
-CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.numeric_table` AS
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.numeric_table2` AS
 SELECT
     CAST(12345.678901234 AS NUMERIC) AS numeric_column,
     [CAST(123.45 AS NUMERIC), CAST(6789.01 AS NUMERIC), CAST(234.56 AS NUMERIC)] AS numeric_list');
+
+statement ok
+CALL bigquery_clear_cache();
+
+query II
+SELECT * FROM bq.${BQ_TEST_DATASET}.numeric_table2;
+----
+12345.678901234	[123.450000000, 6789.010000000, 234.560000000]
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table2;
+
+
+###########################################
+# BIGNUMERIC test
+###########################################
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.bignumeric_table;
 
 statement ok
 CALL bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.bignumeric_table` AS
@@ -91,18 +130,20 @@ SELECT
 statement ok
 CALL bigquery_clear_cache();
 
-query II
-SELECT * FROM bq.${BQ_TEST_DATASET}.numeric_table;
-----
-12345.678901234	[123.450000000, 6789.010000000, 234.560000000]
-
 query I
 SELECT table_name FROM information_schema.tables WHERE table_schema='${BQ_TEST_DATASET}' AND table_name='bignumeric_table';
 ----
 
+statement ok
+CALL bigquery_clear_cache();
 
 statement ok
-DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.numeric_table;
+SET bq_bignumeric_as_varchar=true
+
+query I
+SELECT * FROM bq.${BQ_TEST_DATASET}.bignumeric_table;
+----
+12345.67890123400000000000000000000000000000
 
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.bignumeric_table;

--- a/test/sql/bigquery/attach_types_numeric.test
+++ b/test/sql/bigquery/attach_types_numeric.test
@@ -59,7 +59,7 @@ CREATE TABLE bq.${BQ_TEST_DATASET}.uhugeint_table (h UHUGEINT);
 Not implemented Error: UHUGEINT not supported in BigQuery.
 
 statement error
-CREATE TABLE bq.${BQ_TEST_DATASET}.ubigint_table (h UHUGEINT);
+CREATE TABLE bq.${BQ_TEST_DATASET}.ubigint_table (h UBIGINT);
 ----
 Not implemented Error: UBIGINT not supported in BigQuery.
 


### PR DESCRIPTION
`HUGEINT` and `UHUGEINT` columns were incorrectly created as `BIGDECIMAL`, even though these types are not compatible. This caused inconsistencies between the declared table schema and the actual data read behavior. This merge request removes support for `HUGEINT and `UHUGEINT` to ensure consistency.

Fixes #80 

