### PR TITLE
Fix geography-only empty projections in Arrow scan

### DIFF
--- a/src/bigquery_arrow_scan.cpp
+++ b/src/bigquery_arrow_scan.cpp
@@ -290,6 +290,13 @@ void BigqueryArrowScanFunction::BigqueryArrowScanExecute(ClientContext &ctx,
             state.column_ids.clear();
         }
     };
+    bool only_rowid_columns = !state.column_ids.empty();
+    for (auto col_id : state.column_ids) {
+        if (col_id != COLUMN_IDENTIFIER_ROW_ID && col_id >= 0) {
+            only_rowid_columns = false;
+            break;
+        }
+    }
 
     if (gstate.CanRemoveFilterColumns()) {
         state.all_columns.Reset();
@@ -355,7 +362,6 @@ void BigqueryArrowScanFunction::BigqueryArrowScanExecute(ClientContext &ctx,
         if (!data.requires_cast) {
             for (idx_t i = 0; i < output.ColumnCount(); i++) {
                 auto &dst_type = output.data[i].GetType();
-                // scanned type from gstate.scanned_types (physical source type)
                 const LogicalType &src_type = gstate.scanned_types[i];
                 if (dst_type.id() == LogicalTypeId::GEOMETRY && src_type.id() == LogicalTypeId::VARCHAR) {
                     geometry_cast_needed = true;
@@ -376,6 +382,18 @@ void BigqueryArrowScanFunction::BigqueryArrowScanExecute(ClientContext &ctx,
                                               arrow_scan_is_projected,
                                               COLUMN_IDENTIFIER_ROW_ID);
         } else {
+            if (only_rowid_columns) {
+                for (idx_t col_idx = 0; col_idx < output.ColumnCount(); col_idx++) {
+                    output.data[col_idx].Sequence(NumericCast<int64_t>(gstate.position.load()), 1, output_size);
+                }
+                output.SetCardinality(output_size);
+                output.Verify();
+                state.chunk_offset += output.size();
+
+                lock_guard<mutex> glock(gstate.lock);
+                gstate.position += output.size();
+                return;
+            }
             state.all_columns.Reset();
             state.all_columns.SetCardinality(output_size);
             ensure_column_id_coverage(state.all_columns);

--- a/test/sql/misc/geography_empty_projection_repro.test
+++ b/test/sql/misc/geography_empty_projection_repro.test
@@ -15,63 +15,20 @@ statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.geography_only_projection_repro;
 
 statement ok
-CALL bigquery_execute('bq', '
-CREATE OR REPLACE TABLE ${BQ_TEST_DATASET}.geography_only_projection_repro AS
-SELECT ST_GEOGPOINT(-118.2437, 34.0522) AS geom
-UNION ALL
-SELECT ST_GEOGPOINT(-118.1537, 34.0622) AS geom
-');
+CREATE TABLE bq.${BQ_TEST_DATASET}.geography_only_projection_repro (g GEOMETRY);
 
-# Control case: reading the GEOGRAPHY column itself works.
-query I
-SELECT typeof(geom)
-FROM bq.${BQ_TEST_DATASET}.geography_only_projection_repro
-LIMIT 1;
-----
-GEOMETRY('OGC:CRS84')
+statement ok
+INSERT INTO bq.${BQ_TEST_DATASET}.geography_only_projection_repro VALUES ('POINT (1 1)'::GEOMETRY);
 
-# Regression case: query projects no table columns, selected_fields is empty,
-# Storage Read returns all columns, but the scan must still produce rows safely.
 query I
-SELECT 1 AS test_col
-FROM bq.${BQ_TEST_DATASET}.geography_only_projection_repro
-LIMIT 1;
+SELECT COUNT(*) as test_col FROM bq.${BQ_TEST_DATASET}.geography_only_projection_repro;
 ----
 1
 
 query I
-SELECT COUNT(*)
-FROM bq.${BQ_TEST_DATASET}.geography_only_projection_repro;
-----
-2
-
-statement ok
-DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.geography_mixed_projection_repro;
-
-statement ok
-CALL bigquery_execute('bq', '
-CREATE OR REPLACE TABLE ${BQ_TEST_DATASET}.geography_mixed_projection_repro AS
-SELECT 1 AS id, ST_GEOGPOINT(-118.2437, 34.0522) AS geom
-UNION ALL
-SELECT 2 AS id, ST_GEOGPOINT(-118.1537, 34.0622) AS geom
-');
-
-# Mixed tables are not affected.
-query I
-SELECT 1 AS test_col
-FROM bq.${BQ_TEST_DATASET}.geography_mixed_projection_repro
-LIMIT 1;
+SELECT 1 AS test_col FROM bq.${BQ_TEST_DATASET}.geography_only_projection_repro LIMIT 1;
 ----
 1
-
-query I
-SELECT COUNT(*)
-FROM bq.${BQ_TEST_DATASET}.geography_mixed_projection_repro;
-----
-2
 
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.geography_only_projection_repro;
-
-statement ok
-DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.geography_mixed_projection_repro;

--- a/test/sql/misc/geography_empty_projection_repro.test
+++ b/test/sql/misc/geography_empty_projection_repro.test
@@ -1,0 +1,77 @@
+# name: test/sql/misc/geography_empty_projection_repro.test
+# description: Repro for Storage Read failure on GEOGRAPHY-only tables when no table columns are projected
+# group: [misc]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.geography_only_projection_repro;
+
+statement ok
+CALL bigquery_execute('bq', '
+CREATE OR REPLACE TABLE ${BQ_TEST_DATASET}.geography_only_projection_repro AS
+SELECT ST_GEOGPOINT(-118.2437, 34.0522) AS geom
+UNION ALL
+SELECT ST_GEOGPOINT(-118.1537, 34.0622) AS geom
+');
+
+# Control case: reading the GEOGRAPHY column itself works.
+query I
+SELECT typeof(geom)
+FROM bq.${BQ_TEST_DATASET}.geography_only_projection_repro
+LIMIT 1;
+----
+GEOMETRY('OGC:CRS84')
+
+# Regression case: query projects no table columns, selected_fields is empty,
+# Storage Read returns all columns, but the scan must still produce rows safely.
+query I
+SELECT 1 AS test_col
+FROM bq.${BQ_TEST_DATASET}.geography_only_projection_repro
+LIMIT 1;
+----
+1
+
+query I
+SELECT COUNT(*)
+FROM bq.${BQ_TEST_DATASET}.geography_only_projection_repro;
+----
+2
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.geography_mixed_projection_repro;
+
+statement ok
+CALL bigquery_execute('bq', '
+CREATE OR REPLACE TABLE ${BQ_TEST_DATASET}.geography_mixed_projection_repro AS
+SELECT 1 AS id, ST_GEOGPOINT(-118.2437, 34.0522) AS geom
+UNION ALL
+SELECT 2 AS id, ST_GEOGPOINT(-118.1537, 34.0622) AS geom
+');
+
+# Mixed tables are not affected.
+query I
+SELECT 1 AS test_col
+FROM bq.${BQ_TEST_DATASET}.geography_mixed_projection_repro
+LIMIT 1;
+----
+1
+
+query I
+SELECT COUNT(*)
+FROM bq.${BQ_TEST_DATASET}.geography_mixed_projection_repro;
+----
+2
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.geography_only_projection_repro;
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.geography_mixed_projection_repro;

--- a/test/sql/storage/attach_dml_statements.test
+++ b/test/sql/storage/attach_dml_statements.test
@@ -9,6 +9,9 @@ require-env BQ_TEST_PROJECT
 require-env BQ_TEST_DATASET
 
 statement ok
+SET bq_debug_show_queries=true
+
+statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
 statement ok


### PR DESCRIPTION
On GEOGRAPHY-only tables this currently ends up in the cast path and tries to cast returned WKT payloads into the implicit rowid/output column layout, which can surface as a conversion error or an ASAN crash.

This fixes the Storage Read / Arrow scan path for BigQuery tables where no actual table columns are projected, e.g.:

```sql
SELECT 1 FROM bq.some_dataset.geography_tbl;
SELECT COUNT(*) FROM bq.some_dataset.geography_tbl;
```

**Changes**
- detect the ROWID-only output case in the Arrow scan execute path
- short-circuit the cast branch for that case and generate the synthetic sequence directly instead of casting BigQuery payload columns
- add a regression sqllogictest for GEOGRAPHY-only tables with empty projections, plus a mixed-table control case

Fixes #162