### PR TITLE
fix: properly clean up gRPC stream in BigqueryProtoWriter

### DIFF
--- a/src/bigquery_proto_writer.cpp
+++ b/src/bigquery_proto_writer.cpp
@@ -105,6 +105,17 @@ BigqueryProtoWriter::BigqueryProtoWriter(BigqueryTableEntry *entry, const google
 }
 
 BigqueryProtoWriter::~BigqueryProtoWriter() {
+    // Ensure gRPC stream is properly closed to avoid connection leaks
+    // when the writer is destroyed without calling Finalize() (e.g., on exception paths).
+    if (grpc_stream) {
+        try {
+            grpc_stream->WritesDone().get();
+            grpc_stream->Finish().get();
+        } catch (...) {
+            // Best-effort cleanup during destruction
+        }
+        grpc_stream.reset();
+    }
 }
 
 void BigqueryProtoWriter::InitMessageDescriptor(BigqueryTableEntry *entry) {
@@ -456,6 +467,9 @@ void BigqueryProtoWriter::Finalize() {
     if (!commit) {
         throw IOException("Unexpected error commiting write streams: %s", commit.status().message());
     }
+
+    // Mark stream as consumed so destructor doesn't try to finalize again
+    grpc_stream.reset();
 }
 
 void BigqueryProtoWriter::WriteMessageField(google::protobuf::Message *msg,


### PR DESCRIPTION
## Summary

Two fixes for gRPC stream lifecycle in `BigqueryProtoWriter`, found while investigating write path performance on a GCP VM (see #166 for context):

- **Implement destructor cleanup**: If a `BigqueryProtoWriter` is destroyed without calling `Finalize()` (e.g., due to an exception during writes), the gRPC stream was never closed, leaking connections.
- **Reset `grpc_stream` after `Finalize()`**: `Finalize()` calls `WritesDone()` + `Finish()` on the stream but didn't reset the pointer. When the destructor ran afterwards, it tried to finalize the already-closed stream, triggering `GRPC_CALL_ERROR_TOO_MANY_OPERATIONS` and crashing the process.

## How we found this

While profiling the write path on a GCP VM (e2-standard-4, us-east1-b) with timing instrumentation, consecutive `CREATE TABLE AS` operations crashed with:

```
E0000 call_op_set.h:979] API misuse of type GRPC_CALL_ERROR_TOO_MANY_OPERATIONS observed
F0000 call_op_set.h:981] Check failed: false
```

The crash happened because the stream was finalized in `Finalize()` but not nulled out, so the destructor attempted a second finalize.

## Test plan
- [x] Reproduced the crash with consecutive write operations on GCP VM
- [x] Verified the fix: 4 consecutive write operations (2x CREATE TABLE AS + 2x INSERT INTO) complete without crash
- [ ] Run full test suite