### PR TITLE
Separate extension tests from build artifacts and skip fork PR GCP tests

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -80,12 +80,32 @@ jobs:
             exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
             vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
             extra_toolchains: "parser_tools"
+            skip_tests: true
+            upload_test_bundle: true
             save_cache: ${{ github.event_name != 'pull_request' }}
+            reduced_ci_mode: "disabled"
+
+    duckdb-stable-test:
+        name: Test extension binaries
+        needs: duckdb-stable-build
+        if: |
+            github.event_name == 'pull_request' ||
+            (github.event_name == 'push' && github.ref_name == 'main') ||
+            (github.event_name == 'push' && github.ref_type == 'tag')
+        uses: ./.github/workflows/_extension_tests.yml
+        secrets: inherit
+        with:
+            extension_name: bigquery
+            duckdb_version: v1.5.1
+            ci_tools_version: v1.5.1
+            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
+            vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
+            extra_toolchains: "parser_tools"
             reduced_ci_mode: "disabled"
 
     duckdb-stable-deploy:
         name: Deploy extension binaries
-        needs: duckdb-stable-build
+        needs: duckdb-stable-test
         if: |
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'push' && github.ref_name == 'main') ||

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -77,7 +77,7 @@ jobs:
             extension_name: bigquery
             duckdb_version: v1.5.4
             ci_tools_version: v1.5-variegata
-            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
+            exclude_archs: "linux_amd64_musl;linux_arm64_musl;osx_amd64;osx_arm64;windows_amd64;windows_arm64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
             vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
             extra_toolchains: "parser_tools"
             skip_tests: true
@@ -98,7 +98,7 @@ jobs:
             extension_name: bigquery
             duckdb_version: v1.5.4
             ci_tools_version: v1.5-variegata
-            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
+            exclude_archs: "linux_amd64_musl;linux_arm64_musl;osx_amd64;osx_arm64;windows_amd64;windows_arm64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
             vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
             extra_toolchains: "parser_tools"
             reduced_ci_mode: "disabled"
@@ -116,6 +116,6 @@ jobs:
             extension_name: bigquery
             duckdb_version: v1.5.4
             ci_tools_version: v1.5-variegata
-            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
+            exclude_archs: "linux_amd64_musl;linux_arm64_musl;osx_amd64;osx_arm64;windows_amd64;windows_arm64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
             deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
             reduced_ci_mode: "disabled"

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -96,8 +96,8 @@ jobs:
         secrets: inherit
         with:
             extension_name: bigquery
-            duckdb_version: v1.5.1
-            ci_tools_version: v1.5.1
+            duckdb_version: v1.5.4
+            ci_tools_version: v1.5-variegata
             exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
             vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
             extra_toolchains: "parser_tools"

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -77,7 +77,7 @@ jobs:
             extension_name: bigquery
             duckdb_version: v1.5.4
             ci_tools_version: v1.5-variegata
-            exclude_archs: "linux_amd64_musl;linux_arm64_musl;osx_amd64;osx_arm64;windows_amd64;windows_arm64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
+            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
             vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
             extra_toolchains: "parser_tools"
             skip_tests: true
@@ -98,7 +98,7 @@ jobs:
             extension_name: bigquery
             duckdb_version: v1.5.4
             ci_tools_version: v1.5-variegata
-            exclude_archs: "linux_amd64_musl;linux_arm64_musl;osx_amd64;osx_arm64;windows_amd64;windows_arm64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
+            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
             vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
             extra_toolchains: "parser_tools"
             reduced_ci_mode: "disabled"
@@ -116,6 +116,6 @@ jobs:
             extension_name: bigquery
             duckdb_version: v1.5.4
             ci_tools_version: v1.5-variegata
-            exclude_archs: "linux_amd64_musl;linux_arm64_musl;osx_amd64;osx_arm64;windows_amd64;windows_arm64;windows_amd64_mingw;wasm_mvp;wasm_eh;wasm_threads"
+            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
             deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
             reduced_ci_mode: "disabled"

--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -77,8 +77,7 @@ jobs:
             extension_name: bigquery
             duckdb_version: v1.5.4
             ci_tools_version: v1.5-variegata
-            gcp_environment: ci
-            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;"
+            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
             vcpkg_commit: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
             extra_toolchains: "parser_tools"
             save_cache: ${{ github.event_name != 'pull_request' }}
@@ -87,13 +86,16 @@ jobs:
     duckdb-stable-deploy:
         name: Deploy extension binaries
         needs: duckdb-stable-build
+        if: |
+            github.event_name == 'workflow_dispatch' ||
+            (github.event_name == 'push' && github.ref_name == 'main') ||
+            (github.event_name == 'push' && github.ref_type == 'tag')
         uses: ./.github/workflows/_extension_deploy.yml
         secrets: inherit
         with:
             extension_name: bigquery
             duckdb_version: v1.5.4
             ci_tools_version: v1.5-variegata
-            gcp_environment: ci
-            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;"
+            exclude_archs: "wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw"
             deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
             reduced_ci_mode: "disabled"

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -99,6 +99,8 @@ jobs:
     environment: ${{ inputs.gcp_environment }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.deploy_matrix)}}
+    env:
+      HAS_GCP_DEPLOY_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY != '' && secrets.GCS_DUCKDB_ORG_BUCKET != '' && secrets.GCS_DUCKDB_ORG_EXTENSION_SIGNING_PK != '' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -118,14 +120,17 @@ jobs:
             /tmp/extension
 
       - id: 'auth'
+        if: ${{ env.HAS_GCP_DEPLOY_CREDENTIALS == 'true' }}
         uses: 'google-github-actions/auth@v3'
         with:
             credentials_json: '${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}'
 
       - name: 'Set up Cloud SDK'
+        if: ${{ env.HAS_GCP_DEPLOY_CREDENTIALS == 'true' }}
         uses: 'google-github-actions/setup-gcloud@v3'
 
       - name: Deploy GCP
+        if: ${{ env.HAS_GCP_DEPLOY_CREDENTIALS == 'true' }}
         shell: bash
         env:
           BUCKET_NAME: ${{ secrets.GCS_DUCKDB_ORG_BUCKET }}
@@ -142,3 +147,8 @@ jobs:
           export EXT_VERSION=`git tag --points-at HEAD`
           export EXT_VERSION=${EXT_VERSION:=`git log -1 --format=%h`}
           ${{ inputs.deploy_gcs_script }} ${{ inputs.extension_name }} $EXT_VERSION $DUCKDB_VERSION ${{ matrix.duckdb_arch }} $BUCKET_NAME ${{inputs.deploy_latest || 'true' && 'false'}} ${{inputs.deploy_versioned || 'true' && 'false'}}
+
+      - name: Skip deploy without GCP credentials
+        if: ${{ env.HAS_GCP_DEPLOY_CREDENTIALS != 'true' }}
+        run: |
+          echo "Skipping deploy because GCP deployment credentials are not available for this run."

--- a/.github/workflows/_extension_deploy.yml
+++ b/.github/workflows/_extension_deploy.yml
@@ -48,11 +48,6 @@ on:
         required: false
         type: string
         default: ""
-      # GitHub Environment for the deploy job so GCS deploy secrets can come from environment scope.
-      gcp_environment:
-        required: false
-        type: string
-        default: "ci"
       # Override the default GCS deploy script with a custom script
       deploy_gcs_script:
         required: false
@@ -96,7 +91,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.deploy_matrix != '{}' && needs.generate_matrix.outputs.deploy_matrix != '' }}
-    environment: ${{ inputs.gcp_environment }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.deploy_matrix)}}
     env:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -154,12 +154,6 @@ on:
         required: false
         type: string
         default: "release"
-      # Optional GitHub Environment for jobs that need BigQuery/GCS secrets during CI.
-      # Note: environments are job-scoped, so the entire job is attached to this environment.
-      gcp_environment:
-        required: false
-        type: string
-        default: "ci"
       upload_all_extensions:
         required: false
         type: boolean
@@ -244,7 +238,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}
-    environment: ${{ inputs.gcp_environment }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.linux_matrix)}}
     env:
@@ -551,7 +544,6 @@ jobs:
     runs-on: macos-latest
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.osx_matrix != '{}' && needs.generate_matrix.outputs.osx_matrix != '' }}
-    environment: ${{ inputs.gcp_environment }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
     env:
@@ -817,7 +809,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: generate_matrix
     if: ${{ needs.generate_matrix.outputs.windows_matrix != '{}' && needs.generate_matrix.outputs.windows_matrix != '' }}
-    environment: ${{ inputs.gcp_environment }}
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
     env:

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -244,6 +244,7 @@ jobs:
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.linux_matrix)}}
     env:
+      HAS_GCP_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY != '' && secrets.BQ_TEST_PROJECT != '' && secrets.BQ_TEST_DATASET != '' }}
       # VCPKG config
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
@@ -466,13 +467,13 @@ jobs:
           key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}-${{ steps.ccache_timestamp.outputs.timestamp }}
 
       - id: "auth"
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
         uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
 
       - name: Test extension (inside docker)
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS == 'true' }}
         env:
           BQ_TEST_PROJECT: ${{ secrets.BQ_TEST_PROJECT }}
           BQ_TEST_DATASET: ${{ secrets.BQ_TEST_DATASET }}_${{ matrix.duckdb_arch }}
@@ -489,7 +490,7 @@ jobs:
             duckdb/${{ matrix.duckdb_arch }} make test_${{ inputs.build_type }}
 
       - name: Test extension (outside docker)
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false }}
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS == 'true' }}
         env:
           DUCKDB_GIT_VERSION: ${{ inputs.duckdb_version }}
           LINUX_CI_IN_DOCKER: 0
@@ -499,6 +500,11 @@ jobs:
         run: |
           eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
           make test_${{ inputs.build_type }}
+
+      - name: Skip BigQuery tests without GCP credentials
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS != 'true' }}
+        run: |
+          echo "Skipping BigQuery tests because GCP credentials are not available for this run."
 
       - uses: actions/upload-artifact@v4
         if: ${{ !inputs.upload_all_extensions }}
@@ -534,6 +540,7 @@ jobs:
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
     env:
+      HAS_GCP_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY != '' && secrets.BQ_TEST_PROJECT != '' && secrets.BQ_TEST_DATASET != '' }}
       # VCPKG config
       VCPKG_TOOLCHAIN_PATH: ${{ github.workspace }}/vcpkg/scripts/buildsystems/vcpkg.cmake
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
@@ -733,12 +740,13 @@ jobs:
           EXTENSION_NAME=${{ inputs.extension_name }} EXTENSION_CANONICAL=${{ inputs.extension_canonical }} ENABLE_EXTENSION_AUTOINSTALL=1 ENABLE_EXTENSION_AUTOLOADING=1 make ${{ inputs.build_type }}
 
       - id: "auth"
+        if: ${{ env.HAS_GCP_CREDENTIALS == 'true' }}
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
 
       - name: Test Extension
-        if: ${{ matrix.osx_build_arch == 'arm64' && inputs.skip_tests == false }}
+        if: ${{ matrix.osx_build_arch == 'arm64' && inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS == 'true' }}
         env:
           SUBSET_EXTENSIONS_TESTS: ${{ inputs.extensions_test_selection }}
           BQ_TEST_PROJECT: ${{ secrets.BQ_TEST_PROJECT }}
@@ -747,6 +755,11 @@ jobs:
         run: |
           eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
           make test_${{ inputs.build_type }}
+
+      - name: Skip BigQuery tests without GCP credentials
+        if: ${{ matrix.osx_build_arch == 'arm64' && inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS != 'true' }}
+        run: |
+          echo "Skipping BigQuery tests because GCP credentials are not available for this run."
 
       - uses: actions/upload-artifact@v4
         if: ${{ !inputs.upload_all_extensions }}
@@ -782,6 +795,7 @@ jobs:
     strategy:
       matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
     env:
+      HAS_GCP_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY != '' && secrets.BQ_TEST_PROJECT != '' && secrets.BQ_TEST_DATASET != '' }}
       # VCPKG config
       VCPKG_TARGET_TRIPLET: ${{ matrix.vcpkg_target_triplet }}
       VCPKG_HOST_TRIPLET: ${{ matrix.vcpkg_host_triplet }}
@@ -1013,12 +1027,13 @@ jobs:
           make ${{ inputs.build_type }}
 
       - id: "auth"
+        if: ${{ env.HAS_GCP_CREDENTIALS == 'true' }}
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
 
       - name: Test extension
-        if: ${{ inputs.skip_tests == false }}
+        if: ${{ inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS == 'true' }}
         env:
           BQ_TEST_PROJECT: ${{ secrets.BQ_TEST_PROJECT }}
           BQ_TEST_DATASET: ${{ secrets.BQ_TEST_DATASET }}_${{ matrix.duckdb_arch }}
@@ -1034,6 +1049,12 @@ jobs:
           export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$ROOTS_FILE"
           eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
           make test_${{ inputs.build_type }} GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$ROOTS_FILE"
+
+      - name: Skip BigQuery tests without GCP credentials
+        if: ${{ inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS != 'true' }}
+        shell: bash
+        run: |
+          echo "Skipping BigQuery tests because GCP credentials are not available for this run."
 
       - uses: actions/upload-artifact@v4
         if: ${{ !inputs.upload_all_extensions }}

--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -164,6 +164,10 @@ on:
         required: false
         type: boolean
         default: false
+      upload_test_bundle:
+        required: false
+        type: boolean
+        default: false
       extra_extension_config:
         required: false
         type: string
@@ -466,8 +470,19 @@ jobs:
           path: ./ccache_dir
           key: ccache-extension-distribution-${{ matrix.duckdb_arch }}-${{ inputs.duckdb_version }}-${{ steps.ccache_timestamp.outputs.timestamp }}
 
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload_test_bundle && matrix.duckdb_arch != 'linux_arm64' }}
+        with:
+          if-no-files-found: error
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: |
+            build/${{ inputs.build_type }}/test/**
+            build/${{ inputs.build_type }}/src/**
+            build/${{ inputs.build_type }}/extension/**
+            build/${{ inputs.build_type }}/vcpkg_installed/**
+
       - id: "auth"
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
+        if: ${{ inputs.skip_tests == false && matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
         uses: "google-github-actions/auth@v3"
         with:
           credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
@@ -739,8 +754,19 @@ jobs:
         run: |
           EXTENSION_NAME=${{ inputs.extension_name }} EXTENSION_CANONICAL=${{ inputs.extension_canonical }} ENABLE_EXTENSION_AUTOINSTALL=1 ENABLE_EXTENSION_AUTOLOADING=1 make ${{ inputs.build_type }}
 
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload_test_bundle && matrix.osx_build_arch == 'arm64' }}
+        with:
+          if-no-files-found: error
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: |
+            build/${{ inputs.build_type }}/test/**
+            build/${{ inputs.build_type }}/src/**
+            build/${{ inputs.build_type }}/extension/**
+            build/${{ inputs.build_type }}/vcpkg_installed/**
+
       - id: "auth"
-        if: ${{ env.HAS_GCP_CREDENTIALS == 'true' }}
+        if: ${{ inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS == 'true' }}
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
@@ -1026,8 +1052,19 @@ jobs:
           )
           make ${{ inputs.build_type }}
 
+      - uses: actions/upload-artifact@v4
+        if: ${{ inputs.upload_test_bundle }}
+        with:
+          if-no-files-found: error
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: |
+            build/${{ inputs.build_type }}/test/**
+            build/${{ inputs.build_type }}/src/**
+            build/${{ inputs.build_type }}/extension/**
+            build/${{ inputs.build_type }}/vcpkg_installed/**
+
       - id: "auth"
-        if: ${{ env.HAS_GCP_CREDENTIALS == 'true' }}
+        if: ${{ inputs.skip_tests == false && env.HAS_GCP_CREDENTIALS == 'true' }}
         uses: "google-github-actions/auth@v2"
         with:
           credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"

--- a/.github/workflows/_extension_tests.yml
+++ b/.github/workflows/_extension_tests.yml
@@ -1,0 +1,347 @@
+#
+# Reusable workflow that runs extension tests from build artifacts produced by
+# .github/workflows/_extension_distribution.yml.
+#
+
+name: Extension tests
+on:
+  workflow_call:
+    inputs:
+      extension_name:
+        required: true
+        type: string
+      duckdb_version:
+        required: true
+        type: string
+      ci_tools_version:
+        required: true
+        type: string
+      exclude_archs:
+        required: false
+        type: string
+        default: ""
+      opt_in_archs:
+        required: false
+        type: string
+        default: ""
+      artifact_postfix:
+        required: false
+        type: string
+        default: ""
+      vcpkg_url:
+        required: false
+        type: string
+        default: "https://github.com/microsoft/vcpkg.git"
+      vcpkg_commit:
+        required: false
+        type: string
+        default: "84bab45d415d22042bd0b9081aea57f362da3f35"
+      matrix_parse_script:
+        required: false
+        type: string
+        default: "./extension-ci-tools/scripts/modify_distribution_matrix.py"
+      override_repository:
+        required: false
+        type: string
+        default: ""
+      override_ref:
+        required: false
+        type: string
+        default: ""
+      override_ci_tools_repository:
+        required: false
+        type: string
+        default: "duckdb/extension-ci-tools"
+      extra_toolchains:
+        required: false
+        type: string
+        default: ""
+      enable_rust:
+        required: false
+        type: boolean
+        default: false
+      test_config:
+        required: false
+        type: string
+        default: "{}"
+      build_type:
+        required: false
+        type: string
+        default: "release"
+      reduced_ci_mode:
+        required: false
+        type: string
+        default: "auto"
+      extensions_test_selection:
+        required: false
+        type: string
+        default: "regular"
+
+jobs:
+  generate_matrix:
+    name: Generate matrix
+    runs-on: ubuntu-latest
+    outputs:
+      linux_matrix: ${{ steps.set-matrix-linux.outputs.linux_matrix }}
+      windows_matrix: ${{ steps.set-matrix-windows.outputs.windows_matrix }}
+      osx_matrix: ${{ steps.set-matrix-osx.outputs.osx_matrix }}
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
+
+      - run: |
+          mkdir build
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os linux   --output build/linux_matrix.json   --exclude "${{ inputs.exclude_archs }}" --opt_in "${{ inputs.opt_in_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os osx     --output build/osx_matrix.json     --exclude "${{ inputs.exclude_archs }}" --opt_in "${{ inputs.opt_in_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+          python3 ${{ inputs.matrix_parse_script }} --input extension-ci-tools/config/distribution_matrix.json --select_os windows --output build/windows_matrix.json --exclude "${{ inputs.exclude_archs }}" --opt_in "${{ inputs.opt_in_archs }}" --pretty --reduced_ci_mode ${{ inputs.reduced_ci_mode }}
+
+      - id: set-matrix-linux
+        run: |
+          linux_matrix="`cat build/linux_matrix.json`"
+          echo linux_matrix=$linux_matrix >> $GITHUB_OUTPUT
+
+      - id: set-matrix-osx
+        run: |
+          osx_matrix="`cat build/osx_matrix.json`"
+          echo osx_matrix=$osx_matrix >> $GITHUB_OUTPUT
+
+      - id: set-matrix-windows
+        run: |
+          windows_matrix="`cat build/windows_matrix.json`"
+          echo windows_matrix=$windows_matrix >> $GITHUB_OUTPUT
+
+  linux:
+    name: Linux tests
+    runs-on: ${{ matrix.runner }}
+    needs: generate_matrix
+    if: ${{ needs.generate_matrix.outputs.linux_matrix != '{}' && needs.generate_matrix.outputs.linux_matrix != '' }}
+    strategy:
+      matrix: ${{fromJson(needs.generate_matrix.outputs.linux_matrix)}}
+    env:
+      HAS_GCP_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY != '' && secrets.BQ_TEST_PROJECT != '' && secrets.BQ_TEST_DATASET != '' }}
+      BUILD_SHELL: 1
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout override repository
+        if: ${{ inputs.override_repository != '' }}
+        with:
+          repository: ${{ inputs.override_repository }}
+          ref: ${{ inputs.override_ref }}
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout current repository
+        if: ${{ inputs.override_repository == '' }}
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
+
+      - name: Build Docker image
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
+        shell: bash
+        run: |
+          docker build \
+            --build-arg 'vcpkg_url=${{ inputs.vcpkg_url }}' \
+            --build-arg 'vcpkg_commit=${{ inputs.vcpkg_commit }}' \
+            --build-arg 'extra_toolchains=${{ inputs.enable_rust  && format(';{0};rust;', inputs.extra_toolchains) || format(';{0};', inputs.extra_toolchains) }}' \
+            -t duckdb/${{ matrix.duckdb_arch }} \
+            ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
+
+      - uses: actions/download-artifact@v4
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
+        with:
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: .
+
+      - name: Create env file for docker
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
+        run: |
+          cat <<-EOF > docker_env.txt
+          BUILD_SHELL=1
+          DUCKDB_GIT_VERSION=${{ inputs.duckdb_version }}
+          DUCKDB_PLATFORM=${{ matrix.duckdb_arch }}
+          LINUX_CI_IN_DOCKER=1
+          SUBSET_EXTENSIONS_TESTS=${{ inputs.extensions_test_selection }}
+          EOF
+          echo '${{ inputs.test_config }}' | jq -r '.test_env_variables // {} | to_entries | map("\(.key)=\(.value)") | .[]' >> docker_env.txt
+
+      - id: auth
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+
+      - name: Test extension
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
+        env:
+          BQ_TEST_PROJECT: ${{ secrets.BQ_TEST_PROJECT }}
+          BQ_TEST_DATASET: ${{ secrets.BQ_TEST_DATASET }}_${{ matrix.duckdb_arch }}
+        run: |
+          echo "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}" > /tmp/gcloud-service-key.json
+          docker run \
+            -e BQ_TEST_PROJECT=$BQ_TEST_PROJECT \
+            -e BQ_TEST_DATASET=$BQ_TEST_DATASET \
+            -e GOOGLE_APPLICATION_CREDENTIALS=/auth/gcloud-service-key.json \
+            -v /tmp/gcloud-service-key.json:/auth/gcloud-service-key.json \
+            --env-file=docker_env.txt \
+            -v `pwd`:/duckdb_build_dir \
+            duckdb/${{ matrix.duckdb_arch }} make test_${{ inputs.build_type }}
+
+      - name: Skip tests without GCP credentials
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS != 'true' }}
+        run: |
+          echo "Skipping BigQuery tests because GCP credentials are not available for this run."
+
+  macos:
+    name: MacOS tests
+    runs-on: macos-latest
+    needs: generate_matrix
+    if: ${{ needs.generate_matrix.outputs.osx_matrix != '{}' && needs.generate_matrix.outputs.osx_matrix != '' }}
+    strategy:
+      matrix: ${{fromJson(needs.generate_matrix.outputs.osx_matrix)}}
+    env:
+      HAS_GCP_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY != '' && secrets.BQ_TEST_PROJECT != '' && secrets.BQ_TEST_DATASET != '' }}
+      OSX_BUILD_ARCH: ${{ matrix.osx_build_arch }}
+      GEN: ninja
+      BUILD_SHELL: 1
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+    steps:
+      - uses: actions/checkout@v4
+        name: Checkout override repository
+        if: ${{ inputs.override_repository != '' }}
+        with:
+          repository: ${{ inputs.override_repository }}
+          ref: ${{ inputs.override_ref }}
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout current repository
+        if: ${{ inputs.override_repository == '' }}
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
+
+      - uses: actions/download-artifact@v4
+        if: ${{ matrix.osx_build_arch == 'arm64' }}
+        with:
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: .
+
+      - id: auth
+        if: ${{ matrix.osx_build_arch == 'arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+
+      - name: Test extension
+        if: ${{ matrix.osx_build_arch == 'arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
+        env:
+          SUBSET_EXTENSIONS_TESTS: ${{ inputs.extensions_test_selection }}
+          BQ_TEST_PROJECT: ${{ secrets.BQ_TEST_PROJECT }}
+          BQ_TEST_DATASET: ${{ secrets.BQ_TEST_DATASET }}_${{ matrix.duckdb_arch }}
+        shell: bash
+        run: |
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
+          make test_${{ inputs.build_type }}
+
+      - name: Skip tests without GCP credentials
+        if: ${{ matrix.osx_build_arch == 'arm64' && env.HAS_GCP_CREDENTIALS != 'true' }}
+        run: |
+          echo "Skipping BigQuery tests because GCP credentials are not available for this run."
+
+  windows:
+    name: Windows tests
+    runs-on: ${{ matrix.runner }}
+    needs: generate_matrix
+    if: ${{ needs.generate_matrix.outputs.windows_matrix != '{}' && needs.generate_matrix.outputs.windows_matrix != '' }}
+    strategy:
+      matrix: ${{fromJson(needs.generate_matrix.outputs.windows_matrix)}}
+    env:
+      HAS_GCP_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_KEY != '' && secrets.BQ_TEST_PROJECT != '' && secrets.BQ_TEST_DATASET != '' }}
+      BUILD_SHELL: 1
+      DUCKDB_PLATFORM: ${{ matrix.duckdb_arch }}
+      DUCKDB_PLATFORM_RTOOLS: ${{ (matrix.duckdb_arch == 'windows_amd64_rtools' || matrix.duckdb_arch == 'windows_amd64_mingw') && 1 || 0 }}
+      GEN: ninja
+    steps:
+      - name: Keep \n line endings
+        shell: bash
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
+      - uses: actions/checkout@v4
+        name: Checkout override repository
+        if: ${{ inputs.override_repository != '' }}
+        with:
+          repository: ${{ inputs.override_repository }}
+          ref: ${{ inputs.override_ref }}
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout current repository
+        if: ${{ inputs.override_repository == '' }}
+        with:
+          fetch-depth: 0
+          submodules: 'recursive'
+
+      - uses: actions/checkout@v4
+        name: Checkout Extension CI tools
+        with:
+          path: 'extension-ci-tools'
+          ref: ${{ inputs.ci_tools_version }}
+          repository: ${{ inputs.override_ci_tools_repository }}
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
+          path: .
+
+      - id: auth
+        if: ${{ env.HAS_GCP_CREDENTIALS == 'true' }}
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: "${{ secrets.GCS_SERVICE_ACCOUNT_KEY }}"
+
+      - name: Test extension
+        if: ${{ env.HAS_GCP_CREDENTIALS == 'true' }}
+        env:
+          BQ_TEST_PROJECT: ${{ secrets.BQ_TEST_PROJECT }}
+          BQ_TEST_DATASET: ${{ secrets.BQ_TEST_DATASET }}_${{ matrix.duckdb_arch }}
+          GRPC_DEFAULT_SSL_ROOTS_FILE_PATH: ${{ github.workspace }}\roots.pem
+          SUBSET_EXTENSIONS_TESTS: ${{ inputs.extensions_test_selection }}
+        shell: bash
+        run: |
+          ROOTS_FILE="${{ github.workspace }}/roots.pem"
+          echo "Downloading roots.pem to: $ROOTS_FILE"
+          curl --create-dirs -o "$ROOTS_FILE" -L https://pki.google.com/roots.pem
+          export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$ROOTS_FILE"
+          eval "$(jq -r '.test_env_variables // {} | to_entries[] | "export \(.key)=\(.value | @sh)"' <<< '${{inputs.test_config}}')"
+          make test_${{ inputs.build_type }} GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="$ROOTS_FILE"
+
+      - name: Skip tests without GCP credentials
+        if: ${{ env.HAS_GCP_CREDENTIALS != 'true' }}
+        shell: bash
+        run: |
+          echo "Skipping BigQuery tests because GCP credentials are not available for this run."

--- a/.github/workflows/_extension_tests.yml
+++ b/.github/workflows/_extension_tests.yml
@@ -161,13 +161,13 @@ jobs:
             ./extension-ci-tools/docker/${{ matrix.duckdb_arch }}
 
       - uses: actions/download-artifact@v4
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: build/${{ inputs.build_type }}
 
       - name: Restore test runner permissions
-        if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
         run: chmod +x build/${{ inputs.build_type }}/test/unittest
 
       - name: Create env file for docker
@@ -247,13 +247,13 @@ jobs:
           repository: ${{ inputs.override_ci_tools_repository }}
 
       - uses: actions/download-artifact@v4
-        if: ${{ matrix.osx_build_arch == 'arm64' }}
+        if: ${{ matrix.osx_build_arch == 'arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: build/${{ inputs.build_type }}
 
       - name: Restore test runner permissions
-        if: ${{ matrix.osx_build_arch == 'arm64' }}
+        if: ${{ matrix.osx_build_arch == 'arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
         run: chmod +x build/${{ inputs.build_type }}/test/unittest
 
       - id: auth
@@ -322,6 +322,7 @@ jobs:
           repository: ${{ inputs.override_ci_tools_repository }}
 
       - uses: actions/download-artifact@v4
+        if: ${{ env.HAS_GCP_CREDENTIALS == 'true' }}
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
           path: build/${{ inputs.build_type }}

--- a/.github/workflows/_extension_tests.yml
+++ b/.github/workflows/_extension_tests.yml
@@ -164,7 +164,11 @@ jobs:
         if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: .
+          path: build/${{ inputs.build_type }}
+
+      - name: Restore test runner permissions
+        if: ${{ matrix.duckdb_arch != 'linux_arm64' }}
+        run: chmod +x build/${{ inputs.build_type }}/test/unittest
 
       - name: Create env file for docker
         if: ${{ matrix.duckdb_arch != 'linux_arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
@@ -246,7 +250,11 @@ jobs:
         if: ${{ matrix.osx_build_arch == 'arm64' }}
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: .
+          path: build/${{ inputs.build_type }}
+
+      - name: Restore test runner permissions
+        if: ${{ matrix.osx_build_arch == 'arm64' }}
+        run: chmod +x build/${{ inputs.build_type }}/test/unittest
 
       - id: auth
         if: ${{ matrix.osx_build_arch == 'arm64' && env.HAS_GCP_CREDENTIALS == 'true' }}
@@ -316,7 +324,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.extension_name }}-${{ inputs.duckdb_version }}-test-bundle-${{matrix.duckdb_arch}}${{inputs.artifact_postfix}}
-          path: .
+          path: build/${{ inputs.build_type }}
 
       - id: auth
         if: ${{ env.HAS_GCP_CREDENTIALS == 'true' }}

--- a/README.md
+++ b/README.md
@@ -676,27 +676,6 @@ There are some limitations that arise from the combination of DuckDB and BigQuer
 
 * **Primary Keys and Foreign Keys**: While BigQuery recently introduced the concept of primary keys and foreign keys constraints, they differ from what you're accustomed to in DuckDB or other traditional RDBMS. Therefore, this extension does not support this concept.
 
-## Install Latest Updates from Custom Repository
-
-Updates may not always be immediately available in the Community Extension repository. However, they can be obtained from a custom repository. To get the latest updates, start DuckDB with [unsigned extensions](https://duckdb.org/docs/extensions/overview.html#unsigned-extensions) setting enabled. Use the `allow_unsigned_extensions` flag for client connections, or start the CLI with `-unsigned` as follows:
-
-```bash
-# Example: CLI
-duckdb -unsigned
-
-# Example: Python
-con = duckdb.connect(':memory:', config={'allow_unsigned_extensions' : 'true'})
-```
-
-Then set the custom repository and install the extension:
-
-```sql
--- Set the custom repository, then install and load the DuckDB BigQuery extension
-D SET custom_extension_repository = 'http://storage.googleapis.com/hafenkran';
-D FORCE INSTALL 'bigquery';
-D LOAD 'bigquery';
-```
-
 ## Building the Project
 
 This extension uses VCPKG for dependency management. Enabling VCPKG is very simple: follow the [installation instructions](https://github.com/microsoft/vcpkg?tab=readme-ov-file#quick-start-unix) or just run the following:


### PR DESCRIPTION
This splits extension test execution out of the distribution workflow into a dedicated `_extension_tests.yml` workflow. The build job now uploads reusable test bundles, the new test workflow runs against those artifacts, and deploy waits for the separate test stage.

It also fixes external fork PR behavior by skipping GCP-backed test/auth steps when repository secrets are unavailable, instead of failing during google-github-actions/auth`.