### PR TITLE
Add `dry_run` parameter to `bigquery_query` and `bigquery_execute`

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -21,12 +21,14 @@ jobs:
         uses: ./.github/workflows/_extension_distribution.yml
         secrets: inherit
         with:
+            extension_name: bigquery
             duckdb_version: v1.4.0
             ci_tools_version: v1.4.0
-            extension_name: bigquery
-            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
+            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;"
             vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
             extra_toolchains: "parser_tools"
+            save_cache: ${{ github.event_name != 'pull_request' }}
+            reduced_ci_mode: "disabled"
 
     duckdb-stable-deploy:
         name: Deploy extension binaries
@@ -34,8 +36,8 @@ jobs:
         uses: ./.github/workflows/_extension_deploy.yml
         secrets: inherit
         with:
+            extension_name: bigquery
             duckdb_version: v1.4.0
             ci_tools_version: v1.4.0
-            extension_name: bigquery
-            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
+            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;"
             deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -41,3 +41,4 @@ jobs:
             ci_tools_version: v1.4.0
             exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;"
             deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
+            reduced_ci_mode: "disabled"

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -62,6 +62,11 @@ on:
         required: false
         type: string
         default: "./extension-ci-tools/scripts/modify_distribution_matrix.py"
+      # auto/enabled/disabled: when enabled (or enabled through auto) will skip redundant architectures to reduce CI load
+      reduced_ci_mode:
+        required: false
+        type: string
+        default: 'auto'
 
 
 jobs:
@@ -80,7 +85,7 @@ jobs:
 
       - id: parse-matrices
         run: |
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --deploy_matrix --output deploy_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
           deploy_matrix="`cat deploy_matrix.json`"
           echo deploy_matrix=$deploy_matrix >> $GITHUB_OUTPUT
           echo `cat $GITHUB_OUTPUT`

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -484,16 +484,8 @@ jobs:
   macos:
     name: MacOS
     runs-on: macos-latest
-    needs:
-      - generate_matrix
-      - linux
-    if: |
-      always() &&
-      !cancelled() &&
-      needs.generate_matrix.outputs.osx_matrix != '{}' &&
-      needs.generate_matrix.outputs.osx_matrix != '' &&
-      needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+    needs: generate_matrix
+    if: ${{ needs.generate_matrix.outputs.osx_matrix != '{}' && needs.generate_matrix.outputs.osx_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
     env:
@@ -721,16 +713,8 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    needs:
-      - generate_matrix
-      - linux
-    if: |
-      always() &&
-      !cancelled() &&
-      needs.generate_matrix.outputs.windows_matrix != '{}' &&
-      needs.generate_matrix.outputs.windows_matrix != '' &&
-      needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+    needs: generate_matrix
+    if: ${{ needs.generate_matrix.outputs.windows_matrix != '{}' && needs.generate_matrix.outputs.windows_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
     env:
@@ -989,16 +973,8 @@ jobs:
   wasm:
     name: DuckDB-Wasm
     runs-on: ubuntu-latest
-    needs:
-      - generate_matrix
-      - linux
-    if: |
-      always() &&
-      !cancelled() &&
-      needs.generate_matrix.outputs.wasm_matrix != '{}' &&
-      needs.generate_matrix.outputs.wasm_matrix != '' &&
-      needs.generate_matrix.result == 'success' &&
-      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
+    needs: generate_matrix
+    if: ${{ needs.generate_matrix.outputs.wasm_matrix != '{}' && needs.generate_matrix.outputs.wasm_matrix != '' }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.wasm_matrix)}}
     env:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -92,9 +92,24 @@ on:
         required: false
         type: string
         default: "duckdb/extension-ci-tools"
+      # Override the duckdb repository (for using this workflow from a DuckDB fork)
+      override_duckdb_repository:
+        required: false
+        type: string
+        default: ""
+      # Internal tooling option: allows automatically fetching the duckdb repo and ref from the calling repository.
+      set_caller_as_duckdb:
+        required: false
+        type: boolean
+        default: false
       # Pass extra toolchains
       #   available: (parser_tools, rust, fortran, omp, python3)
       extra_toolchains:
+        required: false
+        type: string
+        default: ""
+      # Experimental option to allow automatically building the vcpkg dependencies of duckdb extensions that are used for testing
+      use_merged_vcpkg_manifest:
         required: false
         type: string
         default: ""
@@ -126,10 +141,30 @@ on:
         required: false
         type: boolean
         default: false
+      test_config:
+        required: false
+        type: string
+        default: "{}"
+      build_type:
+        required: false
+        type: string
+        default: "release"
+      upload_all_extensions:
+        required: false
+        type: boolean
+        default: false
+      extra_extension_config:
+        required: false
+        type: string
+        default: ""
+      # auto/enabled/disabled: when enabled (or enabled through auto) will skip redundant architectures to reduce CI load
+      reduced_ci_mode:
+        required: false
+        type: string
+        default: 'auto'
 
 env:
   VCPKG_BINARY_SOURCES: ${{inputs.vcpkg_binary_sources == '' && 'clear;http,https://vcpkg-cache.duckdb.org,read' || inputs.vcpkg_binary_sources }}
-
 
 jobs:
   generate_matrix:
@@ -151,10 +186,10 @@ jobs:
       - id: parse-matrices
         run: |
           mkdir build
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
-          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux --output build/linux_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx --output build/osx_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os wasm --output build/wasm_matrix.json --exclude "${{ inputs.exclude_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
 
       - id: set-matrix-linux
         run: |
@@ -197,6 +232,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
       # Misc
       GEN: ninja
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
@@ -253,8 +289,21 @@ jobs:
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
 
+      - name: Fetch override repository
+        if: ${{inputs.override_duckdb_repository != ''}}
+        run: |
+          DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
+
+      - name: Set DuckDB to ref of calling workflow
+        if: ${{inputs.set_caller_as_duckdb}}
+        uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-tags: true
+          fetch-depth: 0
+
       - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != ''}}
+        if: ${{ inputs.duckdb_version != '' }}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
@@ -290,14 +339,16 @@ jobs:
         run: |
           cat <<-EOF > docker_env.txt
           VCPKG_BINARY_SOURCES=$VCPKG_BINARY_SOURCES
+          USE_MERGED_VCPKG_MANIFEST=${{ inputs.use_merged_vcpkg_manifest }}
           AWS_ACCESS_KEY_ID=${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY=${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL=${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
           AWS_DEFAULT_REGION=${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+          AWS_REQUEST_CHECKSUM_CALCULATION=when_required
           VCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_target_triplet }}
           BUILD_SHELL=${{ inputs.build_duckdb_shell && '1' || '0' }}
-          OPENSSL_ROOT_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}
-          OPENSSL_DIR=/duckdb_build_dir/build/release/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}
+          OPENSSL_ROOT_DIR=/duckdb_build_dir/build/${{ inputs.build_type }}/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}
+          OPENSSL_DIR=/duckdb_build_dir/build/${{ inputs.build_type }}/vcpkg_installed/${{ matrix.vcpkg_target_triplet }}
           OPENSSL_USE_STATIC_LIBS=true
           DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }}
@@ -305,6 +356,7 @@ jobs:
           EXTENSION_CANONICAL=${{ inputs.extension_canonical }}
           LINUX_CI_IN_DOCKER=1
           EOF
+          echo '${{ inputs.test_config }}'| jq -r '.test_env_variables // {} | to_entries | map("\(.key)=\(.value)")|.[]' >> docker_env.txt
 
       - name: Generate timestamp for Ccache entry
         shell: cmake -P {0}
@@ -324,6 +376,7 @@ jobs:
           key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}-${{ steps.ccache_timestamp.outputs.timestamp }}
           restore-keys: |
             ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+            ccache-extension-distribution-${{ matrix.duckdb_arch }}-
 
       - name: Run configure (outside Docker)
         shell: bash
@@ -344,6 +397,15 @@ jobs:
             done
           fi
 
+      - name: Inject extra extension config
+        if: ${{ inputs.extra_extension_config }}
+        shell: bash
+        env:
+          EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
+        run: |
+          echo -e "\n# Injected Extension Config\n$EXTENSION_CONFIG" >> ./extension_config.cmake
+          cat ./extension_config.cmake
+
       - name: Run configure (inside Docker)
         shell: bash
         run: |
@@ -351,7 +413,7 @@ jobs:
 
       - name: Build extension (inside Docker)
         run: |
-          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make release
+          docker run --env-file=docker_env.txt -v `pwd`:/duckdb_build_dir -v `pwd`/ccache_dir:/ccache_dir duckdb/${{ matrix.duckdb_arch }} make ${{ inputs.build_type }}
 
       - name: Save Ccache
         if: ${{ inputs.save_cache }}
@@ -381,7 +443,7 @@ jobs:
             --env-file=docker_env.txt \
             -v `pwd`:/duckdb_build_dir \
             -v `pwd`/ccache_dir:/ccache_dir \
-            duckdb/${{ matrix.duckdb_arch }} make test_release
+            duckdb/${{ matrix.duckdb_arch }} make test_${{ inputs.build_type }}
 
       - name: Test extension (outside docker)
         if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
@@ -391,18 +453,29 @@ jobs:
           BQ_TEST_PROJECT: ${{ secrets.BQ_TEST_PROJECT }}
           BQ_TEST_DATASET: ${{ secrets.BQ_TEST_DATASET }}_${{ matrix.duckdb_arch }}
         run: |
-          make test_release
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
+          make test_${{ inputs.build_type }}
 
       - uses: actions/upload-artifact@v4
+        if: ${{ !inputs.upload_all_extensions }}
         with:
+          if-no-files-found: error
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |
-            build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+            build/${{ inputs.build_type }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload_all_extensions }}
+        with:
+          if-no-files-found: error
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: |
+            build/${{ inputs.build_type }}/repository/**/*.duckdb_extension
 
       - name: Print Rust logs
         if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         run: |
-          for filename in build/release/rust/src/*/*build-*.log; do
+          for filename in build/${{ inputs.build_type }}/rust/src/*/*build-*.log; do
             echo Printing logs for file $filename
             cat $filename;
             echo Done printing logs for $filename
@@ -411,8 +484,16 @@ jobs:
   macos:
     name: MacOS
     runs-on: macos-latest
-    needs: generate_matrix
-    if: ${{ needs.generate_matrix.outputs.osx_matrix != '{}' && needs.generate_matrix.outputs.osx_matrix != '' }}
+    needs:
+      - generate_matrix
+      - linux
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.generate_matrix.outputs.osx_matrix != '{}' &&
+      needs.generate_matrix.outputs.osx_matrix != '' &&
+      needs.generate_matrix.result == 'success' &&
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
     env:
@@ -420,11 +501,13 @@ jobs:
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
       # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
       # Misc
       OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
       GEN: ninja
@@ -456,7 +539,8 @@ jobs:
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true
         with:
-          key: extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          restore-keys: ccache-extension-distribution-${{ matrix.duckdb_arch }}-
           save: ${{ inputs.save_cache }}
 
       - uses: actions/setup-python@v5
@@ -470,8 +554,21 @@ jobs:
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
 
+      - name: Fetch override repository
+        if: ${{inputs.override_duckdb_repository != ''}}
+        run: |
+          DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
+
+      - name: Set DuckDB to ref of calling workflow
+        if: ${{inputs.set_caller_as_duckdb}}
+        uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-tags: true
+          fetch-depth: 0
+
       - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != ''}}
+        if: ${{ inputs.duckdb_version != '' }}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
@@ -519,6 +616,15 @@ jobs:
         if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';parser_tools;')}}
         run: |
           brew install bison flex
+
+      - name: Inject extra extension config
+        if: ${{ inputs.extra_extension_config }}
+        shell: bash
+        env:
+          EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
+        run: |
+          echo -e "\n# Injected Extension Config\n$EXTENSION_CONFIG" >> ./extension_config.cmake
+          cat ./extension_config.cmake
 
       - name: install omp (x86)
         if: ${{ contains(format(';{0};', inputs.extra_toolchains), ';omp;') && matrix.duckdb_arch == 'osx_amd64' }}
@@ -570,7 +676,7 @@ jobs:
       - name: Build extension
         shell: bash
         run: |
-          EXTENSION_NAME=${{ inputs.extension_name }} EXTENSION_CANONICAL=${{ inputs.extension_canonical }} make release
+          EXTENSION_NAME=${{ inputs.extension_name }} EXTENSION_CANONICAL=${{ inputs.extension_canonical }} make ${{ inputs.build_type }}
 
       - id: "auth"
         uses: "google-github-actions/auth@v2"
@@ -584,19 +690,29 @@ jobs:
           BQ_TEST_DATASET: ${{ secrets.BQ_TEST_DATASET }}_${{ matrix.duckdb_arch }}
         shell: bash
         run: |
-          make test_release
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
+          make test_${{ inputs.build_type }}
 
       - uses: actions/upload-artifact@v4
+        if: ${{ !inputs.upload_all_extensions }}
         with:
           if-no-files-found: error
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |
-            build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+            build/${{ inputs.build_type }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload_all_extensions }}
+        with:
+          if-no-files-found: error
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: |
+            build/${{ inputs.build_type }}/repository/**/*.duckdb_extension
 
       - name: Print Rust logs
         if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         run: |
-          for filename in build/release/rust/src/*/*build-*.log; do
+          for filename in build/${{ inputs.build_type }}/rust/src/*/*build-*.log; do
             echo Printing logs for file $filename
             cat $filename;
             echo Done printing logs for $filename
@@ -605,8 +721,16 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
-    needs: generate_matrix
-    if: ${{ needs.generate_matrix.outputs.windows_matrix != '{}' && needs.generate_matrix.outputs.windows_matrix != '' }}
+    needs:
+      - generate_matrix
+      - linux
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.generate_matrix.outputs.windows_matrix != '{}' &&
+      needs.generate_matrix.outputs.windows_matrix != '' &&
+      needs.generate_matrix.result == 'success' &&
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
     env:
@@ -614,11 +738,13 @@ jobs:
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
+      USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
       # VCPKG caching
       AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
       AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
       AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
       # Misc
       BUILD_SHELL: ${{ inputs.build_duckdb_shell && '1' || '0' }}
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
@@ -686,11 +812,16 @@ jobs:
         run: |
           choco install ninja -y
 
+      - name: Install jq
+        run: |
+          choco install jq -y
+
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true
         with:
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          restore-keys: ccache-extension-distribution-${{ matrix.duckdb_arch }}-
           save: ${{ inputs.save_cache }}
 
       - uses: r-lib/actions/setup-r@v2
@@ -714,8 +845,23 @@ jobs:
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
 
+      - name: Fetch override repository
+        if: ${{inputs.override_duckdb_repository != ''}}
+        env:
+          DUCKDB_GIT_REPOSITORY: ${{ inputs.override_duckdb_repository }}
+        run: |
+          make set_duckdb_repository
+
+      - name: Set DuckDB to ref of calling workflow
+        if: ${{inputs.set_caller_as_duckdb}}
+        uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-tags: true
+          fetch-depth: 0
+
       - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != ''}}
+        if: ${{ inputs.duckdb_version != '' }}
         env:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
         run: |
@@ -738,6 +884,15 @@ jobs:
         with:
           vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
           vcpkgGitURL: ${{ inputs.vcpkg_url }}
+
+      - name: Inject extra extension config
+        if: ${{ inputs.extra_extension_config }}
+        shell: bash
+        env:
+          EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
+        run: |
+          echo -e "\n# Injected Extension Config\n$EXTENSION_CONFIG" >> ./extension_config.cmake
+          cat ./extension_config.cmake
 
       - name: Run configure
         shell: bash
@@ -775,14 +930,15 @@ jobs:
             REM Rename link.exe to link-git.exe to avoid conflicts with git supplied linker.
             mv "C:\Program Files\Git\usr\bin\link.exe" "C:\Program Files\Git\usr\bin\link-git.exe"
           )
-          make release
+          make ${{ inputs.build_type }}
 
       - id: "auth"
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
 
-      - name: Test Extension
+      - name: Test extension
+        if: ${{ inputs.skip_tests == false }}
         env:
           BQ_TEST_PROJECT: ${{ secrets.BQ_TEST_PROJECT }}
           BQ_TEST_DATASET: ${{ secrets.BQ_TEST_DATASET }}_${{ matrix.duckdb_arch }}
@@ -795,20 +951,30 @@ jobs:
           echo "Downloading roots.pem to: $ROOTS_FILE"
           curl --create-dirs -o "$ROOTS_FILE" -L https://pki.google.com/roots.pem
           export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$ROOTS_FILE"
-          make test_release GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$ROOTS_FILE"
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
+          make test_${{ inputs.build_type }} GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$ROOTS_FILE"
 
       - uses: actions/upload-artifact@v4
+        if: ${{ !inputs.upload_all_extensions }}
         with:
           if-no-files-found: error
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |
-            build/release/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+            build/${{ inputs.build_type }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload_all_extensions }}
+        with:
+          if-no-files-found: error
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: |
+            build/${{ inputs.build_type }}/repository/**/*.duckdb_extension
 
       - name: Print Rust logs
         if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         shell: bash
         run: |
-          for filename in build/release/rust/src/*/*build-*.log; do
+          for filename in build/${{ inputs.build_type }}/rust/src/*/*build-*.log; do
             echo Printing logs for file $filename
             cat $filename;
             echo Done printing logs for $filename
@@ -823,15 +989,32 @@ jobs:
   wasm:
     name: DuckDB-Wasm
     runs-on: ubuntu-latest
-    needs: generate_matrix
-    if: ${{ needs.generate_matrix.outputs.wasm_matrix != '{}' && needs.generate_matrix.outputs.wasm_matrix != '' }}
+    needs:
+      - generate_matrix
+      - linux
+    if: |
+      always() &&
+      !cancelled() &&
+      needs.generate_matrix.outputs.wasm_matrix != '{}' &&
+      needs.generate_matrix.outputs.wasm_matrix != '' &&
+      needs.generate_matrix.result == 'success' &&
+      (needs.linux.result == 'success' || needs.linux.result == 'skipped')
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.wasm_matrix)}}
     env:
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
+      USE_MERGED_VCPKG_MANIFEST: ${{ inputs.use_merged_vcpkg_manifest }}
+      # VCPKG caching
+      AWS_ACCESS_KEY_ID: ${{ secrets.VCPKG_CACHING_AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.VCPKG_CACHING_AWS_SECRET_ACCESS_KEY }}
+      AWS_ENDPOINT_URL: ${{ secrets.VCPKG_CACHING_AWS_ENDPOINT_URL }}
+      AWS_DEFAULT_REGION: ${{ secrets.VCPKG_CACHING_AWS_DEFAULT_REGION }}
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
+
       DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      WASM_EXTENSIONS: 1
 
     steps:
       - uses: actions/checkout@v4
@@ -857,8 +1040,21 @@ jobs:
           ref: ${{ inputs.ci_tools_version }}
           repository: ${{ inputs.override_ci_tools_repository }}
 
+      - name: Fetch override repository
+        if: ${{inputs.override_duckdb_repository != ''}}
+        run: |
+          DUCKDB_GIT_REPOSITORY=${{ inputs.override_duckdb_repository }} make set_duckdb_repository
+
+      - name: Set DuckDB to ref of calling workflow
+        if: ${{inputs.set_caller_as_duckdb}}
+        uses: actions/checkout@v4
+        with:
+          path: 'duckdb'
+          fetch-tags: true
+          fetch-depth: 0
+
       - name: Checkout DuckDB to version
-        if: ${{inputs.duckdb_version != ''}}
+        if: ${{ inputs.duckdb_version != '' }}
         run: |
           DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }} make set_duckdb_version
 
@@ -889,16 +1085,43 @@ jobs:
           go-version: '1.23'
 
       - name: Setup vcpkg
-        uses: lukka/run-vcpkg@v11.1
-        with:
-          vcpkgGitCommitId: ${{ inputs.vcpkg_commit }}
-          vcpkgGitURL: ${{ inputs.vcpkg_url }}
+        run: |
+          mkdir local_vcpkg_installation
+          cmake --version
+          cd local_vcpkg_installation
+          git init
+          git remote add origin ${{ inputs.vcpkg_url }}
+          git fetch origin ${{ inputs.vcpkg_commit }}
+          git checkout ${{ inputs.vcpkg_commit }}
+          ./bootstrap-vcpkg.sh
+          echo "VCPKG_ROOT=${{ github.workspace }}/local_vcpkg_installation" >> $GITHUB_ENV
+          echo "VCPKG_TOOLCHAIN_PATH=${{ github.workspace }}/local_vcpkg_installation/scripts/buildsystems/vcpkg.cmake" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/local_vcpkg_installation" >> $GITHUB_PATH
 
       - name: Setup Ccache
         uses: hendrikmuhs/ccache-action@main
         continue-on-error: true
         with:
-          key: ${{ github.job }}-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}
+          restore-keys: ccache-extension-distribution-${{ matrix.duckdb_arch }}-
+          save: ${{ inputs.save_cache }}
+
+      - name: Downgrade AWS cli
+        if: ${{ (contains(format(';{0};', inputs.extra_toolchains), ';downgraded_aws_cli;')) }}
+        run: |
+          curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-2.22.35.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install --update
+          aws --version
+
+      - name: Inject extra extension config
+        if: ${{ inputs.extra_extension_config }}
+        shell: bash
+        env:
+          EXTENSION_CONFIG: ${{ inputs.extra_extension_config }}
+        run: |
+          echo -e "\n# Injected Extension Config\n$EXTENSION_CONFIG" >> ./extension_config.cmake
+          cat ./extension_config.cmake
 
       - name: Run configure
         shell: bash
@@ -907,22 +1130,43 @@ jobs:
         run: |
           make configure_ci
 
+      - name: Install extra vcpkg dependencies
+        if: ${{ inputs.vcpkg_extra_dependencies != '' }}
+        shell: bash
+        run: |
+          JSON='${{inputs.vcpkg_extra_dependencies}}'
+          DEPS=$(python3 -c "import json; data=json.loads(r'$JSON'); print(' '.join(data.get('${{ matrix.duckdb_arch }}', [])) if '${{ matrix.duckdb_arch }}' in data else '')" | tr -d '\n')
+          if [ ! -z "$DEPS" ]; then
+            for dep in $DEPS; do
+              vcpkg install "$dep" --recurse
+            done
+          fi
+
       - name: Build Wasm module
         run: |
           EXTENSION_NAME=${{ inputs.extension_name }} EXTENSION_CANONICAL=${{ inputs.extension_canonical }} make ${{ matrix.duckdb_arch }}
 
       - uses: actions/upload-artifact@v4
+        if: ${{ !inputs.upload_all_extensions }}
         with:
           if-no-files-found: error
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: |
             build/${{ matrix.duckdb_arch }}/extension/${{ inputs.extension_name }}/${{ inputs.extension_name }}.duckdb_extension.wasm
 
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload_all_extensions}}
+        with:
+          if-no-files-found: error
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-extension-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: |
+            build/${{ matrix.duckdb_arch }}/repository/**/*.duckdb_extension.wasm
+
       - name: Print Rust logs
         if: ${{ inputs.rust_logs && (inputs.enable_rust || contains(format(';{0};', inputs.extra_toolchains), ';rust;')) }}
         shell: bash
         run: |
-          for filename in build/release/rust/src/*/*build-*.log; do
+          for filename in build/${{ inputs.build_type }}/rust/src/*/*build-*.log; do
             echo Printing logs for file $filename
             cat $filename;
             echo Done printing logs for $filename

--- a/README.md
+++ b/README.md
@@ -214,18 +214,38 @@ The `bigquery_query` function allows you to run custom [GoogleSQL](https://cloud
 
 ```sql
 D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT * FROM `my_gcp_project.quacking_dataset.duck_tbl`');
+┌───────┬────────────────┐
+│   i   │       s        │
+│ int32 │    varchar     │
+├───────┼────────────────┤
+│    12 │ quack 🦆       │
+│    13 │ quack quack 🦆 │
+└───────┴────────────────┘
 ```
 
 > **Note**: If your goal is straightforward table reads, `bigquery_scan` is often more efficient, as it bypasses the SQL layer for direct data access. However, `bigquery_query` is ideal when you need to execute custom SQL that requires the full querying capabilities of BigQuery expressed in GoogleSQL. In this case, BigQuery transparently creates an anonymous temporary result table, which is fetched using the selected scan engine.
 
+The `dry_run` parameter allows you to validate a query without executing it. This is useful for estimating query costs and checking syntax before running expensive queries:
+
+```sql
+D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT * FROM `my_gcp_project.quacking_dataset.duck_tbl`', dry_run=true);
+┌───────────────────────┬───────────┬──────────┐
+│ total_bytes_processed │ cache_hit │ location │
+│        int64          │  boolean  │ varchar  │
+├───────────────────────┼───────────┼──────────┤
+│                    54 │ false     │ US       │
+└───────────────────────┴───────────┴──────────┘
+```
+
 The `bigquery_query` function supports the following named parameters:
 
-| Parameter         | Type      | Description                                                          |
-| ----------------- | --------- | -------------------------------------------------------------------- |
-| `engine`          | `VARCHAR` | Scan engine to use: `'v1'` (legacy) or `'v2'` (optimized, default).  |
-| `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets). |
-| `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                    |
-| `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                           |
+| Parameter         | Type      | Description                                                                                                        |
+| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------ |
+| `use_legacy_scan` | `BOOLEAN` | Use legacy scan implementation: `true` (legacy) or `false` (optimized, default).                                   |
+| `dry_run`         | `BOOLEAN` | When `true`, validates the query without executing it. Returns metadata: `total_bytes_processed`, `cache_hit`, and `location`. |
+| `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).                                               |
+| `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
+| `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
 
 ### `bigquery_execute` Function
 
@@ -248,6 +268,26 @@ D CALL bigquery_execute('bq', '
 │ true    │ job_-Xu_D2wxe2Xjh-ArZNwZ6gut5ggi │ my_gcp_project  │ US       │          0 │                     0 │ 0                     │
 └─────────┴──────────────────────────────────┴─────────────────┴──────────┴────────────┴───────────────────────┴───────────────────────┘
 ```
+
+Similar to `bigquery_query`, the `dry_run` parameter allows you to validate queries without executing them:
+
+```sql
+D CALL bigquery_execute('my_gcp_project', 'SELECT * FROM `my_gcp_project.quacking_dataset.duck_tbl`', dry_run=true);
+┌───────────────────────┬───────────┬──────────┐
+│ total_bytes_processed │ cache_hit │ location │
+│        int64          │  boolean  │ varchar  │
+├───────────────────────┼───────────┼──────────┤
+│                    54 │ false     │ US       │
+└───────────────────────┴───────────┴──────────┘
+```
+
+The `bigquery_execute` function supports the following named parameters:
+
+| Parameter       | Type      | Description                                                                                                        |
+| --------------- | --------- | ------------------------------------------------------------------------------------------------------------------ |
+| `dry_run`       | `BOOLEAN` | When `true`, validates the query without executing it. Returns metadata: `total_bytes_processed`, `cache_hit`, and `location`. |
+| `api_endpoint`  | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
+| `grpc_endpoint` | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
 
 ### `bigquery_jobs` Function
 
@@ -322,13 +362,13 @@ D ATTACH 'project=my_gcp_project' AS bq (TYPE bigquery);
 
 -- Read GEOGRAPHY columns as native GEOMETRY
 D SELECT name, geography_column FROM bq.dataset.geo_table;
-┌──────────────┬────────────────────────────────────────┐
-│     name     │           geography_column             │
-│   varchar    │               geometry                 │
-├──────────────┼────────────────────────────────────────┤
-│ Location A   │ POINT(-122.4194 37.7749)              │
+┌──────────────┬──────────────────────────────────────────┐
+│     name     │            geography_column              │
+│   varchar    │                geometry                  │
+├──────────────┼──────────────────────────────────────────┤
+│ Location A   │ POINT(-122.4194 37.7749)                 │
 │ Location B   │ POLYGON((-122.5 37.7, -122.3 37.8, ...)) │
-└──────────────┴────────────────────────────────────────┘
+└──────────────┴──────────────────────────────────────────┘
 
 -- Write GEOMETRY data - automatically converted to BigQuery GEOGRAPHY
 D INSERT INTO bq.dataset.geo_table VALUES 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ set(EXTENSION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_attach.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_clear_cache.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_scan.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_query.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_execute.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_extension.cpp

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -668,14 +668,6 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
         throw BinderException("Query execution exceeded the timeout. Job ID: " + job_id);
     }
 
-	std::cout << "Query executed successfully." << std::endl;
-	std::cout << "Total bytes processed: " << response->total_bytes_processed().value() << std::endl;
-	std::cout << "Total bytes billed: " << response->total_bytes_billed() << std::endl;
-	std::cout << "Total rows: " << response->total_rows().value() << std::endl;
-	std::cout << "Cache hit: " << (response->cache_hit().value() ? "true" : "false") << std::endl;
-	// std::cout << "total_partitions_processed: " << response->total_partitions_processed().value() << std::endl
-	std::cout << "DebugString: " << response->DebugString() << std::endl;
-
     return *response;
 }
 

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -39,6 +39,8 @@
 #include "arrow/ipc/writer.h"
 #include "grpcpp/grpcpp.h"
 
+#include <iostream>
+
 
 namespace duckdb {
 namespace bigquery {
@@ -665,6 +667,14 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
         auto job_id = response->job_reference().job_id();
         throw BinderException("Query execution exceeded the timeout. Job ID: " + job_id);
     }
+
+	std::cout << "Query executed successfully." << std::endl;
+	std::cout << "Total bytes processed: " << response->total_bytes_processed().value() << std::endl;
+	std::cout << "Total bytes billed: " << response->total_bytes_billed() << std::endl;
+	std::cout << "Total rows: " << response->total_rows().value() << std::endl;
+	std::cout << "Cache hit: " << (response->cache_hit().value() ? "true" : "false") << std::endl;
+	// std::cout << "total_partitions_processed: " << response->total_partitions_processed().value() << std::endl
+	std::cout << "DebugString: " << response->DebugString() << std::endl;
 
     return *response;
 }

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -21,6 +21,7 @@
 #include "bigquery_settings.hpp"
 #include "bigquery_storage.hpp"
 #include "bigquery_geometry_cast.hpp"
+#include "bigquery_query.hpp"
 
 #include <iostream>
 

--- a/src/bigquery_query.cpp
+++ b/src/bigquery_query.cpp
@@ -1,0 +1,434 @@
+#include "bigquery_query.hpp"
+#include "bigquery_arrow_scan.hpp"
+#include "bigquery_client.hpp"
+#include "bigquery_scan.hpp"
+#include "bigquery_settings.hpp"
+#include "bigquery_utils.hpp"
+#include "storage/bigquery_catalog.hpp"
+#include "storage/bigquery_transaction.hpp"
+
+#include "duckdb.hpp"
+#include "duckdb/function/table/arrow.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/database_manager.hpp"
+
+#include <arrow/c/bridge.h>
+
+namespace duckdb {
+namespace bigquery {
+
+static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
+                                                  TableFunctionBindInput &input,
+                                                  vector<LogicalType> &return_types,
+                                                  vector<string> &names) {
+    auto dbname_or_project_id = input.inputs[0].GetValue<string>();
+    auto query_string = input.inputs[1].GetValue<string>();
+
+    auto &database_manager = DatabaseManager::Get(context);
+    auto database = database_manager.GetDatabase(context, dbname_or_project_id);
+
+    auto params = BigQueryCommonParameters::ParseFromNamedParameters(input.named_parameters);
+
+    // Handle dry_run case separately
+    if (params.dry_run) {
+        return_types.emplace_back(LogicalTypeId::BIGINT);
+        names.emplace_back("total_bytes_processed");
+        return_types.emplace_back(LogicalTypeId::BOOLEAN);
+        names.emplace_back("cache_hit");
+        return_types.emplace_back(LogicalTypeId::VARCHAR);
+        names.emplace_back("location");
+
+        auto result = make_uniq<BigqueryQueryDryRunBindData>();
+        result->query = query_string;
+
+        if (database) {
+            auto &catalog = database->GetCatalog();
+            if (catalog.GetCatalogType() != "bigquery") {
+                throw BinderException("Database " + dbname_or_project_id + " is not a BigQuery database");
+            }
+            if (!params.api_endpoint.empty() || !params.grpc_endpoint.empty()) {
+                throw BinderException("Named parameters are not supported for attached databases");
+            }
+
+            auto &bigquery_catalog = catalog.Cast<BigqueryCatalog>();
+            auto &transaction = BigqueryTransaction::Get(context, bigquery_catalog);
+
+            result->config = bigquery_catalog.config;
+            result->bq_client = transaction.GetBigqueryClient();
+        } else {
+            auto bq_config = BigqueryConfig(dbname_or_project_id)
+                                 .SetApiEndpoint(params.api_endpoint)
+                                 .SetGrpcEndpoint(params.grpc_endpoint);
+            auto bq_client = make_shared_ptr<BigqueryClient>(bq_config);
+
+            result->config = bq_config;
+            result->bq_client = bq_client;
+        }
+        return result;
+    }
+
+    if (!params.use_legacy_scan) {
+        auto bind_data = make_uniq<BigqueryArrowScanBindData>();
+        bind_data->query = query_string;
+        bind_data->estimated_row_count = 1;
+
+        if (database) {
+            auto &catalog = database->GetCatalog();
+            if (catalog.GetCatalogType() != "bigquery") {
+                throw BinderException("Database " + dbname_or_project_id + " is not a BigQuery database");
+            }
+            if (!params.billing_project.empty() || !params.api_endpoint.empty() || !params.grpc_endpoint.empty()) {
+                throw BinderException("Named parameters are not supported for attached databases");
+            }
+
+            auto &bigquery_catalog = catalog.Cast<BigqueryCatalog>();
+            auto &transaction = BigqueryTransaction::Get(context, bigquery_catalog);
+
+            bind_data->bq_config = bigquery_catalog.config;
+            bind_data->bq_client = transaction.GetBigqueryClient();
+        } else {
+            auto bq_config = BigqueryConfig(dbname_or_project_id)
+                                 .SetBillingProjectId(params.billing_project)
+                                 .SetApiEndpoint(params.api_endpoint)
+                                 .SetGrpcEndpoint(params.grpc_endpoint);
+            auto bq_client = make_shared_ptr<BigqueryClient>(bq_config);
+
+            bind_data->bq_config = bq_config;
+            bind_data->bq_client = bq_client;
+        }
+
+        ColumnList columns;
+        vector<unique_ptr<Constraint>> constraints;
+        bind_data->bq_client->GetTableInfoForQuery(query_string, columns, constraints);
+
+        auto arrow_schema_ptr = BigqueryUtils::BuildArrowSchema(columns);
+        auto status = arrow::ExportSchema(*std::move(arrow_schema_ptr), &bind_data->schema_root.arrow_schema);
+        if (!status.ok()) {
+            throw BinderException("Arrow schema export failed: " + status.ToString());
+        }
+
+        // Populate names/types using updated DuckDB Arrow API
+        ArrowTableFunction::PopulateArrowTableSchema(DBConfig::GetConfig(context),
+                                                     bind_data->arrow_table,
+                                                     bind_data->schema_root.arrow_schema);
+        names = bind_data->arrow_table.GetNames();
+        return_types = bind_data->arrow_table.GetTypes();
+
+        if (return_types.empty()) {
+            throw BinderException("BigQuery query has no columns: " + query_string);
+        }
+
+        bind_data->names = names;
+        bind_data->all_types = return_types;
+
+        // Check if we need type mapping for enhanced BigQuery types (including WKT to GEOMETRY conversion)
+        bool requires_cast = false;
+        vector<LogicalType> mapped_bq_types;
+        for (idx_t i = 0; i < return_types.size(); i++) {
+            auto bq_type = BigqueryUtils::CastToBigqueryTypeWithSpatialConversion(return_types[i], &context);
+            if (bq_type != return_types[i]) {
+                requires_cast = true;
+            }
+            mapped_bq_types.push_back(bq_type);
+        }
+
+        if (requires_cast) {
+            bind_data->mapped_bq_types = std::move(mapped_bq_types);
+        }
+        bind_data->requires_cast = requires_cast;
+
+        return std::move(bind_data);
+    } else {
+        // Legacy implementation (V1)
+        auto bind_data = make_uniq<BigqueryLegacyScanBindData>();
+        bind_data->query = query_string;
+        bind_data->estimated_row_count = 1;
+
+        if (database) {
+            auto &catalog = database->GetCatalog();
+            if (catalog.GetCatalogType() != "bigquery") {
+                throw BinderException("Database " + dbname_or_project_id + " is not a BigQuery database");
+            }
+            if (!params.billing_project.empty() || !params.api_endpoint.empty() || !params.grpc_endpoint.empty()) {
+                throw BinderException("Named parameters are not supported for attached databases");
+            }
+
+            auto &bigquery_catalog = catalog.Cast<BigqueryCatalog>();
+            auto &transaction = BigqueryTransaction::Get(context, bigquery_catalog);
+
+            bind_data->config = bigquery_catalog.config;
+            bind_data->bq_client = transaction.GetBigqueryClient();
+        } else {
+            // Use the provided project_id of the gcp project
+            auto bq_config = BigqueryConfig(dbname_or_project_id)
+                                 .SetBillingProjectId(params.billing_project)
+                                 .SetApiEndpoint(params.api_endpoint)
+                                 .SetGrpcEndpoint(params.grpc_endpoint);
+            auto bq_client = make_shared_ptr<BigqueryClient>(bq_config);
+
+            bind_data->config = bq_config;
+            bind_data->bq_client = bq_client;
+        }
+
+        ColumnList columns;
+        vector<unique_ptr<Constraint>> constraints;
+        bind_data->bq_client->GetTableInfoForQuery(query_string, columns, constraints);
+
+        for (auto &column : columns.Logical()) {
+            names.push_back(column.GetName());
+            return_types.push_back(column.GetType());
+        }
+        if (names.empty()) {
+            throw std::runtime_error("no columns for query: " + query_string);
+        }
+
+        if (BigquerySettings::GeographyAsGeometry()) {
+            for (const auto &column : columns.Logical()) {
+                if (BigqueryUtils::IsGeographyType(column.GetType())) {
+                    throw BinderException(
+                        "BigQuery GEOGRAPHY columns with geography_as_geometry=true are not supported in legacy scan. "
+                        "Please either set use_legacy_scan=false (recommended) or set bq_geography_as_geometry=false.");
+                }
+            }
+        }
+
+        bind_data->names = names;
+        bind_data->types = return_types;
+        return std::move(bind_data);
+    }
+}
+
+static unique_ptr<GlobalTableFunctionState> BigqueryQueryInitGlobal(ClientContext &context,
+                                                                    TableFunctionInitInput &input) {
+    // Dry run
+    if (dynamic_cast<const BigqueryQueryDryRunBindData *>(input.bind_data.get())) {
+        return make_uniq<GlobalTableFunctionState>();
+    }
+	// New Scan
+    if (dynamic_cast<const BigqueryArrowScanBindData *>(input.bind_data.get())) {
+        // Arrow scan implementation
+        auto &mutable_bind_data = input.bind_data->CastNoConst<BigqueryArrowScanBindData>();
+
+        // Execute the query and get destination table
+        auto query_response = mutable_bind_data.bq_client->ExecuteQuery(mutable_bind_data.query);
+        auto job = mutable_bind_data.bq_client->GetJobByReference(query_response.job_reference());
+
+        if (job.status().has_error_result()) {
+            throw BinderException(job.status().error_result().message());
+        }
+
+        auto destination_table = job.configuration().query().destination_table();
+        auto table_ref = BigqueryTableRef(destination_table.project_id(),
+                                          destination_table.dataset_id(),
+                                          destination_table.table_id());
+        mutable_bind_data.table_ref = table_ref;
+        return BigqueryArrowScanFunction::BigqueryArrowScanInitGlobal(context, input);
+    } else {
+        // Legacy scan implementation
+        auto &bind_data = input.bind_data->CastNoConst<BigqueryLegacyScanBindData>();
+
+        // Execute the query and get destination table
+        auto query_response = bind_data.bq_client->ExecuteQuery(bind_data.query);
+        auto job = bind_data.bq_client->GetJobByReference(query_response.job_reference());
+
+        if (job.status().has_error_result()) {
+            throw BinderException(job.status().error_result().message());
+        }
+
+        auto destination_table = job.configuration().query().destination_table();
+        auto table_ref = BigqueryTableRef(destination_table.project_id(),
+                                          destination_table.dataset_id(),
+                                          destination_table.table_id());
+        bind_data.table_ref = table_ref;
+        return BigqueryLegacyScanFunction::BigqueryLegacyScanInitGlobalState(context, input);
+    }
+}
+
+static unique_ptr<LocalTableFunctionState> BigqueryQueryInitLocal(ExecutionContext &context,
+                                                                  TableFunctionInitInput &input,
+                                                                  GlobalTableFunctionState *global_state) {
+    // Dry run
+    if (dynamic_cast<const BigqueryQueryDryRunBindData *>(input.bind_data.get())) {
+        return make_uniq<LocalTableFunctionState>();
+    }
+    // New Scan
+    if (dynamic_cast<const BigqueryArrowScanBindData *>(input.bind_data.get())) {
+        return BigqueryArrowScanFunction::BigqueryArrowScanInitLocal(context, input, global_state);
+    }
+    // Legacy scan
+    return BigqueryLegacyScanFunction::BigqueryLegacyScanInitLocalState(context, input, global_state);
+}
+
+static void BigqueryQueryExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+    D_ASSERT(data.bind_data);
+    const auto *base = data.bind_data.get();
+
+	// Dry run
+    if (dynamic_cast<const BigqueryQueryDryRunBindData *>(base)) {
+        auto &bind_data = base->CastNoConst<BigqueryQueryDryRunBindData>();
+        if (bind_data.finished) {
+            return;
+        }
+
+        auto response = bind_data.bq_client->ExecuteQuery(bind_data.query, "", true);
+        bind_data.finished = true;
+
+        output.SetValue(0, 0, Value::BIGINT(response.total_bytes_processed().value()));
+        output.SetValue(1, 0, Value::BOOLEAN(response.cache_hit().value()));
+        output.SetValue(2, 0, response.job_reference().location().value());
+        output.SetCardinality(1);
+        return;
+    }
+
+    // New Scan
+    if (dynamic_cast<const BigqueryArrowScanBindData *>(data.bind_data.get())) {
+        BigqueryArrowScanFunction::BigqueryArrowScanExecute(context, data, output);
+        return;
+    }
+
+    // Legacy scan
+    BigqueryLegacyScanFunction::BigqueryLegacyScanExecute(context, data, output);
+}
+
+static BindInfo BigqueryQueryGetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
+    D_ASSERT(bind_data_p);
+    const auto *base = bind_data_p.get();
+    BindInfo info(ScanType::EXTERNAL);
+
+    // Dry Run
+    if (dynamic_cast<const BigqueryQueryDryRunBindData *>(base)) {
+        return info;
+    }
+
+    // New Scan
+    if (const auto *arrow = dynamic_cast<const BigqueryArrowScanBindData *>(base)) {
+        if (arrow->bq_table_entry) {
+            info.table = arrow->bq_table_entry.get_mutable();
+        }
+        return info;
+    }
+
+    // Legacy scan
+    const auto &legacy = base->Cast<BigqueryLegacyScanBindData>();
+    if (legacy.bq_table_entry) {
+        info.table = legacy.bq_table_entry.get_mutable();
+    }
+    return info;
+}
+
+static InsertionOrderPreservingMap<string> BigqueryQueryToString(TableFunctionToStringInput &input) {
+    D_ASSERT(input.bind_data);
+
+    InsertionOrderPreservingMap<string> result;
+    const auto *base = input.bind_data.get();
+
+    // Dry Run
+    if (const auto *dry_run_bind_data = dynamic_cast<const BigqueryQueryDryRunBindData *>(base)) {
+        result["Query"] = dry_run_bind_data->query;
+        result["Type"] = "Dry Run";
+        return result;
+    }
+
+    // New Scan
+    if (const auto *arrow_bind_data = dynamic_cast<const BigqueryArrowScanBindData *>(input.bind_data.get())) {
+        result["Query"] = arrow_bind_data->query;
+        result["Table"] = arrow_bind_data->TableString();
+        return result;
+    }
+
+    // Legacy scan
+    const auto &bind_data = input.bind_data->Cast<BigqueryLegacyScanBindData>();
+    result["Query"] = bind_data.query;
+    result["Table"] = bind_data.TableString();
+    return result;
+}
+
+static unique_ptr<NodeStatistics> BigqueryQueryCardinality(ClientContext &context, const FunctionData *bind_data_p) {
+    D_ASSERT(bind_data_p);
+    const auto *base = bind_data_p;
+
+    // Dry run
+    if (dynamic_cast<const BigqueryQueryDryRunBindData *>(base)) {
+        return make_uniq<NodeStatistics>(1, 1);
+    }
+
+    // New Scan
+    if (const auto *arrow = dynamic_cast<const BigqueryArrowScanBindData *>(base)) {
+        const idx_t n = arrow->estimated_row_count;
+        return make_uniq<NodeStatistics>(n, n);
+    }
+
+    // Legacy scan
+    const auto &legacy = base->Cast<BigqueryLegacyScanBindData>();
+    const idx_t n = legacy.estimated_row_count;
+    return make_uniq<NodeStatistics>(n, n);
+}
+
+static double BigqueryQueryProgress(ClientContext &context,
+                                    const FunctionData *bind_data_p,
+                                    const GlobalTableFunctionState *global_state) {
+    D_ASSERT(bind_data_p);
+    D_ASSERT(global_state);
+
+    // Dry run
+    if (dynamic_cast<const BigqueryQueryDryRunBindData *>(bind_data_p)) {
+        return 100.0;
+    }
+
+    const auto *b = bind_data_p;
+    const auto *gs = global_state;
+
+    idx_t estimated = 0;
+    idx_t position = 0;
+
+    // New Scan
+    if (const auto *arrow = dynamic_cast<const BigqueryArrowScanBindData *>(b)) {
+        auto &gstate = gs->Cast<BigqueryArrowScanGlobalState>();
+        estimated = arrow->estimated_row_count;
+        if (estimated > 0) {
+            lock_guard<mutex> glock(gstate.lock);
+            position = gstate.position;
+        }
+    } else {
+        // Legacy scan
+        const auto &bind = b->Cast<BigqueryLegacyScanBindData>();
+        auto &gstate = gs->Cast<BigqueryGlobalFunctionState>();
+        estimated = bind.estimated_row_count;
+        if (estimated > 0) {
+            lock_guard<mutex> glock(gstate.lock);
+            position = gstate.position;
+        }
+    }
+
+    double progress = 0.0;
+    if (estimated > 0) {
+        progress = 100.0 * static_cast<double>(position) / static_cast<double>(estimated);
+    }
+    return MinValue<double>(100.0, progress);
+}
+
+BigqueryQueryFunction::BigqueryQueryFunction()
+    : TableFunction("bigquery_query",
+                    {LogicalType::VARCHAR, LogicalType::VARCHAR},
+                    BigqueryQueryExecute,
+                    BigqueryQueryBind,
+                    BigqueryQueryInitGlobal,
+                    BigqueryQueryInitLocal) {
+    to_string = BigqueryQueryToString;
+    cardinality = BigqueryQueryCardinality;
+    table_scan_progress = BigqueryQueryProgress;
+    get_bind_info = BigqueryQueryGetBindInfo;
+
+    projection_pushdown = true;
+    filter_pushdown = true;
+    filter_prune = true;
+
+    named_parameters["billing_project"] = LogicalType::VARCHAR;
+    named_parameters["api_endpoint"] = LogicalType::VARCHAR;
+    named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
+    named_parameters["use_legacy_scan"] = LogicalType::BOOLEAN;
+    named_parameters["dry_run"] = LogicalType::BOOLEAN;
+}
+
+} // namespace bigquery
+} // namespace duckdb

--- a/src/bigquery_scan.cpp
+++ b/src/bigquery_scan.cpp
@@ -29,60 +29,6 @@
 namespace duckdb {
 namespace bigquery {
 
-bool DetermineLegacyScan(ClientContext &context, const TableFunctionBindInput &input) {
-    // Check for explicit use_legacy_scan parameter
-    for (auto &kv : input.named_parameters) {
-        auto lower_key = StringUtil::Lower(kv.first);
-        if (lower_key == "use_legacy_scan") {
-            return BooleanValue::Get(kv.second);
-        }
-    }
-
-    // Fall back to global setting
-    return BigquerySettings::UseLegacyScan();
-}
-
-static void SetFromNamedParameters(const TableFunctionBindInput &input,
-                                   string &billing_project_id,
-                                   string &api_endpoint,
-                                   string &grpc_endpoint,
-                                   string &filter_condition) {
-    for (auto &kv : input.named_parameters) {
-        auto lower_option = StringUtil::Lower(kv.first);
-        if (lower_option == "billing_project") {
-            billing_project_id = kv.second.GetValue<string>();
-        } else if (lower_option == "api_endpoint") {
-            api_endpoint = kv.second.GetValue<string>();
-        } else if (lower_option == "grpc_endpoint") {
-            grpc_endpoint = kv.second.GetValue<string>();
-        } else if (lower_option == "filter") {
-            filter_condition = kv.second.GetValue<string>();
-        }
-    }
-}
-
-struct BigqueryGlobalFunctionState : public GlobalTableFunctionState {
-    explicit BigqueryGlobalFunctionState(shared_ptr<BigqueryArrowReader> arrow_reader, idx_t max_threads)
-        : position(0), max_threads(max_threads), arrow_reader(std::move(arrow_reader)) {
-    }
-
-    mutable mutex lock;
-    atomic<idx_t> position;
-    idx_t max_threads;
-
-    // The index of the next stream to read (i.e., current file + 1)
-    atomic<idx_t> next_stream = 0;
-    shared_ptr<BigqueryArrowReader> arrow_reader;
-
-    idx_t MaxThreads() const override {
-        return max_threads;
-    }
-
-    idx_t NextStreamIndex() {
-        return next_stream.fetch_add(1);
-    }
-};
-
 
 struct BigqueryLocalFunctionState : public LocalTableFunctionState {
     BigqueryLocalFunctionState() : row_offset(0), done(false) {
@@ -167,35 +113,35 @@ private:
     }
 };
 
-static unique_ptr<FunctionData> BigqueryLegacyScanBind(ClientContext &context,
-                                                       TableFunctionBindInput &input,
-                                                       vector<LogicalType> &return_types,
-                                                       vector<string> &names) {
+unique_ptr<FunctionData> BigqueryLegacyScanFunction::BigqueryLegacyScanBind(ClientContext &context,
+                                                                            TableFunctionBindInput &input,
+                                                                            vector<LogicalType> &return_types,
+                                                                            vector<string> &names) {
     auto table_string = input.inputs[0].GetValue<string>();
     auto table_ref = BigqueryUtils::ParseTableString(table_string);
     if (!table_ref.has_dataset_id() || !table_ref.has_table_id()) {
         throw ParserException("Invalid table string: %s", table_string);
     }
 
-    string billing_project_id, api_endpoint, grpc_endpoint, filter_condition;
-    SetFromNamedParameters(input, billing_project_id, api_endpoint, grpc_endpoint, filter_condition);
+    // Parse named parameters using centralized function
+    auto params = BigQueryCommonParameters::ParseFromNamedParameters(input.named_parameters);
 
     auto result = make_uniq<BigqueryLegacyScanBindData>();
     result->table_ref = table_ref;
-    result->filter_condition = filter_condition;
+    result->filter_condition = params.filter;
     result->config = BigqueryConfig(table_ref.project_id)
                          .SetDatasetId(table_ref.dataset_id)
-                         .SetBillingProjectId(billing_project_id)
-                         .SetApiEndpoint(api_endpoint)
-                         .SetGrpcEndpoint(grpc_endpoint);
+                         .SetBillingProjectId(params.billing_project)
+                         .SetApiEndpoint(params.api_endpoint)
+                         .SetGrpcEndpoint(params.grpc_endpoint);
     result->bq_client = make_shared_ptr<BigqueryClient>(result->config);
 
     ColumnList columns;
     vector<unique_ptr<Constraint>> constraints;
 
     string filter_cond = "";
-    if (!filter_condition.empty()) {
-        filter_cond = filter_condition;
+    if (!params.filter.empty()) {
+        filter_cond = params.filter;
     }
 
     auto arrow_reader = result->bq_client->CreateArrowReader(table_ref, 1, std::vector<string>(), filter_cond);
@@ -227,21 +173,23 @@ static unique_ptr<FunctionData> BigqueryLegacyScanBind(ClientContext &context,
     return std::move(result);
 }
 
-static unique_ptr<FunctionData> BigqueryScanBind(ClientContext &context,
-                                                 TableFunctionBindInput &input,
-                                                 vector<LogicalType> &return_types,
-                                                 vector<string> &names) {
-    bool use_legacy = DetermineLegacyScan(context, input);
+unique_ptr<FunctionData> BigqueryScanFunction::BigqueryScanBind(ClientContext &context,
+                                                                TableFunctionBindInput &input,
+                                                                vector<LogicalType> &return_types,
+                                                                vector<string> &names) {
+    // Parse named parameters to check use_legacy_scan
+    auto params = BigQueryCommonParameters::ParseFromNamedParameters(input.named_parameters);
 
-    if (use_legacy) {
-        return BigqueryLegacyScanBind(context, input, return_types, names);
+    if (params.use_legacy_scan) {
+        return BigqueryLegacyScanFunction::BigqueryLegacyScanBind(context, input, return_types, names);
     } else {
         return BigqueryArrowScanFunction::BigqueryArrowScanBind(context, input, return_types, names);
     }
 }
 
-static unique_ptr<GlobalTableFunctionState> BigqueryLegacyScanInitGlobalState(ClientContext &context,
-                                                                              TableFunctionInitInput &input) {
+unique_ptr<GlobalTableFunctionState> BigqueryLegacyScanFunction::BigqueryLegacyScanInitGlobalState(
+    ClientContext &context,
+    TableFunctionInitInput &input) {
     auto &bind_data = input.bind_data->Cast<BigqueryLegacyScanBindData>();
 
     // selected fields
@@ -285,9 +233,10 @@ static unique_ptr<GlobalTableFunctionState> BigqueryLegacyScanInitGlobalState(Cl
     return std::move(result);
 }
 
-static unique_ptr<LocalTableFunctionState> BigqueryLegacyScanInitLocalState(ExecutionContext &context,
-                                                                            TableFunctionInitInput &input,
-                                                                            GlobalTableFunctionState *global_state) {
+unique_ptr<LocalTableFunctionState> BigqueryLegacyScanFunction::BigqueryLegacyScanInitLocalState(
+    ExecutionContext &context,
+    TableFunctionInitInput &input,
+    GlobalTableFunctionState *global_state) {
     auto &gstate = global_state->Cast<BigqueryGlobalFunctionState>();
     auto lstate = make_uniq<BigqueryLocalFunctionState>();
     lstate->arrow_reader = gstate.arrow_reader;
@@ -303,7 +252,9 @@ static unique_ptr<LocalTableFunctionState> BigqueryLegacyScanInitLocalState(Exec
     return std::move(lstate);
 }
 
-static void BigqueryLegacyScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+void BigqueryLegacyScanFunction::BigqueryLegacyScanExecute(ClientContext &context,
+                                                           TableFunctionInput &data,
+                                                           DataChunk &output) {
     auto &lstate = data.local_state->Cast<BigqueryLocalFunctionState>();
     auto &gstate = data.global_state->Cast<BigqueryGlobalFunctionState>();
     if (lstate.done) {
@@ -315,33 +266,34 @@ static void BigqueryLegacyScanExecute(ClientContext &context, TableFunctionInput
     gstate.position += output.size();
 }
 
-static unique_ptr<GlobalTableFunctionState> BigqueryScanInitGlobalState(ClientContext &context,
-                                                                        TableFunctionInitInput &input) {
+unique_ptr<GlobalTableFunctionState> BigqueryScanFunction::BigqueryScanInitGlobalState(ClientContext &context,
+                                                                                       TableFunctionInitInput &input) {
     // Check bind data type and forward to appropriate implementation
     if (dynamic_cast<const BigqueryArrowScanBindData *>(input.bind_data.get())) {
         return BigqueryArrowScanFunction::BigqueryArrowScanInitGlobal(context, input);
     } else {
-        return BigqueryLegacyScanInitGlobalState(context, input);
+        return BigqueryLegacyScanFunction::BigqueryLegacyScanInitGlobalState(context, input);
     }
 }
 
-static unique_ptr<LocalTableFunctionState> BigqueryScanInitLocalState(ExecutionContext &context,
-                                                                      TableFunctionInitInput &input,
-                                                                      GlobalTableFunctionState *global_state) {
+unique_ptr<LocalTableFunctionState> BigqueryScanFunction::BigqueryScanInitLocalState(
+    ExecutionContext &context,
+    TableFunctionInitInput &input,
+    GlobalTableFunctionState *global_state) {
     // Check bind data type and forward to appropriate implementation
     if (dynamic_cast<const BigqueryArrowScanBindData *>(input.bind_data.get())) {
         return BigqueryArrowScanFunction::BigqueryArrowScanInitLocal(context, input, global_state);
     } else {
-        return BigqueryLegacyScanInitLocalState(context, input, global_state);
+        return BigqueryLegacyScanFunction::BigqueryLegacyScanInitLocalState(context, input, global_state);
     }
 }
 
-static void BigqueryScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
+void BigqueryScanFunction::BigqueryScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
     // Check bind data type and forward to appropriate implementation
     if (dynamic_cast<const BigqueryArrowScanBindData *>(data.bind_data.get())) {
         BigqueryArrowScanFunction::BigqueryArrowScanExecute(context, data, output);
     } else {
-        BigqueryLegacyScanExecute(context, data, output);
+        BigqueryLegacyScanFunction::BigqueryLegacyScanExecute(context, data, output);
     }
 }
 
@@ -411,14 +363,13 @@ static BindInfo BigqueryScanGetBindInfo(const optional_ptr<FunctionData> bind_da
     }
 }
 
-
 BigqueryScanFunction::BigqueryScanFunction()
     : TableFunction("bigquery_scan",
                     {LogicalType::VARCHAR},
-                    BigqueryScanExecute,
-                    BigqueryScanBind,
-                    BigqueryScanInitGlobalState,
-                    BigqueryScanInitLocalState) {
+                    BigqueryScanFunction::BigqueryScanExecute,
+                    BigqueryScanFunction::BigqueryScanBind,
+                    BigqueryScanFunction::BigqueryScanInitGlobalState,
+                    BigqueryScanFunction::BigqueryScanInitLocalState) {
     to_string = BigqueryScanToString;
     cardinality = BigqueryScanCardinality;
     table_scan_progress = BigqueryScanProgress;
@@ -431,303 +382,6 @@ BigqueryScanFunction::BigqueryScanFunction()
     named_parameters["api_endpoint"] = LogicalType::VARCHAR;
     named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
     named_parameters["filter"] = LogicalType::VARCHAR;
-    named_parameters["use_legacy_scan"] = LogicalType::BOOLEAN;
-}
-
-static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
-                                                  TableFunctionBindInput &input,
-                                                  vector<LogicalType> &return_types,
-                                                  vector<string> &names) {
-    auto dbname_or_project_id = input.inputs[0].GetValue<string>();
-    auto query_string = input.inputs[1].GetValue<string>();
-
-    bool use_legacy = DetermineLegacyScan(context, input);
-
-    string billing_project_id, api_endpoint, grpc_endpoint, filter_condition;
-    SetFromNamedParameters(input, billing_project_id, api_endpoint, grpc_endpoint, filter_condition);
-
-    if (!use_legacy) {
-        auto bind_data = make_uniq<BigqueryArrowScanBindData>();
-        bind_data->query = query_string;
-        bind_data->estimated_row_count = 1;
-
-        auto &database_manager = DatabaseManager::Get(context);
-        auto database = database_manager.GetDatabase(context, dbname_or_project_id);
-        if (database) {
-            auto &catalog = database->GetCatalog();
-            if (catalog.GetCatalogType() != "bigquery") {
-                throw BinderException("Database " + dbname_or_project_id + " is not a BigQuery database");
-            }
-            if (!billing_project_id.empty() || !api_endpoint.empty() || !grpc_endpoint.empty()) {
-                throw BinderException("Named parameters are not supported for attached databases");
-            }
-
-            auto &bigquery_catalog = catalog.Cast<BigqueryCatalog>();
-            auto &transaction = BigqueryTransaction::Get(context, bigquery_catalog);
-
-            bind_data->bq_config = bigquery_catalog.config;
-            bind_data->bq_client = transaction.GetBigqueryClient();
-        } else {
-            auto bq_config = BigqueryConfig(dbname_or_project_id)
-                                 .SetBillingProjectId(billing_project_id)
-                                 .SetApiEndpoint(api_endpoint)
-                                 .SetGrpcEndpoint(grpc_endpoint);
-            auto bq_client = make_shared_ptr<BigqueryClient>(bq_config);
-
-            bind_data->bq_config = bq_config;
-            bind_data->bq_client = bq_client;
-        }
-
-        ColumnList columns;
-        vector<unique_ptr<Constraint>> constraints;
-        bind_data->bq_client->GetTableInfoForQuery(query_string, columns, constraints);
-
-        auto arrow_schema_ptr = BigqueryUtils::BuildArrowSchema(columns);
-        auto status = arrow::ExportSchema(*std::move(arrow_schema_ptr), &bind_data->schema_root.arrow_schema);
-        if (!status.ok()) {
-            throw BinderException("Arrow schema export failed: " + status.ToString());
-        }
-
-        // Populate names/types using updated DuckDB Arrow API
-        ArrowTableFunction::PopulateArrowTableSchema(DBConfig::GetConfig(context),
-                                                     bind_data->arrow_table,
-                                                     bind_data->schema_root.arrow_schema);
-        names = bind_data->arrow_table.GetNames();
-        return_types = bind_data->arrow_table.GetTypes();
-
-        if (return_types.empty()) {
-            throw BinderException("BigQuery query has no columns: " + query_string);
-        }
-
-        bind_data->names = names;
-        bind_data->all_types = return_types;
-
-        // Check if we need type mapping for enhanced BigQuery types (including WKT to GEOMETRY conversion)
-        bool requires_cast = false;
-        vector<LogicalType> mapped_bq_types;
-        for (idx_t i = 0; i < return_types.size(); i++) {
-            auto bq_type = BigqueryUtils::CastToBigqueryTypeWithSpatialConversion(return_types[i], &context);
-            if (bq_type != return_types[i]) {
-                requires_cast = true;
-            }
-            mapped_bq_types.push_back(bq_type);
-        }
-
-        if (requires_cast) {
-            bind_data->mapped_bq_types = std::move(mapped_bq_types);
-        }
-        bind_data->requires_cast = requires_cast;
-
-        return std::move(bind_data);
-    } else {
-        // Legacy implementation (V1)
-        auto bind_data = make_uniq<BigqueryLegacyScanBindData>();
-        bind_data->query = query_string;
-        bind_data->estimated_row_count = 1;
-
-        auto &database_manager = DatabaseManager::Get(context);
-        auto database = database_manager.GetDatabase(context, dbname_or_project_id);
-        if (database) {
-            auto &catalog = database->GetCatalog();
-            if (catalog.GetCatalogType() != "bigquery") {
-                throw BinderException("Database " + dbname_or_project_id + " is not a BigQuery database");
-            }
-            if (!billing_project_id.empty() || !api_endpoint.empty() || !grpc_endpoint.empty()) {
-                throw BinderException("Named parameters are not supported for attached databases");
-            }
-
-            auto &bigquery_catalog = catalog.Cast<BigqueryCatalog>();
-            auto &transaction = BigqueryTransaction::Get(context, bigquery_catalog);
-
-            bind_data->config = bigquery_catalog.config;
-            bind_data->bq_client = transaction.GetBigqueryClient();
-        } else {
-            // Use the provided project_id of the gcp project
-            auto bq_config = BigqueryConfig(dbname_or_project_id)
-                                 .SetBillingProjectId(billing_project_id)
-                                 .SetApiEndpoint(api_endpoint)
-                                 .SetGrpcEndpoint(grpc_endpoint);
-            auto bq_client = make_shared_ptr<BigqueryClient>(bq_config);
-
-            bind_data->config = bq_config;
-            bind_data->bq_client = bq_client;
-        }
-
-        ColumnList columns;
-        vector<unique_ptr<Constraint>> constraints;
-        bind_data->bq_client->GetTableInfoForQuery(query_string, columns, constraints);
-
-        for (auto &column : columns.Logical()) {
-            names.push_back(column.GetName());
-            return_types.push_back(column.GetType());
-        }
-        if (names.empty()) {
-            throw std::runtime_error("no columns for query: " + query_string);
-        }
-
-        if (BigquerySettings::GeographyAsGeometry()) {
-            for (const auto &column : columns.Logical()) {
-                if (BigqueryUtils::IsGeographyType(column.GetType())) {
-                    throw BinderException(
-                        "BigQuery GEOGRAPHY columns with geography_as_geometry=true are not supported in legacy scan. "
-                        "Please either set use_legacy_scan=false (recommended) or set bq_geography_as_geometry=false.");
-                }
-            }
-        }
-
-        bind_data->names = names;
-        bind_data->types = return_types;
-        return std::move(bind_data);
-    }
-}
-
-static unique_ptr<GlobalTableFunctionState> BigqueryQueryInitGlobal(ClientContext &context,
-                                                                    TableFunctionInitInput &input) {
-    // Execute query first - this is common for both implementations
-    if (dynamic_cast<const BigqueryArrowScanBindData *>(input.bind_data.get())) {
-        // Arrow scan implementation
-        auto &mutable_bind_data = input.bind_data->CastNoConst<BigqueryArrowScanBindData>();
-
-        // Execute the query and get destination table
-        auto query_response = mutable_bind_data.bq_client->ExecuteQuery(mutable_bind_data.query);
-        auto job = mutable_bind_data.bq_client->GetJobByReference(query_response.job_reference());
-
-        if (job.status().has_error_result()) {
-            throw BinderException(job.status().error_result().message());
-        }
-
-        auto destination_table = job.configuration().query().destination_table();
-        auto table_ref = BigqueryTableRef(destination_table.project_id(),
-                                          destination_table.dataset_id(),
-                                          destination_table.table_id());
-        mutable_bind_data.table_ref = table_ref;
-        return BigqueryArrowScanFunction::BigqueryArrowScanInitGlobal(context, input);
-    } else {
-        // Legacy scan implementation
-        auto &bind_data = input.bind_data->CastNoConst<BigqueryLegacyScanBindData>();
-
-        // Execute the query and get destination table
-        auto query_response = bind_data.bq_client->ExecuteQuery(bind_data.query);
-        auto job = bind_data.bq_client->GetJobByReference(query_response.job_reference());
-
-        if (job.status().has_error_result()) {
-            throw BinderException(job.status().error_result().message());
-        }
-
-        auto destination_table = job.configuration().query().destination_table();
-        auto table_ref = BigqueryTableRef(destination_table.project_id(),
-                                          destination_table.dataset_id(),
-                                          destination_table.table_id());
-        bind_data.table_ref = table_ref;
-        return BigqueryLegacyScanInitGlobalState(context, input);
-    }
-}
-
-static unique_ptr<LocalTableFunctionState> BigqueryQueryInitLocal(ExecutionContext &context,
-                                                                  TableFunctionInitInput &input,
-                                                                  GlobalTableFunctionState *global_state) {
-    if (dynamic_cast<const BigqueryArrowScanBindData *>(input.bind_data.get())) {
-        return BigqueryArrowScanFunction::BigqueryArrowScanInitLocal(context, input, global_state);
-    } else {
-        return BigqueryLegacyScanInitLocalState(context, input, global_state);
-    }
-}
-
-static void BigqueryQueryExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {
-    if (dynamic_cast<const BigqueryArrowScanBindData *>(data.bind_data.get())) {
-        BigqueryArrowScanFunction::BigqueryArrowScanExecute(context, data, output);
-    } else {
-        BigqueryLegacyScanExecute(context, data, output);
-    }
-}
-
-static BindInfo BigqueryQueryGetBindInfo(const optional_ptr<FunctionData> bind_data_p) {
-    // Try to cast to BigqueryArrowScanBindData first (experimental scan)
-    if (auto arrow_bind_data = dynamic_cast<const BigqueryArrowScanBindData *>(bind_data_p.get())) {
-        BindInfo info(ScanType::EXTERNAL);
-        if (arrow_bind_data->bq_table_entry) {
-            info.table = arrow_bind_data->bq_table_entry.get_mutable();
-        }
-        return info;
-    } else {
-        auto &bind_data = bind_data_p->Cast<BigqueryLegacyScanBindData>();
-        BindInfo info(ScanType::EXTERNAL);
-        if (bind_data.bq_table_entry) {
-            info.table = bind_data.bq_table_entry.get_mutable();
-        }
-        return info;
-    }
-}
-
-static InsertionOrderPreservingMap<string> BigqueryQueryToString(TableFunctionToStringInput &input) {
-    D_ASSERT(input.bind_data);
-    InsertionOrderPreservingMap<string> result;
-
-    // Try to cast to BigqueryArrowScanBindData first (experimental scan)
-    if (auto *arrow_bind_data = dynamic_cast<const BigqueryArrowScanBindData *>(input.bind_data.get())) {
-        result["Query"] = arrow_bind_data->query;
-        result["Table"] = arrow_bind_data->TableString();
-    } else {
-        auto &bind_data = input.bind_data->Cast<BigqueryLegacyScanBindData>();
-        result["Query"] = bind_data.query;
-        result["Table"] = bind_data.TableString();
-    }
-    return result;
-}
-
-static unique_ptr<NodeStatistics> BigqueryQueryCardinality(ClientContext &context, const FunctionData *bind_data_p) {
-    // Try to cast to BigqueryArrowScanBindData first (experimental scan)
-    if (auto *arrow_bind_data = dynamic_cast<const BigqueryArrowScanBindData *>(bind_data_p)) {
-        return make_uniq<NodeStatistics>(arrow_bind_data->estimated_row_count, arrow_bind_data->estimated_row_count);
-    } else {
-        auto &bind_data = bind_data_p->Cast<BigqueryLegacyScanBindData>();
-        return make_uniq<NodeStatistics>(bind_data.estimated_row_count, bind_data.estimated_row_count);
-    }
-}
-
-static double BigqueryQueryProgress(ClientContext &context,
-                                    const FunctionData *bind_data_p,
-                                    const GlobalTableFunctionState *global_state) {
-    // Try to cast to BigqueryArrowScanBindData first (experimental scan)
-    if (auto *arrow_bind_data = dynamic_cast<const BigqueryArrowScanBindData *>(bind_data_p)) {
-        auto &gstate = global_state->Cast<BigqueryArrowScanGlobalState>();
-        double progress = 0.0;
-        if (arrow_bind_data->estimated_row_count > 0) {
-            lock_guard<mutex> glock(gstate.lock);
-            progress = 100.0 * double(gstate.position) / double(arrow_bind_data->estimated_row_count);
-        }
-        return MinValue<double>(100, progress);
-    } else {
-        auto &bind_data = bind_data_p->Cast<BigqueryLegacyScanBindData>();
-        auto &gstate = global_state->Cast<BigqueryGlobalFunctionState>();
-        double progress = 0.0;
-        if (bind_data.estimated_row_count > 0) {
-            lock_guard<mutex> glock(gstate.lock);
-            progress = 100.0 * double(gstate.position) / double(bind_data.estimated_row_count);
-        }
-        return MinValue<double>(100, progress);
-    }
-}
-
-BigqueryQueryFunction::BigqueryQueryFunction()
-    : TableFunction("bigquery_query",
-                    {LogicalType::VARCHAR, LogicalType::VARCHAR},
-                    BigqueryQueryExecute,
-                    BigqueryQueryBind,
-                    BigqueryQueryInitGlobal,
-                    BigqueryQueryInitLocal) {
-    to_string = BigqueryQueryToString;
-    cardinality = BigqueryQueryCardinality;
-    table_scan_progress = BigqueryQueryProgress;
-    get_bind_info = BigqueryQueryGetBindInfo;
-
-    projection_pushdown = true;
-    filter_pushdown = true;
-    filter_prune = true;
-
-    named_parameters["billing_project"] = LogicalType::VARCHAR;
-    named_parameters["api_endpoint"] = LogicalType::VARCHAR;
-    named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
     named_parameters["use_legacy_scan"] = LogicalType::BOOLEAN;
 }
 

--- a/src/bigquery_utils.cpp
+++ b/src/bigquery_utils.cpp
@@ -972,5 +972,35 @@ uint64_t Iso8601ToMillis(const string &iso8601) {
     return timestamp_ms;
 }
 
+BigQueryCommonParameters BigQueryCommonParameters::ParseFromNamedParameters(
+    const named_parameter_map_t &named_parameters) {
+
+    BigQueryCommonParameters params;
+    for (auto &kv : named_parameters) {
+        auto loption = StringUtil::Lower(kv.first);
+
+        if (loption == "billing_project") {
+            params.billing_project = kv.second.GetValue<string>();
+        } else if (loption == "api_endpoint") {
+            params.api_endpoint = kv.second.GetValue<string>();
+        } else if (loption == "grpc_endpoint") {
+            params.grpc_endpoint = kv.second.GetValue<string>();
+        } else if (loption == "filter") {
+            params.filter = kv.second.GetValue<string>();
+        } else if (loption == "use_legacy_scan") {
+            params.use_legacy_scan = BooleanValue::Get(kv.second);
+        } else if (loption == "dry_run") {
+            params.dry_run = BooleanValue::Get(kv.second);
+        }
+        // otherwise, ignore
+    }
+
+    if (!named_parameters.count("use_legacy_scan") && !named_parameters.count("USE_LEGACY_SCAN")) {
+        params.use_legacy_scan = BigquerySettings::UseLegacyScan();
+    }
+    return params;
+}
+
+
 } // namespace bigquery
 } // namespace duckdb

--- a/src/include/bigquery_query.hpp
+++ b/src/include/bigquery_query.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+#include "bigquery_client.hpp"
+#include "bigquery_utils.hpp"
+
+namespace duckdb {
+namespace bigquery {
+
+struct BigqueryQueryDryRunBindData : public TableFunctionData {
+    BigqueryConfig config;
+    shared_ptr<BigqueryClient> bq_client;
+    string query;
+    bool finished = false;
+};
+
+class BigqueryQueryFunction : public TableFunction {
+public:
+    BigqueryQueryFunction();
+};
+
+} // namespace bigquery
+} // namespace duckdb

--- a/src/include/bigquery_scan.hpp
+++ b/src/include/bigquery_scan.hpp
@@ -11,6 +11,28 @@ namespace bigquery {
 
 class BigqueryClient;
 
+struct BigqueryGlobalFunctionState : public GlobalTableFunctionState {
+    explicit BigqueryGlobalFunctionState(shared_ptr<BigqueryArrowReader> arrow_reader, idx_t max_threads)
+        : position(0), max_threads(max_threads), arrow_reader(std::move(arrow_reader)) {
+    }
+
+    mutable mutex lock;
+    atomic<idx_t> position;
+    idx_t max_threads;
+
+    // The index of the next stream to read (i.e., current file + 1)
+    atomic<idx_t> next_stream = 0;
+    shared_ptr<BigqueryArrowReader> arrow_reader;
+
+    idx_t MaxThreads() const override {
+        return max_threads;
+    }
+
+    idx_t NextStreamIndex() {
+        return next_stream.fetch_add(1);
+    }
+};
+
 struct BigqueryLegacyScanBindData : public TableFunctionData {
     BigqueryConfig config;
     BigqueryTableRef table_ref;
@@ -39,14 +61,38 @@ struct BigqueryLegacyScanBindData : public TableFunctionData {
     }
 };
 
-class BigqueryScanFunction : public TableFunction {
+struct BigqueryScanFunction : public TableFunction {
 public:
     BigqueryScanFunction();
+
+public:
+    static unique_ptr<FunctionData> BigqueryScanBind(ClientContext &context,
+                                                     TableFunctionBindInput &input,
+                                                     vector<LogicalType> &return_types,
+                                                     vector<string> &names);
+    static unique_ptr<GlobalTableFunctionState> BigqueryScanInitGlobalState(ClientContext &context,
+                                                                            TableFunctionInitInput &input);
+    static unique_ptr<LocalTableFunctionState> BigqueryScanInitLocalState(ExecutionContext &context,
+                                                                          TableFunctionInitInput &input,
+                                                                          GlobalTableFunctionState *global_state);
+    static void BigqueryScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output);
 };
 
-class BigqueryQueryFunction : public TableFunction {
+struct BigqueryLegacyScanFunction : public TableFunction {
 public:
-    BigqueryQueryFunction();
+    BigqueryLegacyScanFunction();
+
+public:
+    static unique_ptr<FunctionData> BigqueryLegacyScanBind(ClientContext &context,
+                                                           TableFunctionBindInput &input,
+                                                           vector<LogicalType> &return_types,
+                                                           vector<string> &names);
+    static unique_ptr<GlobalTableFunctionState> BigqueryLegacyScanInitGlobalState(ClientContext &context,
+                                                                                  TableFunctionInitInput &input);
+    static unique_ptr<LocalTableFunctionState> BigqueryLegacyScanInitLocalState(ExecutionContext &context,
+                                                                                TableFunctionInitInput &input,
+                                                                                GlobalTableFunctionState *global_state);
+    static void BigqueryLegacyScanExecute(ClientContext &context, TableFunctionInput &data, DataChunk &output);
 };
 
 } // namespace bigquery

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -152,6 +152,8 @@ struct BigqueryType {
     vector<BigqueryType> children;
 };
 
+
+
 struct BigqueryUtils {
 public:
     // static ConnectionDetails ParseConnectionString(const string &connection_string);
@@ -225,6 +227,18 @@ inline std::vector<column_t> CalculateRanks(const std::vector<column_t> &nums) {
     }
     return ranks;
 }
+
+struct BigQueryCommonParameters {
+    string billing_project;
+    string api_endpoint;
+    string grpc_endpoint;
+    string filter;
+    bool use_legacy_scan = false;
+    bool dry_run = false;
+
+    //! Parse common parameters from named_parameters map
+    static BigQueryCommonParameters ParseFromNamedParameters(const named_parameter_map_t &named_parameters);
+};
 
 template <typename FUNC>
 bool RetryOperation(FUNC op, int max_attempts, int initial_delay_mss) {

--- a/test/sql/bigquery/function_bigquery_execute.test
+++ b/test/sql/bigquery/function_bigquery_execute.test
@@ -16,6 +16,11 @@ SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `$
 ----
 1	<REGEX>:job_.+	<REGEX>:.+	<REGEX>:.+	0	0	0
 
+query III
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`', dry_run=true)
+----
+0	false	<REGEX>:.+
+
 statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 

--- a/test/sql/bigquery/function_bigquery_query.test
+++ b/test/sql/bigquery/function_bigquery_query.test
@@ -45,6 +45,11 @@ cities(name, id, country_code);
 statement ok
 CALL bigquery_execute('bq', 'CREATE VIEW ${BQ_TEST_DATASET}.test_cities_view AS SELECT * FROM ${BQ_TEST_DATASET}.test_cities');
 
+query III
+SELECT * FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view;', dry_run=true);
+----
+0	false	<REGEX>:.+
+
 query I
 SELECT count(*) FROM bigquery_query('bq', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view');
 ----


### PR DESCRIPTION
This PR adds a `dry_run` parameter to both the `bigquery_execute` and `bigquery_query` functions, allowing users to simulate queries and retrieve metadata (such as bytes processed) without executing the actual query. Output columns for dry runs are now distinct from regular execution.

- **`bigquery_query(..., dry_run=true)`**
- **`bigquery_execute(..., dry_run=true)`**

Both return useful metadata:
- `total_bytes_processed` - How much data the query would process
- `cache_hit` - Whether results would come from cache
- `location` - Where the query would run

### Example Usage

```sql
-- Check query cost before running it
SELECT * FROM bigquery_query(
    'my_gcp_project', 
    'SELECT * FROM `my_gcp_project.dataset.big_table`', 
    dry_run=true
);
┌───────────────────────┬───────────┬──────────┐
│ total_bytes_processed │ cache_hit │ location │
│        int64          │  boolean  │ varchar  │
├───────────────────────┼───────────┼──────────┤
│                  1024 │ false     │ US       │
└───────────────────────┴───────────┴──────────┘
```
#101 #116 