### PR TITLE
Allow retrying failed BQ catalog loads

### DIFF
--- a/src/storage/bigquery_catalog_set.cpp
+++ b/src/storage/bigquery_catalog_set.cpp
@@ -86,8 +86,13 @@ void BigqueryCatalogSet::TryLoadEntries(ClientContext &context) {
         return;
     }
 
-    is_loaded = true;
-    LoadEntries(context);
+    try {
+        LoadEntries(context);
+        is_loaded = true;
+    } catch (...) {
+        is_loaded = false;
+        throw;
+    }
 }
 
 BigqueryInSchemaSet::BigqueryInSchemaSet(BigquerySchemaEntry &schema)


### PR DESCRIPTION
When loading BigQuery schemas fails (for example due to bad credentials), the catalog no longer keeps its cache marked as loaded, so subsequent attach attempts can retry once the issue is fixed.