### PR TITLE
BigQuery Geography Type Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,6 @@ The `bigquery_scan` function supports the following named parameters:
 | ----------------------- | --------- | -------------------------------------------------------------------------------- |
 | `filter`                | `VARCHAR` | Row restriction filter statements passed directly to BigQuery Storage Read API.  |
 | `use_legacy_scan`       | `BOOLEAN` | Use legacy scan implementation: `true` (legacy) or `false` (optimized, default). |
-| `geography_as_geometry` | `BOOLEAN` | Return GEOGRAPHY columns as GEOMETRY types (requires spatial extension).         |
 | `billing_project`       | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).             |
 | `api_endpoint`          | `VARCHAR` | Custom BigQuery API endpoint URL.                                                |
 | `grpc_endpoint`         | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                       |

--- a/README.md
+++ b/README.md
@@ -202,13 +202,14 @@ While `bigquery_scan` offers high-speed data retrieval, it does not support read
 
 The `bigquery_scan` function supports the following named parameters:
 
-| Parameter         | Type      | Description                                                                      |
-| ----------------- | --------- | -------------------------------------------------------------------------------- |
-| `filter`          | `VARCHAR` | Row restriction filter statements passed directly to BigQuery Storage Read API.  |
-| `use_legacy_scan` | `BOOLEAN` | Use legacy scan implementation: `true` (legacy) or `false` (optimized, default). |
-| `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).             |
-| `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                                |
-| `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                       |
+| Parameter               | Type      | Description                                                                      |
+| ----------------------- | --------- | -------------------------------------------------------------------------------- |
+| `filter`                | `VARCHAR` | Row restriction filter statements passed directly to BigQuery Storage Read API.  |
+| `use_legacy_scan`       | `BOOLEAN` | Use legacy scan implementation: `true` (legacy) or `false` (optimized, default). |
+| `geography_as_geometry` | `BOOLEAN` | Return GEOGRAPHY columns as GEOMETRY types (requires spatial extension).         |
+| `billing_project`       | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).             |
+| `api_endpoint`          | `VARCHAR` | Custom BigQuery API endpoint URL.                                                |
+| `grpc_endpoint`         | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                       |
 
 ### `bigquery_query` Function
 
@@ -316,8 +317,9 @@ D SELECT * FROM bigquery_scan('bigquery-public-data.geo_us_boundaries.cnecta', b
 
 | Setting                                   | Description                                                                                                                                                                                        | Default |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `bq_bignumeric_as_varchar`                | Read BigQuery `BIGNUMERIC` columns as `VARCHAR` instead of causing a type mapping error. **Note: Only supported with V1 scan engine.**                                                             | `false` |
+| `bq_bignumeric_as_varchar`                | Read BigQuery `BIGNUMERIC` columns as `VARCHAR` instead of causing a type mapping error. **Note: Only supported with legacy scan.**                                                                | `false` |
 | `bq_use_legacy_scan`                      | Use legacy scan implementation instead of optimized Arrow-based scan. Set to `true` for the old scan or `false` for the new optimized implementation.                                              | `false` |
+| `bq_geography_as_geometry`                | Return BigQuery `GEOGRAPHY` columns as DuckDB `GEOMETRY` types (requires spatial extension). When `false`, returns WKT strings as `VARCHAR`.                                                        | `false` |
 | `bq_query_timeout_ms`                     | Timeout for BigQuery queries in milliseconds. If a query exceeds this time, the operation stops waiting.                                                                                           | `90000` |
 | `bq_debug_show_queries`                   | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                                                                                                                  | `false` |
 | `bq_experimental_filter_pushdown`         | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                                                                                                             | `true`  |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,4 +17,5 @@ set(EXTENSION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_info.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_arrow_scan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_geometry_cast.cpp
     PARENT_SCOPE)

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -119,6 +119,12 @@ static void LoadInternal(DatabaseInstance &instance) {
                               LogicalType::BOOLEAN,
                               Value(bigquery::BigquerySettings::UseLegacyScan()),
                               bigquery::BigquerySettings::SetUseLegacyScan);
+    config.AddExtensionOption("bq_geography_as_geometry",
+                              "Whether to return BigQuery GEOGRAPHY columns as DuckDB GEOMETRY types "
+                              "(requires spatial extension). Default is false (returns WKT strings).",
+                              LogicalType::BOOLEAN,
+                              Value(bigquery::BigquerySettings::GeographyAsGeometry()),
+                              bigquery::BigquerySettings::SetGeographyAsGeometry);
 
     // Deprecated setting
     config.AddExtensionOption(

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -21,6 +21,7 @@
 #include "bigquery_scan.hpp"
 #include "bigquery_settings.hpp"
 #include "bigquery_storage.hpp"
+#include "bigquery_geometry_cast.hpp"
 
 #include <iostream>
 
@@ -52,6 +53,8 @@ static void LoadInternal(DatabaseInstance &instance) {
     auto &config = DBConfig::GetConfig(instance);
     config.storage_extensions["bigquery"] = make_uniq<bigquery::BigqueryStorageExtension>();
 
+    // Register WKT->GEOMETRY cast (runtime lookup of spatial extension's ST_GeomFromText)
+    bigquery::RegisterWKTGeometryCast(instance);
 
     bigquery::BigqueryParserExtension bigquery_parser_extension;
     config.parser_extensions.push_back(bigquery_parser_extension);

--- a/src/bigquery_geometry_cast.cpp
+++ b/src/bigquery_geometry_cast.cpp
@@ -15,32 +15,31 @@ namespace duckdb {
 namespace bigquery {
 
 struct WKTGeomCastData : public BoundCastData {
-	WKTGeomCastData() : has_function(false),
-						resolved_function({LogicalType::VARCHAR}, LogicalType::BLOB, nullptr) {
-		target_type = LogicalType::BLOB;
-		target_type.SetAlias("GEOMETRY");
-		source_type = LogicalType::VARCHAR;
-		source_type.SetAlias("WKT");
-		function_return_type = target_type;
-	}
+    WKTGeomCastData() : has_function(false), resolved_function({LogicalType::VARCHAR}, LogicalType::BLOB, nullptr) {
+        target_type = LogicalType::BLOB;
+        target_type.SetAlias("GEOMETRY");
+        source_type = LogicalType::VARCHAR;
+        source_type.SetAlias("WKT");
+        function_return_type = target_type;
+    }
 
-	unique_ptr<BoundCastData> Copy() const override {
-		auto result = make_uniq<WKTGeomCastData>();
-		result->has_function = has_function;
-		result->resolved_function = resolved_function;
-		result->bind_data = bind_data ? bind_data->Copy() : nullptr;
-		result->function_return_type = function_return_type;
-		result->target_type = target_type;
-		result->source_type = source_type;
-		return result;
-	}
+    unique_ptr<BoundCastData> Copy() const override {
+        auto result = make_uniq<WKTGeomCastData>();
+        result->has_function = has_function;
+        result->resolved_function = resolved_function;
+        result->bind_data = bind_data ? bind_data->Copy() : nullptr;
+        result->function_return_type = function_return_type;
+        result->target_type = target_type;
+        result->source_type = source_type;
+        return result;
+    }
 
-	bool has_function;
-	ScalarFunction resolved_function;
-	unique_ptr<FunctionData> bind_data;
-	LogicalType function_return_type;
-	LogicalType target_type;
-	LogicalType source_type;
+    bool has_function;
+    ScalarFunction resolved_function;
+    unique_ptr<FunctionData> bind_data;
+    LogicalType function_return_type;
+    LogicalType target_type;
+    LogicalType source_type;
 };
 
 struct WKTGeomCastLocalState : public FunctionLocalState {
@@ -69,7 +68,7 @@ static unique_ptr<FunctionLocalState> InitWKTGeomCastLocalState(CastLocalStatePa
     // Output chunk uses the function return type; we will cast to target if they differ
     state->output_chunk.Initialize(Allocator::Get(*params.context), {cast_data.function_return_type});
 
-	vector<unique_ptr<Expression>> args;
+    vector<unique_ptr<Expression>> args;
     args.push_back(make_uniq<BoundReferenceExpression>(cast_data.source_type, 0));
     state->expression = make_uniq<BoundFunctionExpression>(cast_data.function_return_type,
                                                            cast_data.resolved_function,
@@ -123,7 +122,7 @@ static BoundCastInfo BindWKTGeomCast(BindCastInput &input, const LogicalType &so
     }
     try {
         auto &catalog = Catalog::GetSystemCatalog(*context);
-        auto &func_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(*context, DEFAULT_SCHEMA, "ST_GeomFromText");
+        auto &func_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(*context, DEFAULT_SCHEMA, "st_geomfromtext");
         vector<LogicalType> args{LogicalType(LogicalTypeId::VARCHAR)};
 
         auto func = func_entry.functions.GetFunctionByArguments(*context, args);

--- a/src/bigquery_geometry_cast.cpp
+++ b/src/bigquery_geometry_cast.cpp
@@ -1,0 +1,158 @@
+#include "bigquery_geometry_cast.hpp"
+#include "bigquery_settings.hpp"
+
+#include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
+#include "duckdb/common/constants.hpp"
+#include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/function/cast/cast_function_set.hpp"
+#include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+
+#include <iostream>
+
+namespace duckdb {
+namespace bigquery {
+
+struct WKTGeomCastData : public BoundCastData {
+	WKTGeomCastData() : has_function(false),
+						resolved_function({LogicalType::VARCHAR}, LogicalType::BLOB, nullptr) {
+		target_type = LogicalType::BLOB;
+		target_type.SetAlias("GEOMETRY");
+		source_type = LogicalType::VARCHAR;
+		source_type.SetAlias("WKT");
+		function_return_type = target_type;
+	}
+
+	unique_ptr<BoundCastData> Copy() const override {
+		auto result = make_uniq<WKTGeomCastData>();
+		result->has_function = has_function;
+		result->resolved_function = resolved_function;
+		result->bind_data = bind_data ? bind_data->Copy() : nullptr;
+		result->function_return_type = function_return_type;
+		result->target_type = target_type;
+		result->source_type = source_type;
+		return result;
+	}
+
+	bool has_function;
+	ScalarFunction resolved_function;
+	unique_ptr<FunctionData> bind_data;
+	LogicalType function_return_type;
+	LogicalType target_type;
+	LogicalType source_type;
+};
+
+struct WKTGeomCastLocalState : public FunctionLocalState {
+    explicit WKTGeomCastLocalState(ClientContext &context_p) : context(context_p) {
+    }
+
+    ClientContext &context;
+    DataChunk input_chunk;
+    DataChunk output_chunk;
+    unique_ptr<ExpressionExecutor> executor;
+    unique_ptr<BoundFunctionExpression> expression;
+};
+
+static unique_ptr<FunctionLocalState> InitWKTGeomCastLocalState(CastLocalStateParameters &params) {
+    if (!params.context) {
+        return nullptr; // no context -> fall back to NOP behavior
+    }
+    auto &cast_data = params.cast_data->Cast<WKTGeomCastData>();
+    if (!cast_data.has_function) {
+        return nullptr; // nothing to do
+    }
+
+    auto state = make_uniq<WKTGeomCastLocalState>(*params.context);
+    // Initialize input chunk with original source_type (preserve alias GEOGRAPHY)
+    state->input_chunk.Initialize(Allocator::Get(*params.context), {cast_data.source_type});
+    // Output chunk uses the function return type; we will cast to target if they differ
+    state->output_chunk.Initialize(Allocator::Get(*params.context), {cast_data.function_return_type});
+
+	vector<unique_ptr<Expression>> args;
+    args.push_back(make_uniq<BoundReferenceExpression>(cast_data.source_type, 0));
+    state->expression = make_uniq<BoundFunctionExpression>(cast_data.function_return_type,
+                                                           cast_data.resolved_function,
+                                                           std::move(args),
+                                                           cast_data.bind_data ? cast_data.bind_data->Copy() : nullptr);
+    state->executor = make_uniq<ExpressionExecutor>(*params.context);
+    state->executor->AddExpression(*state->expression);
+    return std::move(state);
+}
+
+static bool ExecuteWKTGeomCast(Vector &source, Vector &result, idx_t count, CastParameters &parameters) {
+    auto &cdata = parameters.cast_data->Cast<WKTGeomCastData>();
+    if (!cdata.has_function) {
+        result.Reference(source);
+        return true;
+    }
+    if (!parameters.local_state) {
+        VectorOperations::Copy(source, result, count, 0, 0);
+        return true;
+    }
+    auto &lstate = parameters.local_state->Cast<WKTGeomCastLocalState>();
+    lstate.input_chunk.data[0].Reference(source);
+    lstate.input_chunk.SetCardinality(count);
+    lstate.executor->Execute(lstate.input_chunk, lstate.output_chunk);
+    auto &func_result = lstate.output_chunk.data[0];
+    if (func_result.GetType() == result.GetType()) {
+        result.Reference(func_result);
+    } else if (cdata.function_return_type == cdata.target_type) {
+        result.Reference(func_result);
+    } else {
+        auto &client_ctx = lstate.context; // get ClientContext from local state
+        VectorOperations::Cast(client_ctx, func_result, result, count);
+    }
+    return true;
+}
+
+static BoundCastInfo BindWKTGeomCast(BindCastInput &input, const LogicalType &source, const LogicalType &target) {
+    auto state = make_uniq<WKTGeomCastData>();
+    state->target_type = target;
+    state->source_type = source;
+    auto context = input.context;
+
+    if (!context) {
+        return BoundCastInfo(DefaultCasts::NopCast, std::move(state));
+    }
+    if (!BigquerySettings::GeographyAsGeometry()) {
+        return BoundCastInfo(DefaultCasts::NopCast, std::move(state));
+    }
+    if (!BigquerySettings::IsSpatialExtensionLoaded(*context)) {
+        return BoundCastInfo(DefaultCasts::NopCast, std::move(state));
+    }
+    try {
+        auto &catalog = Catalog::GetSystemCatalog(*context);
+        auto &func_entry = catalog.GetEntry<ScalarFunctionCatalogEntry>(*context, DEFAULT_SCHEMA, "ST_GeomFromText");
+        vector<LogicalType> args{LogicalType(LogicalTypeId::VARCHAR)};
+
+        auto func = func_entry.functions.GetFunctionByArguments(*context, args);
+        state->resolved_function = func;
+        state->function_return_type = func.return_type; // store real return type
+
+        if (func.bind) {
+            vector<unique_ptr<Expression>> dummy_args;
+            dummy_args.push_back(make_uniq<BoundReferenceExpression>(LogicalType(LogicalTypeId::VARCHAR), 0));
+            state->bind_data = func.bind(*context, state->resolved_function, dummy_args);
+        }
+
+        state->has_function = true;
+        return BoundCastInfo(ExecuteWKTGeomCast, std::move(state), InitWKTGeomCastLocalState);
+    } catch (Exception &ex) {
+        return BoundCastInfo(DefaultCasts::NopCast, std::move(state));
+    } catch (...) {
+        return BoundCastInfo(DefaultCasts::NopCast, std::move(state));
+    }
+}
+
+void RegisterWKTGeometryCast(DatabaseInstance &db) {
+    auto &casts = DBConfig::GetConfig(db).GetCastFunctions();
+    LogicalType source = LogicalType(LogicalTypeId::VARCHAR);
+    source.SetAlias("GEOGRAPHY");
+    LogicalType target = LogicalType(LogicalTypeId::BLOB);
+    target.SetAlias("GEOMETRY");
+    casts.RegisterCastFunction(source, target, BindWKTGeomCast);
+}
+
+} // namespace bigquery
+} // namespace duckdb

--- a/src/bigquery_proto_writer.cpp
+++ b/src/bigquery_proto_writer.cpp
@@ -682,7 +682,6 @@ void BigqueryProtoWriter::WriteField(google::protobuf::Message *msg,
         break;
     }
     case LogicalTypeId::BLOB: {
-        // auto value = val;
         reflection->SetString(msg, field, val.GetValueUnsafe<string>());
         break;
     }

--- a/src/bigquery_utils.cpp
+++ b/src/bigquery_utils.cpp
@@ -613,6 +613,10 @@ bool BigqueryUtils::IsGeographyType(const LogicalType &type) {
     return type.id() == LogicalTypeId::VARCHAR && type.HasAlias() && type.GetAlias() == "GEOGRAPHY";
 }
 
+bool BigqueryUtils::IsGeometryType(const LogicalType &type) {
+	return type.id() == LogicalTypeId::BLOB && type.HasAlias() && type.GetAlias() == "GEOMETRY";
+}
+
 LogicalType BigqueryUtils::CastToBigqueryTypeWithSpatialConversion(const LogicalType &type, ClientContext *context) {
     LogicalType result = CastToBigqueryType(type);
 

--- a/src/bigquery_utils.cpp
+++ b/src/bigquery_utils.cpp
@@ -561,6 +561,11 @@ LogicalType BigqueryUtils::CastToBigqueryType(const LogicalType &type) {
     case LogicalTypeId::DOUBLE:
         return LogicalType::DOUBLE;
     case LogicalTypeId::BLOB:
+        // if (BigqueryUtils::IsGeometryType(type)) {
+        //     auto geom_type = LogicalType(LogicalTypeId::VARCHAR);
+        //     geom_type.SetAlias("GEOGRAPHY");
+        //     return geom_type;
+        // }
         return type;
     case LogicalTypeId::DATE:
         return LogicalType::DATE;
@@ -614,14 +619,12 @@ bool BigqueryUtils::IsGeographyType(const LogicalType &type) {
 }
 
 bool BigqueryUtils::IsGeometryType(const LogicalType &type) {
-	return type.id() == LogicalTypeId::BLOB && type.HasAlias() && type.GetAlias() == "GEOMETRY";
+    return type.id() == LogicalTypeId::BLOB && type.HasAlias() && type.GetAlias() == "GEOMETRY";
 }
 
 LogicalType BigqueryUtils::CastToBigqueryTypeWithSpatialConversion(const LogicalType &type, ClientContext *context) {
-    LogicalType result = CastToBigqueryType(type);
-
     // Check for WKT alias on VARCHAR types - convert to GEOMETRY if spatial extension is available
-    if (result.id() == LogicalTypeId::BLOB && type.HasAlias() && type.GetAlias() == "GEOMETRY") {
+    if (type.id() == LogicalTypeId::BLOB && type.HasAlias() && type.GetAlias() == "GEOMETRY") {
         if (context && BigquerySettings::IsGeometryConversionEnabled(*context)) {
             // Create GEOMETRY type (BLOB with GEOMETRY alias)
             LogicalType geometry_type = LogicalType(LogicalTypeId::VARCHAR);
@@ -629,13 +632,16 @@ LogicalType BigqueryUtils::CastToBigqueryTypeWithSpatialConversion(const Logical
             return geometry_type;
         }
     }
-
+    LogicalType result = CastToBigqueryType(type);
     return result;
 }
 
 google::protobuf::FieldDescriptorProto::Type BigqueryUtils::LogicalTypeToProtoType(const LogicalType &type) {
     switch (type.id()) {
     case LogicalTypeId::BLOB:
+        if (BigqueryUtils::IsGeometryType(type)) {
+            return google::protobuf::FieldDescriptorProto::TYPE_STRING;
+        }
         return google::protobuf::FieldDescriptorProto::TYPE_BYTES;
     case LogicalTypeId::BIT:
         return google::protobuf::FieldDescriptorProto::TYPE_BOOL;

--- a/src/include/bigquery_geometry_cast.hpp
+++ b/src/include/bigquery_geometry_cast.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+namespace bigquery {
+
+// Register cast from VARCHAR alias WKT -> BLOB alias GEOMETRY (runtime lookup of ST_GeomFromText during execution)
+void RegisterWKTGeometryCast(DatabaseInstance &db);
+
+} // namespace bigquery
+} // namespace duckdb

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -248,6 +248,28 @@ public:
 		       "Please use bq_use_legacy_scan=%s instead.\n",
 		       value ? "false" : "true");
 	}
+
+	static bool IsSpatialExtensionLoaded(ClientContext &context) {
+		if (!context.db->ExtensionIsLoaded("spatial")) {
+			return false;
+		}
+		return true;
+	}
+
+	static bool &GeographyAsGeometry() {
+		static bool bigquery_geography_as_geometry = false;
+		return bigquery_geography_as_geometry;
+	}
+
+	static void SetGeographyAsGeometry(ClientContext &context, SetScope scope, Value &parameter) {
+		auto geography_as_geometry = BooleanValue::Get(parameter);
+		if (BooleanValue::Get(parameter) && !IsSpatialExtensionLoaded(context)) {
+			printf("WARNING: bq_geography_as_geometry=true requires the spatial extension. "
+				   "Please first run: `INSTALL spatial; LOAD spatial;`\n");
+			return;
+		}
+		GeographyAsGeometry() = geography_as_geometry;
+	}
 };
 
 

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -251,7 +251,7 @@ public:
     }
 
     static bool &GeographyAsGeometry() {
-        static bool bigquery_geography_as_geometry = true;
+        static bool bigquery_geography_as_geometry = false;
         return bigquery_geography_as_geometry;
     }
 

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -257,7 +257,7 @@ public:
 	}
 
 	static bool &GeographyAsGeometry() {
-		static bool bigquery_geography_as_geometry = false;
+		static bool bigquery_geography_as_geometry = true;
 		return bigquery_geography_as_geometry;
 	}
 

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -174,6 +174,7 @@ public:
     static string ReplaceQuotes(string &identifier, char to_replace = '\'');
 
 	static bool IsGeographyType(const LogicalType &type);
+	static bool IsGeometryType(const LogicalType &type);
     static LogicalType CastToBigqueryType(const LogicalType &type);
 	static LogicalType CastToBigqueryTypeWithSpatialConversion(const LogicalType &type, ClientContext *context = nullptr);
     static LogicalType FieldSchemaToLogicalType(const google::cloud::bigquery::v2::TableFieldSchema &field);

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "duckdb.hpp"
+#include "duckdb/function/table/arrow.hpp"
 
 // #include "google/cloud/bigquery/v2/minimal/internal/table_schema.h"
 
@@ -13,12 +14,8 @@
 #include <regex>
 #include <thread>
 
-
 namespace duckdb {
 namespace bigquery {
-
-
-
 
 struct BigqueryUtils;
 
@@ -177,6 +174,8 @@ public:
     static string ReplaceQuotes(string &identifier, char to_replace = '\'');
 
     static LogicalType CastToBigqueryType(const LogicalType &type);
+    //! Enhanced cast function that handles WKT to GEOMETRY conversion when spatial extension is available
+    static LogicalType CastToBigqueryTypeWithSpatialConversion(const LogicalType &type, ClientContext *context = nullptr);
     static LogicalType FieldSchemaToLogicalType(const google::cloud::bigquery::v2::TableFieldSchema &field);
     static LogicalType FieldSchemaNumericToLogicalType(const google::cloud::bigquery::v2::TableFieldSchema &field);
 
@@ -186,6 +185,14 @@ public:
                                                         const LogicalType &dtype,
                                                         bool nullable = true);
     static std::shared_ptr<arrow::Schema> BuildArrowSchema(const ColumnList &cols);
+
+    static void PopulateAndMapArrowTableTypes(ClientContext &context,
+                                              ArrowTableType &arrow_table,
+                                              ArrowSchemaWrapper &schema_root,
+                                              vector<string> &names,
+                                              vector<LogicalType> &return_types,
+                                              vector<LogicalType> &mapped_bq_types,
+                                              const ColumnList *source_columns = nullptr);
 
     static string LogicalTypeToBigquerySQL(const LogicalType &type);
     static LogicalType BigquerySQLToLogicalType(const string &type);

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -173,9 +173,9 @@ public:
     static string WriteQuotedIdentifier(const string &identifier);
     static string ReplaceQuotes(string &identifier, char to_replace = '\'');
 
+	static bool IsGeographyType(const LogicalType &type);
     static LogicalType CastToBigqueryType(const LogicalType &type);
-    //! Enhanced cast function that handles WKT to GEOMETRY conversion when spatial extension is available
-    static LogicalType CastToBigqueryTypeWithSpatialConversion(const LogicalType &type, ClientContext *context = nullptr);
+	static LogicalType CastToBigqueryTypeWithSpatialConversion(const LogicalType &type, ClientContext *context = nullptr);
     static LogicalType FieldSchemaToLogicalType(const google::cloud::bigquery::v2::TableFieldSchema &field);
     static LogicalType FieldSchemaNumericToLogicalType(const google::cloud::bigquery::v2::TableFieldSchema &field);
 

--- a/src/storage/bigquery_table_entry.cpp
+++ b/src/storage/bigquery_table_entry.cpp
@@ -57,11 +57,11 @@ TableFunction BigqueryTableEntry::GetScanFunction(ClientContext &context, unique
                                                    result->all_types);
 
 		// Check if we need to map the types to BigQuery types. The BigQuery Arrow scan function will
-		// do a cast to the BigQuery types if necessary.
+		// do a cast to the BigQuery types if necessary. Use enhanced cast that handles WKT to GEOMETRY conversion.
 		bool requires_cast = false;
 		vector<LogicalType> mapped_bq_types;
 		for (auto &col : columns.Logical()) {
-			auto bq_type = BigqueryUtils::CastToBigqueryType(col.GetType());
+			auto bq_type = BigqueryUtils::CastToBigqueryTypeWithSpatialConversion(col.GetType(), &context);
 			if (bq_type != col.GetType()) {
 				requires_cast = true;
 			}

--- a/src/storage/bigquery_table_entry.cpp
+++ b/src/storage/bigquery_table_entry.cpp
@@ -37,12 +37,12 @@ TableFunction BigqueryTableEntry::GetScanFunction(ClientContext &context, unique
 
     auto use_legacy_scan = BigquerySettings::UseLegacyScan();
     if (!use_legacy_scan) {
-        // Use the new Arrow scan function (bigquery_arrow_scan)
         auto result = make_uniq<BigqueryArrowScanBindData>();
         result->table_ref = BigqueryTableRef(bigquery_catalog.GetProjectID(), schema.name, name);
         result->bq_client = bigquery_transaction->GetBigqueryClient();
         result->bq_catalog = &bigquery_catalog;
         result->bq_table_entry = *this;
+        result->bq_config = bigquery_catalog.config;
 
         auto arrow_schema_ptr = BigqueryUtils::BuildArrowSchema(columns);
         auto status = arrow::ExportSchema(*arrow_schema_ptr, &result->schema_root.arrow_schema);
@@ -50,20 +50,77 @@ TableFunction BigqueryTableEntry::GetScanFunction(ClientContext &context, unique
             throw BinderException("Arrow schema export failed: " + status.ToString());
         }
 
-        vector<LogicalType> mapped_bq_types;
+        vector<string> physical_names;             // names extracted from arrow schema
+        vector<LogicalType> physical_return_types; // physical DuckDB logical types derived from Arrow
+        vector<LogicalType> util_mapped_bq_types;  // (unused for table entry logical exposure)
         BigqueryUtils::PopulateAndMapArrowTableTypes(context,
                                                      result->arrow_table,
                                                      result->schema_root,
-                                                     result->names,
-                                                     result->all_types,
-                                                     mapped_bq_types,
+                                                     physical_names,
+                                                     physical_return_types,
+                                                     util_mapped_bq_types,
                                                      &columns);
-        if (!mapped_bq_types.empty()) {
-            result->requires_cast = true;
-            result->mapped_bq_types = std::move(mapped_bq_types);
-        } else {
-            result->requires_cast = false;
+        if (physical_return_types.empty()) {
+            throw BinderException("BigQuery table has no columns");
         }
+
+        vector<LogicalType> user_return_types;
+        user_return_types.reserve(columns.LogicalColumnCount());
+        vector<string> user_names;
+        user_names.reserve(columns.LogicalColumnCount());
+        for (auto &col : columns.Logical()) {
+            user_return_types.push_back(col.GetType());
+            user_names.push_back(col.GetName());
+        }
+
+        if (user_return_types.size() != physical_return_types.size()) {
+            throw InternalException("Arrow schema column count (%llu) != catalog column count (%llu) for table %s",
+                                    (unsigned long long)physical_return_types.size(),
+                                    (unsigned long long)user_return_types.size(),
+                                    name);
+        }
+
+        // Build mapping: if physical type differs from user-visible, we will cast (incl. spatial handling)
+        bool requires_cast = false;
+        vector<LogicalType> mapped_bq_types; // physical source types aligned with user types
+        mapped_bq_types.reserve(user_return_types.size());
+        for (idx_t i = 0; i < user_return_types.size(); i++) {
+            const auto &user_type = user_return_types[i];
+            const auto &arrow_phys = physical_return_types[i];
+
+            auto spatial_source = BigqueryUtils::CastToBigqueryTypeWithSpatialConversion(user_type, &context);
+
+            LogicalType chosen_physical;
+            // SPECIAL CASE (GEOGRAPHY -> GEOMETRY):
+            // Catalog/user type: BLOB alias GEOMETRY (target user-facing GEOMETRY)
+            // Actual BigQuery Arrow stream delivers WKT as VARCHAR alias GEOGRAPHY.
+            // CastToBigqueryTypeWithSpatialConversion returns VARCHAR GEOGRAPHY. We must keep that as the mapped
+            // physical source so that cast logic triggers and converts WKT->GEOMETRY blob.
+            bool is_geometry_target = BigqueryUtils::IsGeometryType(user_type);
+            bool spatial_inversion = BigqueryUtils::IsGeographyType(spatial_source);
+            if (is_geometry_target && spatial_inversion) {
+                // Keep spatial_source (VARCHAR GEOGRAPHY) as mapped physical
+                chosen_physical = spatial_source;
+            } else {
+                // Otherwise trust Arrow's physical interpretation (incl. decimals/structs) – aliases already copied
+                chosen_physical = arrow_phys;
+            }
+
+            if (chosen_physical != user_type) {
+                requires_cast = true;
+            }
+            mapped_bq_types.push_back(chosen_physical);
+        }
+        if (!requires_cast) {
+            mapped_bq_types.clear(); // signal no cast path needed
+        }
+
+        result->names = std::move(user_names);
+        result->all_types = std::move(user_return_types);
+        if (requires_cast) {
+            result->mapped_bq_types = std::move(mapped_bq_types);
+        }
+        result->requires_cast = requires_cast;
 
         bind_data = std::move(result);
 

--- a/test/sql/bigquery/geography_support.test
+++ b/test/sql/bigquery/geography_support.test
@@ -1,0 +1,68 @@
+# name: test/sql/bigquery/geography_support.test
+# description: Test GEOGRAPHY to GEOMETRY type conversion feature
+# group: [bigquery]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+# Create a simple table with GEOGRAPHY columns using bigquery_execute
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', '
+	CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.geography_test` AS
+	SELECT * FROM (
+		SELECT 1 as id, ST_GEOGPOINT(-122.4194, 37.7749) as geom
+		UNION ALL
+		SELECT 2 as id, ST_GEOGFROMTEXT("POLYGON((-122.4 37.7, -122.3 37.7, -122.3 37.8, -122.4 37.8, -122.4 37.7))") as geom
+	)
+');
+
+# Test 1: Default behavior - GEOGRAPHY columns should be returned as VARCHAR (WKT strings)
+query II
+SELECT id, geom FROM bigquery_scan('${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.geography_test') ORDER BY id;
+----
+1	POINT(-122.4194 37.7749)
+2	POLYGON((-122.4 37.7, -122.3 37.7, -122.3 37.8, -122.4 37.8, -122.4 37.7))
+
+# Test 2: Load spatial extension for geometry conversion
+statement ok
+INSTALL spatial;
+
+statement ok
+LOAD spatial;
+
+# Test 3: Set geography_as_geometry to false (default) - should return WKT strings
+statement ok
+SET bq_geography_as_geometry = false;
+
+query II
+SELECT id, geom FROM bigquery_scan('${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.geography_test') ORDER BY id;
+----
+1	POINT(-122.4194 37.7749)
+2	POLYGON((-122.4 37.7, -122.3 37.7, -122.3 37.8, -122.4 37.8, -122.4 37.7))
+
+# Test 4: Set geography_as_geometry to true - should convert to GEOMETRY type
+statement ok
+SET bq_geography_as_geometry = true;
+
+# Verify that spatial functions work on converted GEOMETRY columns
+query III
+SELECT
+    id,
+    ST_AsText(geom) as geom_wkt,
+    ST_GeometryType(geom) as geom_type
+FROM bigquery_scan('${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.geography_test')
+ORDER BY id;
+----
+1	POINT (-122.4194 37.7749)	POINT
+2	POLYGON ((-122.4 37.7, -122.3 37.7, -122.3 37.8, -122.4 37.8, -122.4 37.7))	POLYGON
+
+# Reset setting
+statement ok
+SET bq_geography_as_geometry = false;
+
+# Cleanup
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE `${BQ_TEST_DATASET}.geography_test`');

--- a/test/sql/bigquery/geography_support.test
+++ b/test/sql/bigquery/geography_support.test
@@ -59,6 +59,18 @@ ORDER BY id;
 1	POINT (-122.4194 37.7749)	POINT
 2	POLYGON ((-122.4 37.7, -122.3 37.7, -122.3 37.8, -122.4 37.8, -122.4 37.7))	POLYGON
 
+# Test 5: ATTACH and write to table
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
+
+statement ok
+INSERT INTO bq.${BQ_TEST_DATASET}.geography_test VALUES (4, ST_GeomFromText('POINT(10 20)'))
+
+query II
+SELECT * FROM bq.${BQ_TEST_DATASET}.geography_test WHERE id = 4;
+----
+4	POINT (10 20)
+
 # Reset setting
 statement ok
 SET bq_geography_as_geometry = false;


### PR DESCRIPTION
This pull request extends spatial type support between BigQuery and DuckDB.
When the spatial extension is loaded, BigQuery `GEOGRAPHY` columns can now be returned as DuckDB `GEOMETRY` types. This behavior can be enabled through the new configuration option `bq_geography_as_geometry`. The implementation includes the required cast logic and ensures correct handling in both optimized and legacy scan paths.

```sql
-- 1. Load spatial extension (required)
INSTALL spatial;
LOAD spatial;

-- 2. Configure setting
SET bq_geography_as_geometry = true;

-- 3. Use spatial functions on BigQuery data
SELECT geography_column, ST_GeometryType(geography_column) FROM bigquery_scan('project.dataset.table');
```
In addition, geometry columns can now be written to BigQuery by converting them to WKT (Well-Known Text) via the `ST_AsText` function. To achieve this, a new projection step has been added to the physical plan for geometry types. The changes also ensure proper function lookup and binding, and update utility functions to handle spatial types consistently.

``` sql
-- 1. Load spatial extension (required)
INSTALL spatial;
LOAD spatial;

-- 2. ATTACH the BigQuery project
ATTACH 'project=my-gcp-project' AS bq (TYPE bigquery);

-- 3. Write a Geometry
INSERT INTO bq.some_dataset.geom_table VALUES (ST_GeomFromText('POINT(10 20)'))

-- 4. Read from the table
SELECT * FROM bq.some_dataset.geom_table;
----
POINT (10 20)
``` 

Overall, these improvements strengthen interoperability with BigQuery’s GEOGRAPHY type, refine type mapping and casting for spatial data, and enhance end-to-end spatial workflows. Documentation has been updated accordingly.