### PR TITLE
Fix job lookup when using billing_project in bigquery_query

### DIFF
--- a/src/bigquery_arrow_scan.cpp
+++ b/src/bigquery_arrow_scan.cpp
@@ -134,8 +134,7 @@ unique_ptr<GlobalTableFunctionState> BigqueryArrowScanFunction::BigqueryArrowSca
     // Initialize the BigQuery arrow reader
     idx_t max_read_streams = BigquerySettings::GetMaxReadStreams(context);
     auto bq_arrow_reader = bind_data.bq_client->CreateArrowReader( //
-        bind_data.table_ref.dataset_id,
-        bind_data.table_ref.table_id,
+        bind_data.table_ref,
         max_read_streams,
         selected_fields,
         filter_string //

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -73,6 +73,7 @@ public:
 
     vector<google::cloud::bigquery::v2::ListFormatJob> ListJobs(const ListJobsParams &params);
     google::cloud::bigquery::v2::Job GetJob(const string &job_id, const string &location = "");
+	google::cloud::bigquery::v2::Job GetJobByReference(const google::cloud::bigquery::v2::JobReference &job_ref);
 
     google::cloud::bigquery::v2::QueryResponse ExecuteQuery(const string &query,
                                                             const string &location = "",
@@ -81,8 +82,7 @@ public:
         const google::cloud::bigquery::v2::JobReference &job_ref,
         const string &page_token = "");
 
-    shared_ptr<BigqueryArrowReader> CreateArrowReader(const string &dataset_id,
-                                                      const string &table_id,
+    shared_ptr<BigqueryArrowReader> CreateArrowReader(const BigqueryTableRef &table_ref,
                                                       const idx_t num_streams,
                                                       const vector<string> &column_ids = std::vector<string>(),
                                                       const string &filter_cond = "");

--- a/test/sql/bigquery/attach_bq_pseudo_columns.test
+++ b/test/sql/bigquery/attach_bq_pseudo_columns.test
@@ -8,8 +8,6 @@ require-env BQ_TEST_PROJECT
 
 require-env BQ_TEST_DATASET
 
-require-env SKIP
-
 statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 

--- a/test/sql/bigquery/function_bigquery_query_billing_project.test
+++ b/test/sql/bigquery/function_bigquery_query_billing_project.test
@@ -1,0 +1,45 @@
+# name: test/sql/bigquery/function_bigquery_query_billing_project.test
+# description: Test bigquery_query function with billing_project parameter
+# group: [bigquery]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_BILLING_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+SET bq_debug_show_queries = true;
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.test_billing_query;
+
+statement ok
+CREATE TABLE bq.${BQ_TEST_DATASET}.test_billing_query AS
+SELECT *
+FROM (
+    VALUES
+    ('Test Row 1', 100),
+    ('Test Row 2', 200),
+    ('Test Row 3', 300)
+)
+test_table(name, value);
+
+# Test bigquery_query with billing_project parameter - should work correctly
+query I
+SELECT count(*) FROM bigquery_query(
+    '${BQ_TEST_PROJECT}',
+    'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.test_billing_query`',
+    billing_project='${BQ_TEST_BILLING_PROJECT}'
+);
+----
+3
+
+# Clean up test table
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.test_billing_query;


### PR DESCRIPTION
When `billing_project` is set, the job is created in that project, but the previous logic still tried to look it up in the data project. This caused job lookup failures.

This MR updates the job retrieval logic to correctly use the billing project when specified, fixing queries like:

```sql 
SELECT * FROM bigquery_query(
    'data_project',
    'SELECT * FROM `data_project.my_dataset.INFORMATION_SCHEMA.PARTITIONS`',
    billing_project='my_billing_project'
);
```

Also added a minimal test to cover this case.

Fixes #104 
