### PR TITLE
Enhanced bigquery_query with the new Arrow Scan Integration

### DIFF
--- a/src/bigquery_arrow_scan.cpp
+++ b/src/bigquery_arrow_scan.cpp
@@ -39,10 +39,10 @@ static void SetFromNamedParameters(const TableFunctionBindInput &input,
     }
 }
 
-unique_ptr<FunctionData> BigqueryArrowScanBind(ClientContext &context,
-                                               TableFunctionBindInput &input,
-                                               vector<LogicalType> &return_types,
-                                               vector<string> &names) {
+unique_ptr<FunctionData> BigqueryArrowScanFunction::BigqueryArrowScanBind(ClientContext &context,
+                                                                          TableFunctionBindInput &input,
+                                                                          vector<LogicalType> &return_types,
+                                                                          vector<string> &names) {
     // Parse table name parameter
     if (input.inputs.empty()) {
         throw BinderException("bigquery_arrow_scan: table name must be provided");
@@ -96,8 +96,9 @@ unique_ptr<FunctionData> BigqueryArrowScanBind(ClientContext &context,
     return std::move(bind_data);
 }
 
-unique_ptr<GlobalTableFunctionState> BigqueryArrowScanInitGlobal(ClientContext &context,
-                                                                 TableFunctionInitInput &input) {
+unique_ptr<GlobalTableFunctionState> BigqueryArrowScanFunction::BigqueryArrowScanInitGlobal(
+    ClientContext &context,
+    TableFunctionInitInput &input) {
     auto &bind_data = input.bind_data->CastNoConst<BigqueryArrowScanBindData>();
 
     // Build selected fields for BigQuery (exclude ROWID columns)
@@ -204,9 +205,10 @@ unique_ptr<GlobalTableFunctionState> BigqueryArrowScanInitGlobal(ClientContext &
     return std::move(gstate);
 }
 
-unique_ptr<LocalTableFunctionState> BigqueryArrowScanInitLocal(ExecutionContext &context,
-                                                               TableFunctionInitInput &input,
-                                                               GlobalTableFunctionState *global_state_p) {
+unique_ptr<LocalTableFunctionState> BigqueryArrowScanFunction::BigqueryArrowScanInitLocal(
+    ExecutionContext &context,
+    TableFunctionInitInput &input,
+    GlobalTableFunctionState *global_state_p) {
     auto &client_context = context.client;
     auto &bind_data = input.bind_data->CastNoConst<BigqueryArrowScanBindData>();
     auto &global_state = global_state_p->Cast<ArrowScanGlobalState>();
@@ -233,7 +235,9 @@ unique_ptr<LocalTableFunctionState> BigqueryArrowScanInitLocal(ExecutionContext 
     return std::move(result);
 }
 
-static void BigqueryArrowScanExecute(ClientContext &ctx, TableFunctionInput &data_p, DataChunk &output) {
+void BigqueryArrowScanFunction::BigqueryArrowScanExecute(ClientContext &ctx,
+                                                         TableFunctionInput &data_p,
+                                                         DataChunk &output) {
     if (!data_p.local_state) {
         return;
     }
@@ -349,10 +353,10 @@ double BigqueryArrowScanProgress(ClientContext &context,
 BigqueryArrowScanFunction::BigqueryArrowScanFunction()
     : TableFunction("bigquery_arrow_scan",
                     {LogicalType::VARCHAR},
-                    BigqueryArrowScanExecute,
-                    BigqueryArrowScanBind,
-                    BigqueryArrowScanInitGlobal,
-                    BigqueryArrowScanInitLocal) {
+                    BigqueryArrowScanFunction::BigqueryArrowScanExecute,
+                    BigqueryArrowScanFunction::BigqueryArrowScanBind,
+                    BigqueryArrowScanFunction::BigqueryArrowScanInitGlobal,
+                    BigqueryArrowScanFunction::BigqueryArrowScanInitLocal) {
     projection_pushdown = true;
     filter_pushdown = true;
     filter_prune = true;

--- a/src/include/bigquery_arrow_scan.hpp
+++ b/src/include/bigquery_arrow_scan.hpp
@@ -39,6 +39,8 @@ struct BigqueryArrowScanBindData : public ArrowScanFunctionData {
 public:
     // The BigQuery table reference for this scan
     BigqueryTableRef table_ref;
+    //! The query string for the scan (used for bigquery_query function)
+    string query;
     //! The filter string for the scan
     string filter_condition;
 
@@ -63,6 +65,10 @@ public:
 
     shared_ptr<FactoryDependency> factory_dep() {
         return dependency ? shared_ptr_cast<DependencyItem, FactoryDependency>(dependency) : nullptr;
+    }
+
+    bool RequiresQueryExec() const {
+        return !query.empty();
     }
 
     string ParentString() const {
@@ -90,7 +96,20 @@ public:
 };
 
 struct BigqueryArrowScanFunction : public TableFunction {
+public:
     BigqueryArrowScanFunction();
+
+public:
+    static unique_ptr<FunctionData> BigqueryArrowScanBind(ClientContext &context,
+                                                          TableFunctionBindInput &input,
+                                                          vector<LogicalType> &return_types,
+                                                          vector<string> &names);
+    static unique_ptr<GlobalTableFunctionState> BigqueryArrowScanInitGlobal(ClientContext &context,
+                                                                            TableFunctionInitInput &input);
+    static unique_ptr<LocalTableFunctionState> BigqueryArrowScanInitLocal(ExecutionContext &context,
+                                                                          TableFunctionInitInput &input,
+                                                                          GlobalTableFunctionState *global_state_p);
+    static void BigqueryArrowScanExecute(ClientContext &ctx, TableFunctionInput &data_p, DataChunk &output);
 };
 
 } // namespace bigquery

--- a/test/sql/bigquery/attach_incubating_scan.test
+++ b/test/sql/bigquery/attach_incubating_scan.test
@@ -66,6 +66,12 @@ SELECT d, i2, s FROM bq.${BQ_TEST_DATASET}.new_scan WHERE i = 10 ORDER BY d;
 ----
 123.4	32	some string
 
+query II
+SELECT i, d FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT * FROM ${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.new_scan') ORDER BY i;
+----
+10	123.4
+12	123.4567
+
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.new_scan;
 

--- a/test/sql/bigquery/attach_incubating_scan.test
+++ b/test/sql/bigquery/attach_incubating_scan.test
@@ -8,8 +8,8 @@ require-env BQ_TEST_PROJECT
 
 require-env BQ_TEST_DATASET
 
-#statement ok
-#SET bq_experimental_use_incubating_scan=TRUE
+statement ok
+SET bq_experimental_use_incubating_scan=TRUE
 
 statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);


### PR DESCRIPTION
This PR integrates the `bigquery_query` function with the new improved Arrow scan implementation, significantly improving query execution performance while maintaining backward compatibility. The `bigquery_query` has been refactored to use the new Arrow scan backend when the new scan is enabled (i.e., `SET bq_experimental_use_incubating_scan=TRUE;`).

#86 