### PR TITLE
Refactored Arrow reader; fixed some complex type mappings

### DIFF
--- a/src/bigquery_arrow_reader.cpp
+++ b/src/bigquery_arrow_reader.cpp
@@ -30,8 +30,8 @@ BigqueryArrowReader::BigqueryArrowReader(const BigqueryTableRef table_ref,
                                          const google::cloud::Options &options,
                                          const vector<string> &selected_columns,
                                          const string &filter_condition)
-    : table_ref(table_ref), billing_project_id(billing_project_id), num_streams(num_streams), options(options),
-      localhost_test_env(false) {
+    : table_ref(table_ref), billing_project_id(billing_project_id), num_streams(num_streams),
+      options(options), localhost_test_env(false) {
 
     if (options.has<google::cloud::EndpointOption>()) {
         localhost_test_env = true; // TODO
@@ -61,10 +61,12 @@ BigqueryArrowReader::BigqueryArrowReader(const BigqueryTableRef table_ref,
 
     auto new_session = read_client->CreateReadSession(parent, session, num_streams);
     if (!new_session) {
-        throw BinderException("Error while creating read session: " + new_session.status().message());
+        throw BinderException("Error while creating read session: " +
+                              new_session.status().message());
     }
 
-    read_session = make_uniq<google::cloud::bigquery::storage::v1::ReadSession>(std::move(new_session.value()));
+    read_session = make_uniq<google::cloud::bigquery::storage::v1::ReadSession>(
+        std::move(new_session.value()));
 }
 
 shared_ptr<google::cloud::bigquery::storage::v1::ReadStream> BigqueryArrowReader::NextStream() {
@@ -90,7 +92,8 @@ std::shared_ptr<arrow::Schema> BigqueryArrowReader::GetSchema() {
     return arrow_schema;
 }
 
-void BigqueryArrowReader::MapTableInfo(ColumnList &res_columns, vector<unique_ptr<Constraint>> &res_constraints) {
+void BigqueryArrowReader::MapTableInfo(ColumnList &res_columns,
+                                       vector<unique_ptr<Constraint>> &res_constraints) {
     // Get the schema of the table
     auto schema = read_session->arrow_schema();
     auto table_schema = GetSchema();
@@ -114,9 +117,8 @@ void BigqueryArrowReader::MapTableInfo(ColumnList &res_columns, vector<unique_pt
     }
 }
 
-google::cloud::v2_33::StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> BigqueryArrowReader::ReadRows(
-    const string &stream_name,
-    int row_offset) {
+google::cloud::v2_33::StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
+BigqueryArrowReader::ReadRows(const string &stream_name, int row_offset) {
     return read_client->ReadRows(stream_name, row_offset);
 }
 
@@ -149,7 +151,8 @@ std::shared_ptr<arrow::RecordBatch> BigqueryArrowReader::ReadBatch(
             throw BinderException("Failed to create RecordBatchStreamReader: " +
                                   arrow_reader_result.status().ToString());
         }
-        std::shared_ptr<arrow::ipc::RecordBatchStreamReader> arrow_reader = arrow_reader_result.ValueOrDie();
+        std::shared_ptr<arrow::ipc::RecordBatchStreamReader> arrow_reader =
+            arrow_reader_result.ValueOrDie();
 
         // Step 3: Read the RecordBatch
         auto arrow_read_result = arrow_reader->ReadNext(&arrow_batch);
@@ -166,7 +169,8 @@ std::shared_ptr<arrow::RecordBatch> BigqueryArrowReader::ReadBatch(
         arrow::Result<std::shared_ptr<arrow::RecordBatch>> arrow_record_batch_res =
             arrow::ipc::ReadRecordBatch(schema, nullptr, options, &buffer_reader);
         if (!arrow_record_batch_res.ok()) {
-            throw BinderException("Failed to read Arrow RecordBatch: " + arrow_record_batch_res.status().message());
+            throw BinderException("Failed to read Arrow RecordBatch: " +
+                                  arrow_record_batch_res.status().message());
         }
 
         arrow_batch = arrow_record_batch_res.ValueOrDie();
@@ -177,42 +181,40 @@ std::shared_ptr<arrow::RecordBatch> BigqueryArrowReader::ReadBatch(
 void BigqueryArrowReader::ReadColumn(const std::shared_ptr<arrow::Array> &column, Vector &out_vec) {
     switch (column->type_id()) {
     case arrow::Type::STRUCT: {
-        ReadStructColumn(std::static_pointer_cast<arrow::StructArray>(column), out_vec);
+        ConvertStructArrayToVector(std::static_pointer_cast<arrow::StructArray>(column), out_vec);
         break;
     }
     case arrow::Type::LIST: {
-        ReadListColumn(std::static_pointer_cast<arrow::ListArray>(column), out_vec);
+        ConvertListArrayToVector(std::static_pointer_cast<arrow::ListArray>(column), out_vec);
         break;
     }
     default: {
-        ReadSimpleColumn(column, out_vec);
+        ConvertFlatArrayToVector(column, out_vec);
         break;
     }
     }
 }
 
-void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &column, Vector &out_vec) {
-    switch (column->type_id()) {
+void BigqueryArrowReader::ConvertFlatArrayToVector(const std::shared_ptr<arrow::Array> &array,
+                                                   Vector &out_vec) {
+
+    const auto type_id = array->type_id();
+    const auto row_count = array->length();
+
+    switch (type_id) {
     case arrow::Type::BOOL: {
-        auto bool_array = std::static_pointer_cast<arrow::BooleanArray>(column);
-        for (int64_t row = 0; row < bool_array->length(); ++row) {
-            if (!bool_array->IsNull(row)) {
-                auto value = bool_array->Value(row);
-                out_vec.SetValue(row, Value(value));
-            } else {
-                out_vec.SetValue(row, Value());
-            }
-        }
+        ConvertPrimitiveArray<arrow::BooleanArray>(array, out_vec, [](bool val) {
+            return Value(val);
+        });
         break;
     }
     case arrow::Type::BINARY: {
-        auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(column);
-        for (int64_t row = 0; row < binary_array->length(); ++row) {
+        auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(array);
+        for (int64_t row = 0; row < row_count; ++row) {
             if (!binary_array->IsNull(row)) {
                 int32_t length;
-                const uint8_t *value = binary_array->GetValue(row, &length);
-                auto value_blob = Value::BLOB(value, length);
-                out_vec.SetValue(row, value_blob);
+                const uint8_t *data = binary_array->GetValue(row, &length);
+                out_vec.SetValue(row, Value::BLOB(data, length));
             } else {
                 out_vec.SetValue(row, Value());
             }
@@ -220,12 +222,11 @@ void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &
         break;
     }
     case arrow::Type::DATE32: {
-        auto date32_array = std::static_pointer_cast<arrow::Date32Array>(column);
-        for (int64_t row = 0; row < date32_array->length(); ++row) {
+        auto date32_array = std::static_pointer_cast<arrow::Date32Array>(array);
+        for (int64_t row = 0; row < row_count; ++row) {
             if (!date32_array->IsNull(row)) {
                 int32_t days_since_epoch = date32_array->Value(row);
-                auto value = Date::EpochDaysToDate(days_since_epoch);
-                out_vec.SetValue(row, Value::DATE(value));
+                out_vec.SetValue(row, Value::DATE(Date::EpochDaysToDate(days_since_epoch)));
             } else {
                 out_vec.SetValue(row, Value());
             }
@@ -233,44 +234,33 @@ void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &
         break;
     }
     case arrow::Type::TIME64: {
-        auto time_array = std::static_pointer_cast<arrow::Time64Array>(column);
-        for (int64_t row = 0; row < time_array->length(); ++row) {
-            if (!time_array->IsNull(row)) {
-                // Extract the time value
-                int64_t time_value = time_array->Value(row);
-
-                // Convert the time value to the appropriate unit
-                auto time_unit = std::static_pointer_cast<arrow::Time64Type>(time_array->type())->unit();
-                Value value;
-                switch (time_unit) {
-                case arrow::TimeUnit::MICRO:
-                    value = Value::TIME(Time::FromTimeMs(time_value / 1000));
-                    break;
-                case arrow::TimeUnit::NANO:
-                    value = Value::TIME(Time::FromTimeMs(time_value / 1000 / 1000));
-                    break;
-                default:
-                    std::cerr << "Unsupported time unit in TIME64 array." << std::endl;
-                    continue;
-                }
-                out_vec.SetValue(row, value);
-            } else {
+        auto time_array = std::static_pointer_cast<arrow::Time64Array>(array);
+        auto time_unit = std::static_pointer_cast<arrow::Time64Type>(array->type())->unit();
+        for (int64_t row = 0; row < row_count; ++row) {
+            if (time_array->IsNull(row)) {
                 out_vec.SetValue(row, Value());
+                continue;
+            }
+            int64_t time_value = time_array->Value(row);
+            switch (time_unit) {
+            case arrow::TimeUnit::MICRO:
+                out_vec.SetValue(row, Value::TIME(Time::FromTimeMs(time_value / 1000)));
+                break;
+            case arrow::TimeUnit::NANO:
+                out_vec.SetValue(row, Value::TIME(Time::FromTimeMs(time_value / 1000000)));
+                break;
+            default:
+                throw InternalException("Unsupported time unit in TIME64 array.");
             }
         }
         break;
     }
     case arrow::Type::TIMESTAMP: {
-        auto timestamp_array = std::static_pointer_cast<arrow::TimestampArray>(column);
-        for (int64_t row = 0; row < timestamp_array->length(); ++row) {
+        auto timestamp_array = std::static_pointer_cast<arrow::TimestampArray>(array);
+        for (int64_t row = 0; row < row_count; ++row) {
             if (!timestamp_array->IsNull(row)) {
-                // Extract the timestamp value (number of seconds since epoch)
-                int64_t seconds_since_epoch = timestamp_array->Value(row);
-
-                // Convert the timestamp to a DuckDB timestamp
-                auto ts_value = Timestamp::FromEpochMicroSeconds(seconds_since_epoch);
-                auto value = Value::TIMESTAMP(ts_value);
-                out_vec.SetValue(row, value);
+                int64_t micros = timestamp_array->Value(row);
+                out_vec.SetValue(row, Value::TIMESTAMP(Timestamp::FromEpochMicroSeconds(micros)));
             } else {
                 out_vec.SetValue(row, Value());
             }
@@ -278,15 +268,13 @@ void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &
         break;
     }
     case arrow::Type::INTERVAL_MONTH_DAY_NANO: {
-        auto interval_array = std::static_pointer_cast<arrow::MonthDayNanoIntervalArray>(column);
-        for (int64_t row = 0; row < interval_array->length(); ++row) {
+        auto interval_array = std::static_pointer_cast<arrow::MonthDayNanoIntervalArray>(array);
+        for (int64_t row = 0; row < row_count; ++row) {
             if (!interval_array->IsNull(row)) {
-                // Extract the interval value
                 auto interval = interval_array->Value(row);
-
-                // Convert the interval to a DuckDB interval
-                auto value = Value::INTERVAL(interval.months, interval.days, interval.nanoseconds / 1000);
-                out_vec.SetValue(row, value);
+                out_vec.SetValue(
+                    row,
+                    Value::INTERVAL(interval.months, interval.days, interval.nanoseconds / 1000));
             } else {
                 out_vec.SetValue(row, Value());
             }
@@ -294,47 +282,28 @@ void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &
         break;
     }
     case arrow::Type::INT64: {
-        auto int64_array = std::static_pointer_cast<arrow::Int64Array>(column);
-        for (int64_t row = 0; row < int64_array->length(); ++row) {
-            if (!int64_array->IsNull(row)) {
-                int64_t value = int64_array->Value(row);
-                out_vec.SetValue(row, Value::BIGINT(value));
-            } else {
-                out_vec.SetValue(row, Value());
-            }
-        }
+        ConvertPrimitiveArray<arrow::Int64Array>(array, out_vec, [](int64_t val) {
+            return Value::BIGINT(val);
+        });
         break;
     }
     case arrow::Type::FLOAT: {
-        auto float_array = std::static_pointer_cast<arrow::FloatArray>(column);
-        for (int64_t row = 0; row < float_array->length(); ++row) {
-            if (!float_array->IsNull(row)) {
-                auto value = float_array->Value(row);
-                out_vec.SetValue(row, Value(value));
-            } else {
-                out_vec.SetValue(row, Value());
-            }
-        }
+        ConvertPrimitiveArray<arrow::FloatArray>(array, out_vec, [](float val) {
+            return Value(val);
+        });
         break;
     }
     case arrow::Type::DOUBLE: {
-        auto double_array = std::static_pointer_cast<arrow::DoubleArray>(column);
-        for (int64_t row = 0; row < double_array->length(); ++row) {
-            if (!double_array->IsNull(row)) {
-                auto value = double_array->Value(row);
-                out_vec.SetValue(row, Value(value));
-            } else {
-                out_vec.SetValue(row, Value());
-            }
-        }
+        ConvertPrimitiveArray<arrow::DoubleArray>(array, out_vec, [](double val) {
+            return Value(val);
+        });
         break;
     }
     case arrow::Type::STRING: {
-        auto string_array = std::static_pointer_cast<arrow::StringArray>(column);
-        for (int64_t row = 0; row < string_array->length(); ++row) {
+        auto string_array = std::static_pointer_cast<arrow::StringArray>(array);
+        for (int64_t row = 0; row < row_count; ++row) {
             if (!string_array->IsNull(row)) {
-                auto value = string_array->GetString(row);
-                out_vec.SetValue(row, Value(value));
+                out_vec.SetValue(row, Value(string_array->GetString(row)));
             } else {
                 out_vec.SetValue(row, Value());
             }
@@ -342,21 +311,17 @@ void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &
         break;
     }
     case arrow::Type::DECIMAL128: {
-        auto decimal_array = std::static_pointer_cast<arrow::Decimal128Array>(column);
-        auto decimal_type = std::static_pointer_cast<arrow::Decimal128Type>(column->type());
-
+        auto decimal_array = std::static_pointer_cast<arrow::Decimal128Array>(array);
+        auto decimal_type = std::static_pointer_cast<arrow::Decimal128Type>(array->type());
         auto scale = decimal_type->scale();
         auto precision = decimal_type->precision();
 
-        for (int64_t row = 0; row < decimal_array->length(); ++row) {
+        for (int64_t row = 0; row < row_count; ++row) {
             if (!decimal_array->IsNull(row)) {
-                auto value_ptr = decimal_array->Value(row);
-                arrow::Decimal128 decimal_value(value_ptr);
-
+                arrow::Decimal128 decimal_value(decimal_array->Value(row));
                 hugeint_t hugeint_value;
                 hugeint_value.upper = static_cast<int64_t>(decimal_value.high_bits());
                 hugeint_value.lower = static_cast<uint64_t>(decimal_value.low_bits());
-
                 out_vec.SetValue(row, Value::DECIMAL(hugeint_value, precision, scale));
             } else {
                 out_vec.SetValue(row, Value());
@@ -365,21 +330,180 @@ void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &
         break;
     }
     case arrow::Type::DECIMAL256: {
-        auto decimal_array = std::static_pointer_cast<arrow::Decimal256Array>(column);
-        auto decimal_type = std::static_pointer_cast<arrow::Decimal256Type>(column->type());
+        auto decimal_array = std::static_pointer_cast<arrow::Decimal256Array>(array);
+        auto decimal_type = std::static_pointer_cast<arrow::Decimal256Type>(array->type());
+        auto scale = decimal_type->scale();
+        auto precision = decimal_type->precision();
 
+        if (out_vec.GetType() == LogicalType::VARCHAR) {
+            for (int64_t row = 0; row < row_count; ++row) {
+                if (!decimal_array->IsNull(row)) {
+                    out_vec.SetValue(row, Value(decimal_array->FormatValue(row)));
+                } else {
+                    out_vec.SetValue(row, Value());
+                }
+            }
+            break;
+        }
+
+        if (precision > 38) {
+            throw BinderException(
+                "BIGDECIMAL precision of " + std::to_string(precision) +
+                " exceeds the maximum supported precision of 38 in DuckDB. Consider enabling "
+                "'bq_bignumeric_as_varchar' to read them as VARCHAR instead.");
+        }
+
+        for (int64_t row = 0; row < row_count; ++row) {
+            if (decimal_array->IsNull(row)) {
+                out_vec.SetValue(row, Value());
+                continue;
+            }
+            const uint8_t *value_ptr = decimal_array->Value(row);
+
+            uint64_t parts[4] = {0};
+            for (int i = 0; i < 4; ++i) {
+                parts[i] = *reinterpret_cast<const uint64_t *>(value_ptr + i * sizeof(uint64_t));
+            }
+
+            if (parts[2] != 0 || parts[3] != 0) {
+                throw BinderException(
+                    "BIGDECIMAL value exceeds the range of 128-bit Decimal supported by DuckDB.");
+            }
+
+            hugeint_t hugeint_value;
+            hugeint_value.lower = parts[0];
+            hugeint_value.upper = static_cast<int64_t>(parts[1]);
+            out_vec.SetValue(row, Value::DECIMAL(hugeint_value, precision, scale));
+        }
+        break;
+    }
+    default:
+        throw InternalException("Unsupported Arrow type: " + array->type()->name());
+    }
+}
+
+void BigqueryArrowReader::ConvertListArrayToVector(
+    const std::shared_ptr<arrow::ListArray> &list_array,
+    Vector &out_vec) {
+    for (int64_t row = 0; row < list_array->length(); ++row) {
+        auto list_value = ConvertListElementToValue(list_array, row, out_vec.GetType());
+        out_vec.SetValue(row, list_value);
+    }
+}
+
+Value BigqueryArrowReader::ConvertListElementToValue(
+    const std::shared_ptr<arrow::ListArray> &list_array,
+    int64_t row,
+    const LogicalType &target_type) {
+    if (list_array->IsNull(row)) {
+        return Value();
+    }
+
+    auto values = list_array->values();
+    auto value_type = values->type_id();
+    auto child_type = BigqueryUtils::ArrowTypeToLogicalType(values->type());
+
+    int32_t start_offset = list_array->value_offset(row);
+    int32_t end_offset = list_array->value_offset(row + 1);
+
+    vector<Value> list_values;
+    list_values.reserve(end_offset - start_offset);
+
+    // clang-format off
+    switch (value_type) {
+	case arrow::Type::BOOL: {
+        ReadPrimitiveListElements<arrow::BooleanArray>(values, start_offset, end_offset, list_values,
+            [](bool val) { return Value(val); });
+        break;
+	}
+    case arrow::Type::BINARY: {
+        auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(values);
+        for (int32_t i = start_offset; i < end_offset; ++i) {
+            if (binary_array->IsNull(i)) {
+                list_values.push_back(Value());
+            } else {
+                int32_t length;
+                const uint8_t *data = binary_array->GetValue(i, &length);
+                list_values.push_back(Value::BLOB(data, length));
+            }
+        }
+		break;
+    }
+    case arrow::Type::DATE32: {
+        ReadPrimitiveListElements<arrow::Date32Array>(values, start_offset, end_offset, list_values,
+            [](int32_t days) { return Value::DATE(Date::EpochDaysToDate(days)); });
+        break;
+    }
+    case arrow::Type::TIMESTAMP: {
+        auto timestamp_array = std::static_pointer_cast<arrow::TimestampArray>(values);
+        for (int32_t i = start_offset; i < end_offset; ++i) {
+            if (timestamp_array->IsNull(i)) {
+                list_values.push_back(Value());
+            } else {
+                list_values.push_back(Value::TIMESTAMP(Timestamp::FromEpochMicroSeconds(timestamp_array->Value(i))));
+            }
+        }
+        break;
+    }
+    case arrow::Type::INT32: {
+        ReadPrimitiveListElements<arrow::Int32Array>(values, start_offset, end_offset, list_values,
+            [](int32_t val) { return Value(val); });
+        break;
+    }
+    case arrow::Type::INT64: {
+        ReadPrimitiveListElements<arrow::Int64Array>(values, start_offset, end_offset, list_values,
+            [](int64_t val) { return Value(val); });
+        break;
+    }
+    case arrow::Type::FLOAT: {
+        ReadPrimitiveListElements<arrow::FloatArray>(values, start_offset, end_offset, list_values,
+            [](float val) { return Value(val); });
+        break;
+    }
+    case arrow::Type::DOUBLE: {
+        ReadPrimitiveListElements<arrow::DoubleArray>(values, start_offset, end_offset, list_values,
+            [](double val) { return Value(val); });
+        break;
+    }
+    case arrow::Type::STRING: {
+		ReadPrimitiveListElements<arrow::StringArray>(values, start_offset, end_offset, list_values,
+			[](std::string_view val) { return Value(string(val)); });
+        break;
+    }
+    case arrow::Type::DECIMAL128: {
+        auto decimal_array = std::static_pointer_cast<arrow::Decimal128Array>(values);
+        auto decimal_type = std::static_pointer_cast<arrow::Decimal128Type>(values->type());
+        int32_t scale = decimal_type->scale();
+        int32_t precision = decimal_type->precision();
+
+        for (int32_t i = start_offset; i < end_offset; ++i) {
+            if (decimal_array->IsNull(i)) {
+                list_values.push_back(Value());
+            } else {
+                arrow::Decimal128 decimal_value(decimal_array->Value(i));
+                hugeint_t hugeint_value;
+                hugeint_value.upper = static_cast<int64_t>(decimal_value.high_bits());
+                hugeint_value.lower = static_cast<uint64_t>(decimal_value.low_bits());
+                list_values.push_back(Value::DECIMAL(hugeint_value, precision, scale));
+            }
+        }
+        break;
+    }
+    case arrow::Type::DECIMAL256: {
+        auto decimal_array = std::static_pointer_cast<arrow::Decimal256Array>(values);
+        auto decimal_type = std::static_pointer_cast<arrow::Decimal256Type>(values->type());
         auto scale = decimal_type->scale();
         auto precision = decimal_type->precision();
 
         // bq_bignumeric_as_varchar setting
-        if (out_vec.GetType() == LogicalType::VARCHAR) {
-            for (int64_t row = 0; row < decimal_array->length(); ++row) {
-                if (!decimal_array->IsNull(row)) {
-                    auto value_str = decimal_array->FormatValue(row);
-                    out_vec.SetValue(row, Value(value_str));
+        if (target_type == LogicalType::VARCHAR) {
+            for (int32_t i = start_offset; i < end_offset; ++i) {
+                if (!decimal_array->IsNull(i)) {
+                    auto value_str = decimal_array->FormatValue(i);
+                    list_values.push_back(Value(value_str));
                     continue;
                 } else {
-                    out_vec.SetValue(row, Value());
+                    list_values.push_back(Value());
                 }
             }
             break;
@@ -391,9 +515,9 @@ void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &
                                   "'bq_bignumeric_as_varchar' to read them as VARCHAR instead.");
         }
 
-        for (int64_t row = 0; row < decimal_array->length(); ++row) {
-            if (!decimal_array->IsNull(row)) {
-                const uint8_t *value_ptr = decimal_array->Value(row);
+        for (int32_t i = start_offset; i < end_offset; ++i) {
+            if (!decimal_array->IsNull(i)) {
+                const uint8_t *value_ptr = decimal_array->Value(i);
 
                 uint64_t parts[4] = {0};
                 for (int i = 0; i < 4; i++) {
@@ -405,416 +529,230 @@ void BigqueryArrowReader::ReadSimpleColumn(const std::shared_ptr<arrow::Array> &
                 hugeint_value.upper = static_cast<int64_t>(parts[1]); // next 64 Bits
 
                 if (parts[2] != 0 || parts[3] != 0) {
-                    throw BinderException(
-                        "BIGDECIMAL value exceeds the range of 128-bit Decimal supported by DuckDB. Consider enabling "
-                        "'bq_bignumeric_as_varchar' to read them as VARCHAR instead.");
+                    throw BinderException("BIGDECIMAL value exceeds the range of 128-bit Decimal supported by "
+                                          "DuckDB. Consider enabling "
+                                          "'bq_bignumeric_as_varchar' to read them as VARCHAR instead.");
                 }
 
-                out_vec.SetValue(row, Value::DECIMAL(hugeint_value, precision, scale));
+                list_values.push_back(Value::DECIMAL(hugeint_value, precision, scale));
             } else {
-                out_vec.SetValue(row, Value());
+                list_values.push_back(Value());
             }
         }
         break;
     }
-    default: {
-        throw InternalException("Unsupported Arrow type: " + column->type()->name());
+	case arrow::Type::LIST: {
+        auto list_array_nested = std::static_pointer_cast<arrow::ListArray>(values);
+        for (int32_t i = start_offset; i < end_offset; ++i) {
+            if (list_array_nested->IsNull(i)) {
+                list_values.push_back(Value());
+            } else {
+                list_values.push_back(ConvertListElementToValue(list_array_nested, i, child_type));
+            }
+        }
+        break;
     }
+    case arrow::Type::STRUCT: {
+        auto struct_array = std::static_pointer_cast<arrow::StructArray>(values);
+        for (int32_t i = start_offset; i < end_offset; ++i) {
+            if (struct_array->IsNull(i)) {
+                list_values.push_back(Value());
+            } else {
+                list_values.push_back(ConvertStructFieldToValue(struct_array, i, child_type));
+            }
+        }
+        break;
     }
+    default:
+        throw InternalException("Unsupported Arrow type in list: " + values->type()->name());
+    }
+    // clang-format on
+
+    return Value::LIST(child_type, std::move(list_values));
 }
 
-void BigqueryArrowReader::ReadListColumn(const std::shared_ptr<arrow::ListArray> &list_array, Vector &out_vec) {
-    auto values = list_array->values();
-    auto value_type = values->type_id();
-    auto child_type = BigqueryUtils::ArrowTypeToLogicalType(values->type());
 
-    for (int64_t row = 0; row < list_array->length(); ++row) {
-        if (list_array->IsNull(row)) {
-            continue;
-        }
-        int32_t start_offset = list_array->value_offset(row);
-        int32_t end_offset = list_array->value_offset(row + 1);
+void BigqueryArrowReader::ConvertStructArrayToVector(
+    const std::shared_ptr<arrow::StructArray> &struct_array,
+    Vector &out_vec) {
 
-        // Creating a DuckDB Value Arrays for the lists
-        vector<Value> list_values;
-        switch (value_type) {
-        case arrow::Type::BOOL: {
-            auto bool_array = std::static_pointer_cast<arrow::BooleanArray>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!bool_array->IsNull(i)) {
-                    auto value = bool_array->Value(i);
-                    list_values.push_back(Value(value));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::BINARY: {
-            auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!binary_array->IsNull(i)) {
-                    int32_t length;
-                    const uint8_t *value = binary_array->GetValue(i, &length);
-                    auto value_blob = Value::BLOB(value, length);
-                    list_values.push_back(value_blob);
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::DATE32: {
-            auto date32_array = std::static_pointer_cast<arrow::Date32Array>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!date32_array->IsNull(i)) {
-                    int32_t days_since_epoch = date32_array->Value(i);
-                    auto value = Date::EpochDaysToDate(days_since_epoch);
-                    list_values.push_back(Value::DATE(value));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::TIMESTAMP: {
-            auto timestamp_array = std::static_pointer_cast<arrow::TimestampArray>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!timestamp_array->IsNull(i)) {
-                    int64_t seconds_since_epoch = timestamp_array->Value(i);
-                    auto ts_value = Timestamp::FromEpochMicroSeconds(seconds_since_epoch);
-                    auto value = Value::TIMESTAMP(ts_value);
-                    list_values.push_back(value);
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::INT32: {
-            auto int_array = std::static_pointer_cast<arrow::Int32Array>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!int_array->IsNull(i)) {
-                    list_values.push_back(Value(int_array->Value(i)));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::INT64: {
-            auto int_array = std::static_pointer_cast<arrow::Int64Array>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!int_array->IsNull(i)) {
-                    list_values.push_back(Value(int_array->Value(i)));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::FLOAT: {
-            auto float_array = std::static_pointer_cast<arrow::FloatArray>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!float_array->IsNull(i)) {
-                    list_values.push_back(Value(float_array->Value(i)));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::DOUBLE: {
-            auto double_array = std::static_pointer_cast<arrow::DoubleArray>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!double_array->IsNull(i)) {
-                    list_values.push_back(Value(double_array->Value(i)));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::STRING: {
-            auto string_array = std::static_pointer_cast<arrow::StringArray>(values);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!string_array->IsNull(i)) {
-                    list_values.push_back(Value(string_array->GetString(i)));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::DECIMAL128: {
-            auto decimal_array = std::static_pointer_cast<arrow::Decimal128Array>(values);
-            auto decimal_type = std::static_pointer_cast<arrow::Decimal128Type>(values->type());
+    auto struct_fields = struct_array->type()->fields();
 
-            auto scale = decimal_type->scale();
-            auto precision = decimal_type->precision();
-
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!decimal_array->IsNull(i)) {
-                    auto value_ptr = decimal_array->Value(i);
-                    arrow::Decimal128 decimal_value(value_ptr);
-
-                    hugeint_t hugeint_value;
-                    hugeint_value.upper = static_cast<int64_t>(decimal_value.high_bits());
-                    hugeint_value.lower = static_cast<uint64_t>(decimal_value.low_bits());
-
-                    list_values.push_back(Value::DECIMAL(hugeint_value, precision, scale));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        case arrow::Type::DECIMAL256: {
-            auto decimal_array = std::static_pointer_cast<arrow::Decimal256Array>(values);
-            auto decimal_type = std::static_pointer_cast<arrow::Decimal256Type>(values->type());
-
-            auto scale = decimal_type->scale();
-            auto precision = decimal_type->precision();
-
-            // bq_bignumeric_as_varchar setting
-            if (out_vec.GetType() == LogicalType::VARCHAR) {
-                for (int32_t i = start_offset; i < end_offset; ++i) {
-                    if (!decimal_array->IsNull(i)) {
-                        auto value_str = decimal_array->FormatValue(i);
-                        list_values.push_back(Value(value_str));
-                        continue;
-                    } else {
-                        list_values.push_back(Value());
-                    }
-                }
-                break;
-            }
-
-            if (precision > 38) {
-                throw BinderException("BIGDECIMAL precision of " + std::to_string(precision) +
-                                      " exceeds the maximum supported precision of 38 in DuckDB. Consider enabling "
-                                      "'bq_bignumeric_as_varchar' to read them as VARCHAR instead.");
-            }
-
-			for (int32_t i = start_offset; i < end_offset; ++i) {
-				if (!decimal_array->IsNull(i)) {
-					const uint8_t *value_ptr = decimal_array->Value(i);
-
-					uint64_t parts[4] = {0};
-					for (int i = 0; i < 4; i++) {
-						parts[i] = *reinterpret_cast<const uint64_t *>(value_ptr + i * sizeof(uint64_t));
-					}
-
-					hugeint_t hugeint_value;
-					hugeint_value.lower = parts[0];                       // lower 64 Bits
-					hugeint_value.upper = static_cast<int64_t>(parts[1]); // next 64 Bits
-
-					if (parts[2] != 0 || parts[3] != 0) {
-						throw BinderException(
-							"BIGDECIMAL value exceeds the range of 128-bit Decimal supported by DuckDB. Consider enabling "
-							"'bq_bignumeric_as_varchar' to read them as VARCHAR instead.");
-					}
-
-					list_values.push_back(Value::DECIMAL(hugeint_value, precision, scale));
-				} else {
-					list_values.push_back(Value());
-				}
-			}
-			break;
-        }
-        case arrow::Type::STRUCT: {
-            auto struct_array = std::static_pointer_cast<arrow::StructArray>(values);
-
-            auto struct_type = BigqueryUtils::ArrowTypeToLogicalType(struct_array->type());
-            duckdb::Vector struct_vector(struct_type);
-
-            ReadStructColumn(struct_array, struct_vector);
-            for (int32_t i = start_offset; i < end_offset; ++i) {
-                if (!struct_array->IsNull(i)) {
-                    list_values.push_back(struct_vector.GetValue(i));
-                } else {
-                    list_values.push_back(Value());
-                }
-            }
-            break;
-        }
-        default:
-            throw InternalException("Unsupported Arrow type: " + values->type()->name());
-        }
-
-        if (list_values.empty()) {
-            out_vec.SetValue(row, Value::LIST(child_type, list_values));
-        } else {
-            out_vec.SetValue(row, Value::LIST(list_values));
-        }
+    // Get target LogicalTypes for every field in advance
+    vector<LogicalType> target_types;
+    target_types.reserve(struct_fields.size());
+    for (const auto &field : struct_fields) {
+        target_types.push_back(BigqueryUtils::ArrowTypeToLogicalType(field->type()));
     }
-}
 
-void BigqueryArrowReader::ReadStructColumn(const std::shared_ptr<arrow::StructArray> &struct_array, Vector &out_vec) {
     for (int64_t row = 0; row < struct_array->length(); ++row) {
         if (struct_array->IsNull(row)) {
             out_vec.SetValue(row, Value());
             continue;
         }
-
-        Value row_value = ReadStructRow(struct_array, row);
-        out_vec.SetValue(row, row_value);
+        auto row_value = ConvertStructRowToValue(struct_array, row, target_types);
+        out_vec.SetValue(row, std::move(row_value));
     }
 }
 
-Value BigqueryArrowReader::ReadStructRow(const std::shared_ptr<arrow::StructArray> &struct_array, int64_t row) {
+Value BigqueryArrowReader::ConvertStructRowToValue(
+    const std::shared_ptr<arrow::StructArray> &struct_array,
+    int64_t row,
+    const vector<LogicalType> &target_types) {
+
     child_list_t<Value> struct_values;
 
     auto field_arrays = struct_array->fields();
     auto struct_fields = struct_array->type()->fields();
 
-    for (size_t i = 0; i < field_arrays.size(); ++i) {
-        auto field_name = struct_fields[i]->name();
-        auto field_array = field_arrays[i];
-        auto field_type = field_array->type();
+    D_ASSERT(field_arrays.size() == struct_fields.size());
+    D_ASSERT(field_arrays.size() == target_types.size());
+
+    for (idx_t i = 0; i < field_arrays.size(); ++i) {
+        const auto &field_array = field_arrays[i];
+        const auto &field_name = struct_fields[i]->name();
+        const auto &logical_type = target_types[i];
 
         if (field_array->IsNull(row)) {
             struct_values.push_back(make_pair(field_name, Value()));
             continue;
         }
 
-        switch (field_type->id()) {
-        case arrow::Type::BOOL: {
-            auto bool_array = std::static_pointer_cast<arrow::BooleanArray>(field_array);
-            struct_values.push_back(make_pair(field_name, Value(bool_array->Value(row))));
-            break;
-        }
-        case arrow::Type::BINARY: {
-            auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(field_array);
-            int32_t length;
-            const uint8_t *value = binary_array->GetValue(row, &length);
-            struct_values.push_back(make_pair(field_name, Value::BLOB(value, length)));
-            break;
-        }
-        case arrow::Type::DATE32: {
-            auto date32_array = std::static_pointer_cast<arrow::Date32Array>(field_array);
-            int32_t days_since_epoch = date32_array->Value(row);
-            struct_values.push_back(make_pair(field_name, Value::DATE(Date::EpochDaysToDate(days_since_epoch))));
-            break;
-        }
-        case arrow::Type::TIME64: {
-            auto time64_array = std::static_pointer_cast<arrow::Time64Array>(field_array);
-            int64_t time_value = time64_array->Value(row);
-            auto time_unit = std::static_pointer_cast<arrow::Time64Type>(field_array->type())->unit();
-            Value value;
-            switch (time_unit) {
-            case arrow::TimeUnit::MICRO:
-                value = Value::TIME(Time::FromTimeMs(time_value / 1000));
-                break;
-            case arrow::TimeUnit::NANO:
-                value = Value::TIME(Time::FromTimeMs(time_value / 1000 / 1000));
-                break;
-            default:
-                throw InternalException("Unsupported time unit in TIME64 array.");
-            }
-            struct_values.push_back(make_pair(field_name, value));
-            break;
-        }
-        case arrow::Type::TIMESTAMP: {
-            auto timestamp_array = std::static_pointer_cast<arrow::TimestampArray>(field_array);
-            int64_t seconds_since_epoch = timestamp_array->Value(row);
-            auto ts_value = Timestamp::FromEpochMicroSeconds(seconds_since_epoch);
-            struct_values.push_back(make_pair(field_name, Value::TIMESTAMP(ts_value)));
-            break;
-        }
-        case arrow::Type::INTERVAL_MONTH_DAY_NANO: {
-            auto interval_array = std::static_pointer_cast<arrow::MonthDayNanoIntervalArray>(field_array);
-            auto interval = interval_array->Value(row);
-            struct_values.push_back(
-                make_pair(field_name, Value::INTERVAL(interval.months, interval.days, interval.nanoseconds / 1000)));
-            break;
-        }
-        case arrow::Type::INT64: {
-            auto int64_array = std::static_pointer_cast<arrow::Int64Array>(field_array);
-            struct_values.push_back(make_pair(field_name, Value(int64_array->Value(row))));
-            break;
-        }
-        case arrow::Type::FLOAT: {
-            auto float_array = std::static_pointer_cast<arrow::FloatArray>(field_array);
-            struct_values.push_back(make_pair(field_name, Value(float_array->Value(row))));
-            break;
-        }
-        case arrow::Type::DOUBLE: {
-            auto double_array = std::static_pointer_cast<arrow::DoubleArray>(field_array);
-            struct_values.push_back(make_pair(field_name, Value(double_array->Value(row))));
-            break;
-        }
-        case arrow::Type::STRING: {
-            auto string_array = std::static_pointer_cast<arrow::StringArray>(field_array);
-            struct_values.push_back(make_pair(field_name, Value(string_array->GetString(row))));
-            break;
-        }
-        case arrow::Type::DECIMAL128: {
-            auto decimal_array = std::static_pointer_cast<arrow::Decimal128Array>(field_array);
-            auto decimal_type = std::static_pointer_cast<arrow::Decimal128Type>(field_array->type());
-
-            int32_t scale = decimal_type->scale();
-            int32_t precision = decimal_type->precision();
-
-            if (!decimal_array->IsNull(row)) {
-                auto value_ptr = decimal_array->Value(i);
-                arrow::Decimal128 decimal_value(value_ptr);
-                hugeint_t hugeint_value;
-                hugeint_value.upper = static_cast<int64_t>(decimal_value.high_bits());
-                hugeint_value.lower = static_cast<uint64_t>(decimal_value.low_bits());
-                struct_values.push_back(make_pair(field_name, Value::DECIMAL(hugeint_value, precision, scale)));
-            } else {
-                struct_values.push_back(make_pair(field_name, Value()));
-            }
-            break;
-        }
-        case arrow::Type::DECIMAL256: {
-            auto decimal_array = std::static_pointer_cast<arrow::Decimal256Array>(field_array);
-            auto decimal_type = std::static_pointer_cast<arrow::Decimal256Type>(field_array->type());
-
-            int32_t scale = decimal_type->scale();
-            int32_t precision = decimal_type->precision();
-
-            if (precision > 38) {
-                throw std::runtime_error("BIGDECIMAL precision of " + std::to_string(precision) +
-                                         " exceeds the maximum supported precision of 38 in DuckDB.");
-            }
-
-            if (!decimal_array->IsNull(row)) {
-                const uint8_t *value_ptr = decimal_array->Value(row);
-
-                uint64_t parts[4] = {0};
-                for (int i = 0; i < 4; i++) {
-                    parts[i] = *reinterpret_cast<const uint64_t *>(value_ptr + i * sizeof(uint64_t));
-                }
-
-                if (parts[2] != 0 || parts[3] != 0) {
-                    throw std::runtime_error(
-                        "BIGDECIMAL value exceeds the range of 128-bit Decimal supported by DuckDB.");
-                }
-
-                hugeint_t hugeint_value;
-                hugeint_value.lower = parts[0];
-                hugeint_value.upper = static_cast<int64_t>(parts[1]);
-
-                struct_values.push_back(make_pair(field_name, Value::DECIMAL(hugeint_value, precision, scale)));
-            } else {
-                struct_values.push_back(make_pair(field_name, Value()));
-            }
-            break;
-        }
-        case arrow::Type::STRUCT: {
-            auto nested_struct_array = std::static_pointer_cast<arrow::StructArray>(field_array);
-            Value nested_value = ReadStructRow(nested_struct_array, row);
-            struct_values.push_back(make_pair(field_name, nested_value));
-            break;
-        }
-        default:
-            throw InternalException("Unsupported Arrow type: " + field_type->name());
-        }
+        struct_values.push_back(
+            make_pair(field_name, ConvertStructFieldToValue(field_array, row, logical_type)));
     }
 
     return Value::STRUCT(std::move(struct_values));
+}
+
+Value BigqueryArrowReader::ConvertStructFieldToValue(
+    const std::shared_ptr<arrow::Array> &field_array,
+    int64_t row,
+    const LogicalType &target_type) {
+    if (field_array->IsNull(row)) {
+        return Value();
+    }
+
+    auto field_type = field_array->type();
+
+    switch (field_type->id()) {
+    case arrow::Type::BOOL: {
+        auto bool_array = std::static_pointer_cast<arrow::BooleanArray>(field_array);
+        return Value(bool_array->Value(row));
+    }
+    case arrow::Type::BINARY: {
+        auto binary_array = std::static_pointer_cast<arrow::BinaryArray>(field_array);
+        int32_t length;
+        const uint8_t *value = binary_array->GetValue(row, &length);
+        return Value::BLOB(value, length);
+    }
+    case arrow::Type::DATE32: {
+        auto date32_array = std::static_pointer_cast<arrow::Date32Array>(field_array);
+        int32_t days_since_epoch = date32_array->Value(row);
+        return Value::DATE(Date::EpochDaysToDate(days_since_epoch));
+    }
+    case arrow::Type::TIME64: {
+        auto time64_array = std::static_pointer_cast<arrow::Time64Array>(field_array);
+        int64_t time_value = time64_array->Value(row);
+        auto time_unit = std::static_pointer_cast<arrow::Time64Type>(field_array->type())->unit();
+        switch (time_unit) {
+        case arrow::TimeUnit::MICRO:
+            return Value::TIME(Time::FromTimeMs(time_value / 1000));
+        case arrow::TimeUnit::NANO:
+            return Value::TIME(Time::FromTimeMs(time_value / 1000 / 1000));
+        default:
+            throw InternalException("Unsupported time unit in TIME64 array.");
+        }
+    }
+    case arrow::Type::TIMESTAMP: {
+        auto timestamp_array = std::static_pointer_cast<arrow::TimestampArray>(field_array);
+        int64_t micros = timestamp_array->Value(row);
+        return Value::TIMESTAMP(Timestamp::FromEpochMicroSeconds(micros));
+    }
+    case arrow::Type::INTERVAL_MONTH_DAY_NANO: {
+        auto interval_array =
+            std::static_pointer_cast<arrow::MonthDayNanoIntervalArray>(field_array);
+        auto interval = interval_array->Value(row);
+        return Value::INTERVAL(interval.months, interval.days, interval.nanoseconds / 1000);
+    }
+    case arrow::Type::INT64: {
+        auto int64_array = std::static_pointer_cast<arrow::Int64Array>(field_array);
+        return Value(int64_array->Value(row));
+    }
+    case arrow::Type::FLOAT: {
+        auto float_array = std::static_pointer_cast<arrow::FloatArray>(field_array);
+        return Value(float_array->Value(row));
+    }
+    case arrow::Type::DOUBLE: {
+        auto double_array = std::static_pointer_cast<arrow::DoubleArray>(field_array);
+        return Value(double_array->Value(row));
+    }
+    case arrow::Type::STRING: {
+        auto string_array = std::static_pointer_cast<arrow::StringArray>(field_array);
+        return Value(string_array->GetString(row));
+    }
+    case arrow::Type::DECIMAL128: {
+        auto decimal_array = std::static_pointer_cast<arrow::Decimal128Array>(field_array);
+        auto decimal_type = std::static_pointer_cast<arrow::Decimal128Type>(field_array->type());
+        int32_t scale = decimal_type->scale();
+        int32_t precision = decimal_type->precision();
+
+        arrow::Decimal128 decimal_value(decimal_array->Value(row));
+        hugeint_t hugeint_value;
+        hugeint_value.upper = static_cast<int64_t>(decimal_value.high_bits());
+        hugeint_value.lower = static_cast<uint64_t>(decimal_value.low_bits());
+        return Value::DECIMAL(hugeint_value, precision, scale);
+    }
+    case arrow::Type::DECIMAL256: {
+        auto decimal_array = std::static_pointer_cast<arrow::Decimal256Array>(field_array);
+        auto decimal_type = std::static_pointer_cast<arrow::Decimal256Type>(field_array->type());
+        int32_t scale = decimal_type->scale();
+        int32_t precision = decimal_type->precision();
+
+        if (target_type.id() == LogicalTypeId::VARCHAR) {
+            auto value_str = decimal_array->FormatValue(row);
+            return Value(value_str);
+        }
+
+        if (precision > 38) {
+            throw BinderException("BIGDECIMAL precision of " + std::to_string(precision) +
+                                  " exceeds maximum supported precision of 38 in DuckDB.");
+        }
+
+        const uint8_t *value_ptr = decimal_array->Value(row);
+        uint64_t parts[4] = {0};
+        for (int i = 0; i < 4; i++) {
+            parts[i] = *reinterpret_cast<const uint64_t *>(value_ptr + i * sizeof(uint64_t));
+        }
+        if (parts[2] != 0 || parts[3] != 0) {
+            throw BinderException(
+                "BIGDECIMAL value exceeds the range of 128-bit Decimal supported by DuckDB.");
+        }
+
+        hugeint_t hugeint_value;
+        hugeint_value.lower = parts[0];
+        hugeint_value.upper = static_cast<int64_t>(parts[1]);
+        return Value::DECIMAL(hugeint_value, precision, scale);
+    }
+    case arrow::Type::LIST: {
+        auto list_array = std::static_pointer_cast<arrow::ListArray>(field_array);
+        return ConvertListElementToValue(list_array, row, target_type);
+    }
+    case arrow::Type::STRUCT: {
+        auto struct_array = std::static_pointer_cast<arrow::StructArray>(field_array);
+
+        vector<LogicalType> child_types;
+        auto struct_fields = struct_array->type()->fields();
+        child_types.reserve(struct_fields.size());
+        for (const auto &child_field : struct_fields) {
+            child_types.push_back(BigqueryUtils::ArrowTypeToLogicalType(child_field->type()));
+        }
+
+        return ConvertStructRowToValue(struct_array, row, child_types);
+    }
+    default:
+        throw InternalException("Unsupported Arrow type in struct field: " + field_type->name());
+    }
 }
 
 int64_t BigqueryArrowReader::GetEstimatedRowCount() {

--- a/src/bigquery_arrow_reader.cpp
+++ b/src/bigquery_arrow_reader.cpp
@@ -18,6 +18,7 @@
 #include <stdexcept>
 
 #include "bigquery_arrow_reader.hpp"
+#include "bigquery_settings.hpp"
 #include "bigquery_utils.hpp"
 
 
@@ -56,6 +57,9 @@ BigqueryArrowReader::BigqueryArrowReader(const BigqueryTableRef table_ref,
         }
     }
     if (!filter_condition.empty()) {
+        if (BigquerySettings::DebugQueryPrint()) {
+            std::cout << "BigQuery row restrictions: " << filter_condition << std::endl;
+        }
         read_options->set_row_restriction(filter_condition);
     }
 

--- a/src/bigquery_utils.cpp
+++ b/src/bigquery_utils.cpp
@@ -219,6 +219,12 @@ LogicalType BigqueryUtils::FieldSchemaNumericToLogicalType(const google::cloud::
     auto precision = field.precision();
     auto scale = field.scale();
 
+	// If no precision and scale are provided, BigQuery assumes default values
+	if (precision == 0 && scale == 0) {
+		precision = BQ_NUMERIC_PRECISION_DEFAULT;
+		scale = BQ_NUMERIC_SCALE_DEFAULT;
+	}
+
     const auto &bigquery_type = field.type();
     if (bigquery_type == "BIGNUMERIC" && BigquerySettings::BignumericAsVarchar()) {
         return LogicalType::VARCHAR;

--- a/src/include/bigquery_arrow_reader.hpp
+++ b/src/include/bigquery_arrow_reader.hpp
@@ -21,7 +21,7 @@ namespace bigquery {
 struct BigqueryArrowReader {
 public:
     BigqueryArrowReader(const BigqueryTableRef table_ref,
-						const string billing_project_id,
+                        const string billing_project_id,
                         idx_t num_streams,
                         const google::cloud::Options &options,
                         const vector<string> &column_ids = std::vector<string>(),
@@ -29,28 +29,22 @@ public:
 
     std::shared_ptr<arrow::Schema> GetSchema();
     int64_t GetEstimatedRowCount();
-
-    void MapTableInfo(ColumnList &res_columns, vector<unique_ptr<Constraint>> &res_constraints);
-
-    shared_ptr<google::cloud::bigquery::storage::v1::ReadStream> NextStream();
-
-    google::cloud::v2_33::StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
-        const string &stream_name,
-        int row_offset);
-    void ReadColumn(const std::shared_ptr<arrow::Array> &column, Vector &out_vec);
-    std::shared_ptr<arrow::Schema> ReadSchema(const google::cloud::bigquery::storage::v1::ArrowSchema &schema);
-    std::shared_ptr<arrow::RecordBatch> ReadBatch(const google::cloud::bigquery::storage::v1::ArrowRecordBatch &batch);
-
     BigqueryTableRef GetTableRef() const;
 
-private:
-    void ReadSimpleColumn(const std::shared_ptr<arrow::Array> &column, Vector &out_vec);
-    void ReadListColumn(const std::shared_ptr<arrow::ListArray> &list_array, Vector &out_vec);
-    void ReadStructColumn(const std::shared_ptr<arrow::StructArray> &struct_array, Vector &out_vec);
-	Value ReadStructRow(const std::shared_ptr<arrow::StructArray> &struct_array, int64_t row);
+    void MapTableInfo(ColumnList &res_columns, vector<unique_ptr<Constraint>> &res_constraints);
+    shared_ptr<google::cloud::bigquery::storage::v1::ReadStream> NextStream();
+    google::cloud::v2_33::StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
+    ReadRows(const string &stream_name, int row_offset);
 
-	BigqueryTableRef table_ref;
-	string billing_project_id;
+    void ReadColumn(const std::shared_ptr<arrow::Array> &column, Vector &out_vec);
+    std::shared_ptr<arrow::Schema> ReadSchema(
+        const google::cloud::bigquery::storage::v1::ArrowSchema &schema);
+    std::shared_ptr<arrow::RecordBatch> ReadBatch(
+        const google::cloud::bigquery::storage::v1::ArrowRecordBatch &batch);
+
+private:
+    BigqueryTableRef table_ref;
+    string billing_project_id;
 
     idx_t num_streams;
     idx_t next_stream = 0;
@@ -61,8 +55,55 @@ private:
     std::shared_ptr<arrow::Schema> arrow_schema;
 
     bool localhost_test_env;
+
+    // Convert simple types
+    void ConvertFlatArrayToVector(const std::shared_ptr<arrow::Array> &column, Vector &out_vec);
+
+    // Convert Lists
+    void ConvertListArrayToVector(const std::shared_ptr<arrow::ListArray> &list_array,
+                                  Vector &out_vec);
+    Value ConvertListElementToValue(const std::shared_ptr<arrow::ListArray> &list_array,
+                                    int64_t row,
+                                    const LogicalType &target_type);
+
+    // Convert Structs
+    void ConvertStructArrayToVector(const std::shared_ptr<arrow::StructArray> &struct_array,
+                                    Vector &out_vec);
+    Value ConvertStructRowToValue(const std::shared_ptr<arrow::StructArray> &struct_array,
+                                  int64_t row,
+                                  const vector<LogicalType> &target_types);
+    Value ConvertStructFieldToValue(const std::shared_ptr<arrow::Array> &field_array,
+                                    int64_t row,
+                                    const LogicalType &target_type);
 };
 
+template <class ArrowArrayType, class ValueCreator>
+void ConvertPrimitiveArray(const std::shared_ptr<arrow::Array> &array,
+                           Vector &out_vec,
+                           ValueCreator create_value) {
+    auto typed_array = std::static_pointer_cast<ArrowArrayType>(array);
+    for (int64_t row = 0; row < typed_array->length(); ++row) {
+        out_vec.SetValue(row,
+                         typed_array->IsNull(row) ? Value()
+                                                  : create_value(typed_array->Value(row)));
+    }
+}
+
+template <class ArrowArrayType, class ValueCreator>
+void ReadPrimitiveListElements(const std::shared_ptr<arrow::Array> &values,
+                               int32_t start_offset,
+                               int32_t end_offset,
+                               vector<Value> &list_values,
+                               ValueCreator &&create_value) {
+    auto array = std::static_pointer_cast<ArrowArrayType>(values);
+    for (int32_t i = start_offset; i < end_offset; ++i) {
+        if (array->IsNull(i)) {
+            list_values.push_back(Value());
+        } else {
+            list_values.push_back(create_value(array->Value(i)));
+        }
+    }
+}
 
 } // namespace bigquery
 } // namespace duckdb

--- a/test/sql/bigquery/function_bigquery_query_types.test
+++ b/test/sql/bigquery/function_bigquery_query_types.test
@@ -1,0 +1,129 @@
+# name: test/sql/bigquery/function_bigquery_query_types.test
+# description: Tests the bigquery_query(...) function with complex result types
+# group: [bigquery]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
+
+query I
+SELECT * FROM bigquery_query('bq', '
+	SELECT * FROM UNNEST([
+		STRUCT(STRUCT(2 AS Order_Id, [1, 2] AS Item_Name) as holder),
+		STRUCT(STRUCT(1 AS Order_Id, [3, 4] AS Item_Name) as holder)
+	])
+')
+----
+{'Order_Id': 2, 'Item_Name': [1, 2]}
+{'Order_Id': 1, 'Item_Name': [3, 4]}
+
+query I
+SELECT * FROM bigquery_query('bq', '
+    SELECT * FROM UNNEST([
+        STRUCT(
+            [
+                STRUCT(10 AS Product_Id, ["Apple", "Banana"] AS Product_Names),
+                STRUCT(20 AS Product_Id, ["Orange", "Mango"] AS Product_Names)
+            ] AS Items
+        ),
+        STRUCT(
+            [
+                STRUCT(30 AS Product_Id, ["Carrot", "Peas"] AS Product_Names),
+                STRUCT(40 AS Product_Id, ["Tomato", "Cucumber"] AS Product_Names)
+            ] AS Items
+        )
+    ])
+')
+----
+[{'Product_Id': 10, 'Product_Names': [Apple, Banana]}, {'Product_Id': 20, 'Product_Names': [Orange, Mango]}]
+[{'Product_Id': 30, 'Product_Names': [Carrot, Peas]}, {'Product_Id': 40, 'Product_Names': [Tomato, Cucumber]}]
+
+query II
+SELECT * FROM bigquery_query('bq',
+"SELECT * FROM UNNEST([
+    STRUCT(
+        [STRUCT(1 AS key, 'x' AS val), STRUCT(2 AS key, 'y' AS val)] AS struct_list,
+        [10, 20, 30] AS int_list
+    ),
+    STRUCT(
+        [STRUCT(3 AS key, 'z' AS val)] AS struct_list,
+        [40, 50] AS int_list
+    )
+])"
+)
+----
+[{'key': 1, 'val': x}, {'key': 2, 'val': y}]	[10, 20, 30]
+[{'key': 3, 'val': z}]	[40, 50]
+
+query I
+SELECT * FROM bigquery_query('bq',
+"SELECT * FROM UNNEST([
+    STRUCT([
+        STRUCT(1 AS id, [10,20] AS values),
+        STRUCT(2 AS id, [30,40] AS values)
+    ] AS list_of_structs)
+])"
+)
+----
+[{'id': 1, 'values': [10, 20]}, {'id': 2, 'values': [30, 40]}]
+
+statement error
+SELECT * FROM bigquery_query('bq',
+"SELECT * FROM UNNEST([
+    STRUCT([[1,2,3], [4,5,6]] AS nested_list),
+    STRUCT([[7,8]] AS nested_list)
+])"
+)
+----
+Cannot construct array with element type ARRAY<INT64> because nested arrays are not supported at [2:13]
+
+statement error
+SELECT * FROM bigquery_query('bq',
+"SELECT * FROM UNNEST([
+    STRUCT([
+        [STRUCT(1 AS a), STRUCT(2 AS a)],
+        [STRUCT(3 AS a)]
+    ] AS crazy_nested_list)
+])"
+)
+----
+Cannot construct array with element type ARRAY<STRUCT<a INT64>> because nested arrays are not supported at [3:9]
+
+query I
+SELECT * FROM bigquery_query('bq', '
+	SELECT * FROM UNNEST([
+		STRUCT([
+			STRUCT(
+				TRUE AS bool_col,
+				42 AS int32_col,
+				9223372036854775807 AS int64_col,
+				3.14 AS float_col,
+				2.718281828 AS double_col,
+				"hello" AS string_col,
+				DATE("2024-01-01") AS date_col,
+				TIME(12, 34, 56) AS time_col,
+				TIMESTAMP("2024-01-01 12:34:56 UTC") AS timestamp_col,
+				INTERVAL 1 YEAR + INTERVAL 2 MONTH + INTERVAL 3 DAY + INTERVAL 4 HOUR + INTERVAL 5 MINUTE + INTERVAL 6 SECOND AS interval_col
+			),
+			STRUCT(
+				FALSE AS bool_col,
+				-100 AS int32_col,
+				-9223372036854775808 AS int64_col,
+				-1.23 AS float_col,
+				-4.56 AS double_col,
+				"world" AS string_col,
+				DATE("1999-12-31") AS date_col,
+				TIME(23, 59, 59) AS time_col,
+				TIMESTAMP("1999-12-31 23:59:59 UTC") AS timestamp_col,
+				INTERVAL -1 YEAR AS interval_col
+			)] AS complex_struct_list
+		)
+	])
+')
+----
+[{'bool_col': true, 'int32_col': 42, 'int64_col': 9223372036854775807, 'float_col': 3.14, 'double_col': 2.7182817, 'string_col': hello, 'date_col': 2024-01-01, 'time_col': 12:34:56, 'timestamp_col': 2024-01-01 12:34:56, 'interval_col': 1 year 2 months 3 days 04:05:06}, {'bool_col': false, 'int32_col': -100, 'int64_col': -9223372036854775808, 'float_col': -1.23, 'double_col': -4.56, 'string_col': world, 'date_col': 1999-12-31, 'time_col': 23:59:59, 'timestamp_col': 1999-12-31 23:59:59, 'interval_col': -1 year}]

--- a/test/sql/bigquery/function_bigquery_query_types.test
+++ b/test/sql/bigquery/function_bigquery_query_types.test
@@ -108,7 +108,8 @@ SELECT * FROM bigquery_query('bq', '
 				DATE("2024-01-01") AS date_col,
 				TIME(12, 34, 56) AS time_col,
 				TIMESTAMP("2024-01-01 12:34:56 UTC") AS timestamp_col,
-				INTERVAL 1 YEAR + INTERVAL 2 MONTH + INTERVAL 3 DAY + INTERVAL 4 HOUR + INTERVAL 5 MINUTE + INTERVAL 6 SECOND AS interval_col
+				INTERVAL 1 YEAR + INTERVAL 2 MONTH + INTERVAL 3 DAY + INTERVAL 4 HOUR + INTERVAL 5 MINUTE + INTERVAL 6 SECOND AS interval_col,
+				NUMERIC "12345.6789" AS decimal128_col
 			),
 			STRUCT(
 				FALSE AS bool_col,
@@ -120,10 +121,35 @@ SELECT * FROM bigquery_query('bq', '
 				DATE("1999-12-31") AS date_col,
 				TIME(23, 59, 59) AS time_col,
 				TIMESTAMP("1999-12-31 23:59:59 UTC") AS timestamp_col,
-				INTERVAL -1 YEAR AS interval_col
+				INTERVAL -1 YEAR AS interval_col,
+				NUMERIC "-12345.6789" AS decimal128_col
 			)] AS complex_struct_list
 		)
 	])
 ')
 ----
-[{'bool_col': true, 'int32_col': 42, 'int64_col': 9223372036854775807, 'float_col': 3.14, 'double_col': 2.7182817, 'string_col': hello, 'date_col': 2024-01-01, 'time_col': 12:34:56, 'timestamp_col': 2024-01-01 12:34:56, 'interval_col': 1 year 2 months 3 days 04:05:06}, {'bool_col': false, 'int32_col': -100, 'int64_col': -9223372036854775808, 'float_col': -1.23, 'double_col': -4.56, 'string_col': world, 'date_col': 1999-12-31, 'time_col': 23:59:59, 'timestamp_col': 1999-12-31 23:59:59, 'interval_col': -1 year}]
+[{'bool_col': true, 'int32_col': 42, 'int64_col': 9223372036854775807, 'float_col': 3.14, 'double_col': 2.7182817, 'string_col': hello, 'date_col': 2024-01-01, 'time_col': 12:34:56, 'timestamp_col': 2024-01-01 12:34:56, 'interval_col': 1 year 2 months 3 days 04:05:06, 'decimal128_col': 12345.678900000}, {'bool_col': false, 'int32_col': -100, 'int64_col': -9223372036854775808, 'float_col': -1.23, 'double_col': -4.56, 'string_col': world, 'date_col': 1999-12-31, 'time_col': 23:59:59, 'timestamp_col': 1999-12-31 23:59:59, 'interval_col': -1 year, 'decimal128_col': -12345.678900000}]
+
+query IIIIIIIIIII
+SELECT * FROM bigquery_query('bq', '
+	SELECT * FROM UNNEST([
+		STRUCT(
+			[TRUE, FALSE, TRUE] AS bool_list,
+			[1, 2, 3] AS int32_list,
+			[9223372036854775807, -9223372036854775808] AS int64_list,
+			[3.14, 2.71, 1.61] AS float_list,
+			[2.718281828, 3.1415926535] AS double_list,
+			["hello", "world"] AS string_list,
+			[DATE("2024-01-01"), DATE("2023-12-31")] AS date_list,
+			[TIME(12, 0, 0), TIME(13, 30, 30)] AS time_list,
+			[TIMESTAMP("2024-01-01 12:00:00 UTC"), TIMESTAMP("2023-12-31 23:59:59 UTC")] AS timestamp_list,
+			[
+				INTERVAL 1 YEAR + INTERVAL 2 MONTH,
+				INTERVAL 3 DAY + INTERVAL 4 HOUR
+			] AS interval_list,
+			[NUMERIC "123.45", NUMERIC "678.90"] AS decimal128_list
+		)
+	]);
+')
+----
+[true, false, true]	[1, 2, 3]	[9223372036854775807, -9223372036854775808]	[3.14, 2.71, 1.61]	[2.7182817, 3.1415927]	[hello, world]	[2024-01-01, 2023-12-31]	[12:00:00, 13:30:30]	[2024-01-01 12:00:00, 2023-12-31 23:59:59]	[1 year 2 months, 3 days 04:00:00]	[123.450000000, 678.900000000]


### PR DESCRIPTION
This PR refactors the BigqueryArrowReader internals to improve clarity, consistency, and performance when reading Arrow data from BigQuery into DuckDB types. Existing functionality preserved, but cleaned up (incl. some fixes).

Changes:
* Introduced ConvertFlatArrayToVector, ConvertListArrayToVector, and ConvertStructArrayToVector for better separation of concerns.
* Added helper functions like ConvertListElementToValue and ConvertStructFieldToValue.
* Correctly handle nested lists, nested structs, and mixed types.
* Added proper LogicalType propagation for nested fields.
* Optimized reading primitives with templated ConvertPrimitiveArray.
* New test cases added for deeply nested structures.

Fixes #84 

