### PR TITLE
Optimize BigQuery protobuf write path

### DIFF
--- a/src/bigquery_geography.cpp
+++ b/src/bigquery_geography.cpp
@@ -583,6 +583,33 @@ static idx_t SerializedMultiPolygonGeometrySize(const vector<Polygon> &polygons,
     return size;
 }
 
+static void SerializePolygonGeometry(const Polygon &polygon, idx_t dimensions, char *result_data, idx_t result_size) {
+    GeometryBlobWriter writer(result_data, UnsafeNumericCast<uint32_t>(result_size));
+    writer.Write<uint8_t>(1);
+    writer.Write<uint32_t>(polygon.meta);
+    WritePolygonBody(writer, polygon, dimensions);
+    writer.Finalize();
+}
+
+static void SerializeMultiPolygonGeometry(const vector<Polygon> &polygons,
+                                          uint32_t meta,
+                                          idx_t dimensions,
+                                          char *result_data,
+                                          idx_t result_size) {
+    GeometryBlobWriter writer(result_data, UnsafeNumericCast<uint32_t>(result_size));
+    writer.Write<uint8_t>(1);
+    writer.Write<uint32_t>(meta);
+    writer.Write<uint32_t>(UnsafeNumericCast<uint32_t>(polygons.size()));
+
+    for (const auto &polygon : polygons) {
+        writer.Write<uint8_t>(1);
+        writer.Write<uint32_t>(polygon.meta);
+        WritePolygonBody(writer, polygon, dimensions);
+    }
+
+    writer.Finalize();
+}
+
 static bool NormalizePolygonGeometry(const string_t &input_geom,
                                      string_t &result_geom,
                                      Vector &result_vector,
@@ -602,11 +629,7 @@ static bool NormalizePolygonGeometry(const string_t &input_geom,
     }
 
     auto blob = StringVector::EmptyString(result_vector, SerializedPolygonGeometrySize(polygon, dimensions));
-    GeometryBlobWriter writer(blob.GetDataWriteable(), UnsafeNumericCast<uint32_t>(blob.GetSize()));
-    writer.Write<uint8_t>(byte_order);
-    writer.Write<uint32_t>(polygon.meta);
-    WritePolygonBody(writer, polygon, dimensions);
-    writer.Finalize();
+    SerializePolygonGeometry(polygon, dimensions, blob.GetDataWriteable(), blob.GetSize());
     blob.Finalize();
 
     result_geom = blob;
@@ -649,18 +672,7 @@ static bool NormalizeMultiPolygonGeometry(const string_t &input_geom,
     }
 
     auto blob = StringVector::EmptyString(result_vector, SerializedMultiPolygonGeometrySize(polygons, dimensions));
-    GeometryBlobWriter writer(blob.GetDataWriteable(), UnsafeNumericCast<uint32_t>(blob.GetSize()));
-    writer.Write<uint8_t>(byte_order);
-    writer.Write<uint32_t>(meta);
-    writer.Write<uint32_t>(polygon_count);
-
-    for (const auto &polygon : polygons) {
-        writer.Write<uint8_t>(1);
-        writer.Write<uint32_t>(polygon.meta);
-        WritePolygonBody(writer, polygon, dimensions);
-    }
-
-    writer.Finalize();
+    SerializeMultiPolygonGeometry(polygons, meta, dimensions, blob.GetDataWriteable(), blob.GetSize());
     blob.Finalize();
 
     result_geom = blob;
@@ -676,6 +688,86 @@ bool NormalizeGeography(const string_t &input_geom, string_t &result_geom, Vecto
         return NormalizePolygonGeometry(input_geom, result_geom, result_vector, dimensions);
     case GeometryType::MULTIPOLYGON:
         return NormalizeMultiPolygonGeometry(input_geom, result_geom, result_vector, dimensions);
+    default:
+        result_geom = input_geom;
+        return false;
+    }
+}
+
+static bool NormalizePolygonGeometry(const string_t &input_geom,
+                                     string_t &result_geom,
+                                     string &result_storage,
+                                     idx_t dimensions) {
+    GeometryBlobReader reader(input_geom.GetData(), UnsafeNumericCast<uint32_t>(input_geom.GetSize()));
+
+    const auto byte_order = reader.Read<uint8_t>();
+    if (byte_order != 1) {
+        throw InvalidInputException("Unsupported byte order %d in geometry", byte_order);
+    }
+
+    const auto meta = reader.Read<uint32_t>();
+    auto polygon = ReadPolygonBody(reader, dimensions, meta);
+    if (!FixPolygonWinding(polygon)) {
+        result_geom = input_geom;
+        return false;
+    }
+
+    result_storage.resize(SerializedPolygonGeometrySize(polygon, dimensions));
+    SerializePolygonGeometry(polygon, dimensions, result_storage.data(), result_storage.size());
+    result_geom = string_t(result_storage.data(), UnsafeNumericCast<uint32_t>(result_storage.size()));
+    return true;
+}
+
+static bool NormalizeMultiPolygonGeometry(const string_t &input_geom,
+                                          string_t &result_geom,
+                                          string &result_storage,
+                                          idx_t dimensions) {
+    GeometryBlobReader reader(input_geom.GetData(), UnsafeNumericCast<uint32_t>(input_geom.GetSize()));
+
+    const auto byte_order = reader.Read<uint8_t>();
+    if (byte_order != 1) {
+        throw InvalidInputException("Unsupported byte order %d in geometry", byte_order);
+    }
+
+    const auto meta = reader.Read<uint32_t>();
+    const auto polygon_count = reader.Read<uint32_t>();
+
+    vector<Polygon> polygons;
+    polygons.reserve(polygon_count);
+
+    bool changed = false;
+    for (uint32_t polygon_idx = 0; polygon_idx < polygon_count; polygon_idx++) {
+        const auto polygon_byte_order = reader.Read<uint8_t>();
+        if (polygon_byte_order != 1) {
+            throw InvalidInputException("Unsupported polygon byte order %d in multipolygon", polygon_byte_order);
+        }
+
+        const auto polygon_meta = reader.Read<uint32_t>();
+        auto polygon = ReadPolygonBody(reader, dimensions, polygon_meta);
+        changed |= FixPolygonWinding(polygon);
+        polygons.push_back(std::move(polygon));
+    }
+
+    if (!changed) {
+        result_geom = input_geom;
+        return false;
+    }
+
+    result_storage.resize(SerializedMultiPolygonGeometrySize(polygons, dimensions));
+    SerializeMultiPolygonGeometry(polygons, meta, dimensions, result_storage.data(), result_storage.size());
+    result_geom = string_t(result_storage.data(), UnsafeNumericCast<uint32_t>(result_storage.size()));
+    return true;
+}
+
+bool NormalizeGeography(const string_t &input_geom, string_t &result_geom, string &result_storage) {
+    const auto type_info = Geometry::GetType(input_geom);
+    const auto dimensions = VertexDimensions(type_info.second);
+
+    switch (type_info.first) {
+    case GeometryType::POLYGON:
+        return NormalizePolygonGeometry(input_geom, result_geom, result_storage, dimensions);
+    case GeometryType::MULTIPOLYGON:
+        return NormalizeMultiPolygonGeometry(input_geom, result_geom, result_storage, dimensions);
     default:
         result_geom = input_geom;
         return false;

--- a/src/bigquery_proto_writer.cpp
+++ b/src/bigquery_proto_writer.cpp
@@ -153,8 +153,10 @@ void WriteScalarUnifiedField(google::protobuf::Message *msg,
         reflection->SetInt32(msg, field, UnifiedVectorFormat::GetData<int32_t>(format)[source_idx]);
         return;
     case LogicalTypeId::INTERVAL:
-        reflection->SetString(
-            msg, field, BigqueryUtils::IntervalToBigqueryIntervalString(UnifiedVectorFormat::GetData<interval_t>(format)[source_idx]));
+        reflection->SetString(msg,
+                              field,
+                              BigqueryUtils::IntervalToBigqueryIntervalString(
+                                  UnifiedVectorFormat::GetData<interval_t>(format)[source_idx]));
         return;
     case LogicalTypeId::SMALLINT:
         reflection->SetInt32(msg, field, UnifiedVectorFormat::GetData<int16_t>(format)[source_idx]);
@@ -193,7 +195,8 @@ void WriteScalarUnifiedField(google::protobuf::Message *msg,
         reflection->SetString(msg, field, UUID::ToString(UnifiedVectorFormat::GetData<hugeint_t>(format)[source_idx]));
         return;
     default:
-        throw InternalException("Unsupported scalar fast path type in BigQuery protobuf writer: %s", col_type.ToString());
+        throw InternalException("Unsupported scalar fast path type in BigQuery protobuf writer: %s",
+                                col_type.ToString());
     }
 }
 
@@ -284,36 +287,32 @@ BigqueryProtoWriter::BigqueryProtoWriter(BigqueryTableEntry *entry, const google
                     status.message());
             }
             if (status.code() == google::cloud::StatusCode::kUnauthenticated) {
-                throw IOException(
-                    "BigQuery Storage Write API authentication failed for %s.\n"
-                    "\n"
-                    "The provided credentials are invalid or have expired.\n"
-                    "  - For user credentials: gcloud auth application-default login\n"
-                    "  - For service accounts: verify your service account key is valid\n"
-                    "\n"
-                    "Error details: %s",
-                    table_string,
-                    status.message());
+                throw IOException("BigQuery Storage Write API authentication failed for %s.\n"
+                                  "\n"
+                                  "The provided credentials are invalid or have expired.\n"
+                                  "  - For user credentials: gcloud auth application-default login\n"
+                                  "  - For service accounts: verify your service account key is valid\n"
+                                  "\n"
+                                  "Error details: %s",
+                                  table_string,
+                                  status.message());
             }
             if (status.code() == google::cloud::StatusCode::kNotFound) {
-                throw BinderException(
-                    "BigQuery table not found: %s.\n"
-                    "\n"
-                    "Error details: %s",
-                    table_string,
-                    status.message());
+                throw BinderException("BigQuery table not found: %s.\n"
+                                      "\n"
+                                      "Error details: %s",
+                                      table_string,
+                                      status.message());
             }
             if (status.code() == google::cloud::StatusCode::kInvalidArgument) {
-                throw BinderException(
-                    "BigQuery Storage Write API invalid argument for %s.\n"
-                    "\n"
-                    "Error details: %s",
-                    table_string,
-                    status.message());
+                throw BinderException("BigQuery Storage Write API invalid argument for %s.\n"
+                                      "\n"
+                                      "Error details: %s",
+                                      table_string,
+                                      status.message());
             }
 
-            std::cout << "Failed to create write stream: " << status << std::endl
-                      << status.message() << std::endl;
+            std::cout << "Failed to create write stream: " << status << std::endl << status.message() << std::endl;
             if (attempt < max_retries - 1) {
                 std::cout << "Retrying..." << std::endl;
                 std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -574,7 +573,9 @@ void BigqueryProtoWriter::WriteChunk(DataChunk &chunk, const vector<idx_t> &targ
         }
 
         geometry_text_vectors[binding_idx] = make_uniq<Vector>(LogicalType::VARCHAR);
-        ConvertGeometryVectorToText(chunk.data[binding.source_col_idx], chunk.size(), *geometry_text_vectors[binding_idx]);
+        ConvertGeometryVectorToText(chunk.data[binding.source_col_idx],
+                                    chunk.size(),
+                                    *geometry_text_vectors[binding_idx]);
         geometry_text_vectors[binding_idx]->ToUnifiedFormat(chunk.size(), geometry_text_formats[binding_idx]);
         has_geometry_text[binding_idx] = true;
     }
@@ -596,7 +597,12 @@ void BigqueryProtoWriter::WriteChunk(DataChunk &chunk, const vector<idx_t> &targ
             }
 
             if (has_scalar_fast_path[binding_idx]) {
-                WriteScalarUnifiedField(msg, reflection, binding.field, binding.col_type, scalar_formats[binding_idx], i);
+                WriteScalarUnifiedField(msg,
+                                        reflection,
+                                        binding.field,
+                                        binding.col_type,
+                                        scalar_formats[binding_idx],
+                                        i);
                 continue;
             }
 

--- a/src/bigquery_proto_writer.cpp
+++ b/src/bigquery_proto_writer.cpp
@@ -5,6 +5,8 @@
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
 #include "duckdb.hpp"
+#include "duckdb/common/types/decimal.hpp"
+#include "duckdb/common/types/geometry.hpp"
 #include "duckdb/common/types/time.hpp"
 #include "duckdb/common/types/timestamp.hpp"
 #include "duckdb/common/types/uuid.hpp"
@@ -12,6 +14,7 @@
 #include "duckdb/parser/expression/constant_expression.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 
+#include "bigquery_geography.hpp"
 #include "bigquery_proto_writer.hpp"
 #include "storage/bigquery_catalog.hpp"
 #include "storage/bigquery_table_entry.hpp"
@@ -24,6 +27,177 @@
 
 namespace duckdb {
 namespace bigquery {
+
+void ValidateDateRange(const duckdb::date_t &value);
+void ValidateTimeRange(const duckdb::dtime_t &value);
+void ValidateTimestampRange(const duckdb::timestamp_t &value);
+
+namespace {
+
+void SetProtoString(google::protobuf::Message *msg,
+                    const google::protobuf::Reflection *reflection,
+                    const google::protobuf::FieldDescriptor *field,
+                    const string_t &value) {
+    reflection->SetString(msg, field, string(value.GetData(), value.GetSize()));
+}
+
+string GeometryToBigqueryText(const string_t &input_geom) {
+    string normalized_geom_storage;
+    string_t normalized_geom;
+    NormalizeGeography(input_geom, normalized_geom, normalized_geom_storage);
+
+    auto text_vector = Vector(LogicalType::VARCHAR);
+    auto text = Geometry::ToString(text_vector, normalized_geom);
+    return text.GetString();
+}
+
+void ConvertGeometryVectorToText(Vector &source, idx_t count, Vector &result) {
+    UnaryExecutor::Execute<string_t, string_t>(source, result, count, [&](const string_t &input_geom) {
+        string normalized_geom_storage;
+        string_t normalized_geom;
+        NormalizeGeography(input_geom, normalized_geom, normalized_geom_storage);
+        return Geometry::ToString(result, normalized_geom);
+    });
+}
+
+bool SupportsScalarUnifiedWrite(const LogicalType &col_type) {
+    switch (col_type.id()) {
+    case LogicalTypeId::BIGINT:
+    case LogicalTypeId::BIT:
+    case LogicalTypeId::BLOB:
+    case LogicalTypeId::BOOLEAN:
+    case LogicalTypeId::DATE:
+    case LogicalTypeId::DECIMAL:
+    case LogicalTypeId::DOUBLE:
+    case LogicalTypeId::FLOAT:
+    case LogicalTypeId::HUGEINT:
+    case LogicalTypeId::INTEGER:
+    case LogicalTypeId::INTERVAL:
+    case LogicalTypeId::SMALLINT:
+    case LogicalTypeId::TIME:
+    case LogicalTypeId::TIMESTAMP:
+    case LogicalTypeId::TINYINT:
+    case LogicalTypeId::UBIGINT:
+    case LogicalTypeId::UHUGEINT:
+    case LogicalTypeId::UINTEGER:
+    case LogicalTypeId::USMALLINT:
+    case LogicalTypeId::UTINYINT:
+    case LogicalTypeId::UUID:
+    case LogicalTypeId::VARCHAR:
+        return true;
+    default:
+        return false;
+    }
+}
+
+string DecimalToBigqueryString(const UnifiedVectorFormat &format, const LogicalType &col_type, idx_t source_idx) {
+    auto width = DecimalType::GetWidth(col_type);
+    auto scale = DecimalType::GetScale(col_type);
+    switch (format.physical_type) {
+    case PhysicalType::INT16:
+        return Decimal::ToString(UnifiedVectorFormat::GetData<int16_t>(format)[source_idx], width, scale);
+    case PhysicalType::INT32:
+        return Decimal::ToString(UnifiedVectorFormat::GetData<int32_t>(format)[source_idx], width, scale);
+    case PhysicalType::INT64:
+        return Decimal::ToString(UnifiedVectorFormat::GetData<int64_t>(format)[source_idx], width, scale);
+    case PhysicalType::INT128:
+        return Decimal::ToString(UnifiedVectorFormat::GetData<hugeint_t>(format)[source_idx], width, scale);
+    default:
+        throw InternalException("Unsupported decimal physical type in BigQuery protobuf writer: %s",
+                                TypeIdToString(format.physical_type));
+    }
+}
+
+void WriteScalarUnifiedField(google::protobuf::Message *msg,
+                             const google::protobuf::Reflection *reflection,
+                             const google::protobuf::FieldDescriptor *field,
+                             const LogicalType &col_type,
+                             const UnifiedVectorFormat &format,
+                             idx_t row_idx) {
+    auto source_idx = format.sel->get_index(row_idx);
+    if (!format.validity.RowIsValid(source_idx)) {
+        return;
+    }
+
+    switch (col_type.id()) {
+    case LogicalTypeId::BIGINT:
+        reflection->SetInt64(msg, field, UnifiedVectorFormat::GetData<int64_t>(format)[source_idx]);
+        return;
+    case LogicalTypeId::BIT:
+    case LogicalTypeId::BLOB:
+    case LogicalTypeId::VARCHAR:
+        SetProtoString(msg, reflection, field, UnifiedVectorFormat::GetData<string_t>(format)[source_idx]);
+        return;
+    case LogicalTypeId::BOOLEAN:
+        reflection->SetBool(msg, field, UnifiedVectorFormat::GetData<bool>(format)[source_idx]);
+        return;
+    case LogicalTypeId::DATE: {
+        auto value = UnifiedVectorFormat::GetData<date_t>(format)[source_idx];
+        ValidateDateRange(value);
+        reflection->SetInt32(msg, field, Date::EpochDays(value));
+        return;
+    }
+    case LogicalTypeId::DECIMAL:
+        reflection->SetString(msg, field, DecimalToBigqueryString(format, col_type, source_idx));
+        return;
+    case LogicalTypeId::DOUBLE:
+        reflection->SetDouble(msg, field, UnifiedVectorFormat::GetData<double>(format)[source_idx]);
+        return;
+    case LogicalTypeId::FLOAT:
+        reflection->SetFloat(msg, field, UnifiedVectorFormat::GetData<float>(format)[source_idx]);
+        return;
+    case LogicalTypeId::HUGEINT:
+        reflection->SetString(msg, field, UnifiedVectorFormat::GetData<hugeint_t>(format)[source_idx].ToString());
+        return;
+    case LogicalTypeId::INTEGER:
+        reflection->SetInt32(msg, field, UnifiedVectorFormat::GetData<int32_t>(format)[source_idx]);
+        return;
+    case LogicalTypeId::INTERVAL:
+        reflection->SetString(
+            msg, field, BigqueryUtils::IntervalToBigqueryIntervalString(UnifiedVectorFormat::GetData<interval_t>(format)[source_idx]));
+        return;
+    case LogicalTypeId::SMALLINT:
+        reflection->SetInt32(msg, field, UnifiedVectorFormat::GetData<int16_t>(format)[source_idx]);
+        return;
+    case LogicalTypeId::TIME: {
+        auto value = UnifiedVectorFormat::GetData<dtime_t>(format)[source_idx];
+        ValidateTimeRange(value);
+        reflection->SetString(msg, field, Time::ToString(value));
+        return;
+    }
+    case LogicalTypeId::TIMESTAMP: {
+        auto value = UnifiedVectorFormat::GetData<timestamp_t>(format)[source_idx];
+        ValidateTimestampRange(value);
+        reflection->SetInt64(msg, field, Timestamp::GetEpochMicroSeconds(value));
+        return;
+    }
+    case LogicalTypeId::TINYINT:
+        reflection->SetInt32(msg, field, UnifiedVectorFormat::GetData<int8_t>(format)[source_idx]);
+        return;
+    case LogicalTypeId::UBIGINT:
+        reflection->SetString(msg, field, std::to_string(UnifiedVectorFormat::GetData<uint64_t>(format)[source_idx]));
+        return;
+    case LogicalTypeId::UHUGEINT:
+        reflection->SetString(msg, field, UnifiedVectorFormat::GetData<uhugeint_t>(format)[source_idx].ToString());
+        return;
+    case LogicalTypeId::UINTEGER:
+        reflection->SetUInt32(msg, field, UnifiedVectorFormat::GetData<uint32_t>(format)[source_idx]);
+        return;
+    case LogicalTypeId::USMALLINT:
+        reflection->SetUInt32(msg, field, UnifiedVectorFormat::GetData<uint16_t>(format)[source_idx]);
+        return;
+    case LogicalTypeId::UTINYINT:
+        reflection->SetUInt32(msg, field, UnifiedVectorFormat::GetData<uint8_t>(format)[source_idx]);
+        return;
+    case LogicalTypeId::UUID:
+        reflection->SetString(msg, field, UUID::ToString(UnifiedVectorFormat::GetData<hugeint_t>(format)[source_idx]));
+        return;
+    default:
+        throw InternalException("Unsupported scalar fast path type in BigQuery protobuf writer: %s", col_type.ToString());
+    }
+}
+
+} // namespace
 
 void ValidateDateRange(const duckdb::date_t &value) {
     // Range: 0001-01-01 to 9999-12-31
@@ -167,6 +341,10 @@ BigqueryProtoWriter::~BigqueryProtoWriter() {
 }
 
 void BigqueryProtoWriter::InitMessageDescriptor(BigqueryTableEntry *entry) {
+    row_message.reset();
+    msg_prototype = nullptr;
+    row_reflection = nullptr;
+    msg_factory.reset();
     this->pool.~DescriptorPool();
     new (&this->pool) google::protobuf::DescriptorPool();
     column_bindings.clear();
@@ -256,6 +434,18 @@ void BigqueryProtoWriter::InitMessageDescriptor(BigqueryTableEntry *entry) {
     if (msg_descriptor == nullptr) {
         throw BinderException("Cannot get message descriptor from file descriptor");
     }
+
+    msg_factory = make_uniq<google::protobuf::DynamicMessageFactory>();
+    msg_prototype = msg_factory->GetPrototype(msg_descriptor);
+    if (msg_prototype == nullptr) {
+        throw BinderException("Cannot get message prototype from message descriptor");
+    }
+
+    row_message.reset(msg_prototype->New());
+    if (!row_message) {
+        throw InternalException("Cannot allocate protobuf message");
+    }
+    row_reflection = row_message->GetReflection();
 }
 
 string BigqueryProtoWriter::CreateNestedMessage(google::protobuf::DescriptorProto *parent_proto,
@@ -291,8 +481,7 @@ string BigqueryProtoWriter::CreateNestedMessage(google::protobuf::DescriptorProt
     return nested_type_name; // damit der Aufrufer das Feld korrekt setzen kann
 }
 
-void BigqueryProtoWriter::InitializeColumnBindings(const DataChunk &chunk,
-                                                   const std::map<std::string, idx_t> &column_idxs) {
+void BigqueryProtoWriter::InitializeColumnBindings(const DataChunk &chunk, const vector<idx_t> &target_column_idxs) {
     if (column_bindings_initialized) {
         if (column_bindings.size() != chunk.ColumnCount()) {
             throw InternalException("Unexpected column count change in BigQuery protobuf writer");
@@ -311,7 +500,7 @@ void BigqueryProtoWriter::InitializeColumnBindings(const DataChunk &chunk,
     };
 
     column_bindings.reserve(chunk.ColumnCount());
-    if (column_idxs.empty()) {
+    if (target_column_idxs.empty()) {
         for (idx_t source_col_idx = 0; source_col_idx < chunk.ColumnCount(); source_col_idx++) {
             auto *field = msg_descriptor->field(source_col_idx);
             if (field == nullptr) {
@@ -321,24 +510,18 @@ void BigqueryProtoWriter::InitializeColumnBindings(const DataChunk &chunk,
             column_bindings.push_back({source_col_idx, field, col_type, get_write_kind(col_type)});
         }
     } else {
-        idx_t source_col_idx = 0;
-        for (const auto &kv : column_idxs) {
-            if (source_col_idx >= chunk.ColumnCount()) {
-                throw InternalException("Unexpected source column index in BigQuery protobuf writer");
-            }
+        if (target_column_idxs.size() != chunk.ColumnCount()) {
+            throw InternalException("Unexpected column binding count in BigQuery protobuf writer");
+        }
 
-            auto target_col_idx = kv.second;
+        for (idx_t source_col_idx = 0; source_col_idx < target_column_idxs.size(); source_col_idx++) {
+            auto target_col_idx = target_column_idxs[source_col_idx];
             auto *field = msg_descriptor->field(target_col_idx);
             if (field == nullptr) {
                 throw BinderException("Cannot get field descriptor for BigQuery message");
             }
             const auto &col_type = chunk.data[source_col_idx].GetType();
             column_bindings.push_back({source_col_idx, field, col_type, get_write_kind(col_type)});
-            source_col_idx++;
-        }
-
-        if (source_col_idx != chunk.ColumnCount()) {
-            throw InternalException("Unexpected column binding count in BigQuery protobuf writer");
         }
     }
     column_bindings_initialized = true;
@@ -370,23 +553,53 @@ void BigqueryProtoWriter::FlushBufferedRequest() {
     buffered_request_initialized = false;
 }
 
-void BigqueryProtoWriter::WriteChunk(DataChunk &chunk, const std::map<std::string, idx_t> &column_idxs) {
-    auto msg_factory_local = google::protobuf::DynamicMessageFactory();
-    auto *msg_prototype = msg_factory_local.GetPrototype(msg_descriptor);
-    if (msg_prototype == nullptr) {
-        throw BinderException("Cannot get message prototype from message descriptor");
+void BigqueryProtoWriter::WriteChunk(DataChunk &chunk, const vector<idx_t> &target_column_idxs) {
+    InitializeColumnBindings(chunk, target_column_idxs);
+    auto *msg = row_message.get();
+    const google::protobuf::Reflection *reflection = row_reflection;
+    vector<UnifiedVectorFormat> scalar_formats(column_bindings.size());
+    vector<bool> has_scalar_fast_path(column_bindings.size(), false);
+    vector<unique_ptr<Vector>> geometry_text_vectors(column_bindings.size());
+    vector<UnifiedVectorFormat> geometry_text_formats(column_bindings.size());
+    vector<bool> has_geometry_text(column_bindings.size(), false);
+
+    for (idx_t binding_idx = 0; binding_idx < column_bindings.size(); binding_idx++) {
+        const auto &binding = column_bindings[binding_idx];
+        if (binding.write_kind != BoundWriteKind::SCALAR || !BigqueryUtils::IsGeometryType(binding.col_type)) {
+            if (binding.write_kind == BoundWriteKind::SCALAR && SupportsScalarUnifiedWrite(binding.col_type)) {
+                chunk.data[binding.source_col_idx].ToUnifiedFormat(chunk.size(), scalar_formats[binding_idx]);
+                has_scalar_fast_path[binding_idx] = true;
+            }
+            continue;
+        }
+
+        geometry_text_vectors[binding_idx] = make_uniq<Vector>(LogicalType::VARCHAR);
+        ConvertGeometryVectorToText(chunk.data[binding.source_col_idx], chunk.size(), *geometry_text_vectors[binding_idx]);
+        geometry_text_vectors[binding_idx]->ToUnifiedFormat(chunk.size(), geometry_text_formats[binding_idx]);
+        has_geometry_text[binding_idx] = true;
     }
-    InitializeColumnBindings(chunk, column_idxs);
-    unique_ptr<google::protobuf::Message> msg(msg_prototype->New());
-    if (!msg) {
-        throw InternalException("Cannot allocate protobuf message");
-    }
-    const google::protobuf::Reflection *reflection = msg->GetReflection();
-    string serialized_msg;
 
     for (idx_t i = 0; i < chunk.size(); i++) {
         msg->Clear();
-        for (const auto &binding : column_bindings) {
+        for (idx_t binding_idx = 0; binding_idx < column_bindings.size(); binding_idx++) {
+            const auto &binding = column_bindings[binding_idx];
+            if (has_geometry_text[binding_idx]) {
+                const auto &geometry_text_format = geometry_text_formats[binding_idx];
+                auto source_idx = geometry_text_format.sel->get_index(i);
+                if (!geometry_text_format.validity.RowIsValid(source_idx)) {
+                    continue;
+                }
+
+                auto text_value = UnifiedVectorFormat::GetData<string_t>(geometry_text_format)[source_idx];
+                SetProtoString(msg, reflection, binding.field, text_value);
+                continue;
+            }
+
+            if (has_scalar_fast_path[binding_idx]) {
+                WriteScalarUnifiedField(msg, reflection, binding.field, binding.col_type, scalar_formats[binding_idx], i);
+                continue;
+            }
+
             auto &col = chunk.data[binding.source_col_idx];
             auto val = col.GetValue(i);
             if (val.IsNull()) {
@@ -395,22 +608,19 @@ void BigqueryProtoWriter::WriteChunk(DataChunk &chunk, const std::map<std::strin
 
             switch (binding.write_kind) {
             case BoundWriteKind::REPEATED:
-                WriteRepeatedField(msg.get(), reflection, binding.field, binding.col_type, val);
+                WriteRepeatedField(msg, reflection, binding.field, binding.col_type, val);
                 break;
             case BoundWriteKind::MESSAGE:
-                WriteMessageField(msg.get(), reflection, binding.field, binding.col_type, val);
+                WriteMessageField(msg, reflection, binding.field, binding.col_type, val);
                 break;
             case BoundWriteKind::SCALAR:
-                WriteField(msg.get(), reflection, binding.field, binding.col_type, val);
+                WriteField(msg, reflection, binding.field, binding.col_type, val);
                 break;
             }
         }
 
-        serialized_msg.clear();
-        if (!msg->SerializeToString(&serialized_msg)) {
-            throw std::runtime_error("Failed to serialize message");
-        }
-        auto estimated_size_increase = serialized_msg.size() + APPEND_ROWS_ROW_OVERHEAD;
+        auto serialized_size = msg->ByteSizeLong();
+        auto estimated_size_increase = serialized_size + APPEND_ROWS_ROW_OVERHEAD;
 
         EnsureRequestInitialized();
         if (buffered_rows == 0 && buffered_request_bytes + estimated_size_increase > DEFAULT_APPEND_ROWS_SOFT_LIMIT) {
@@ -422,7 +632,12 @@ void BigqueryProtoWriter::WriteChunk(DataChunk &chunk, const std::map<std::strin
             EnsureRequestInitialized();
         }
 
-        buffered_request.mutable_proto_rows()->mutable_rows()->add_serialized_rows(serialized_msg);
+        auto *serialized_row = buffered_request.mutable_proto_rows()->mutable_rows()->add_serialized_rows();
+        serialized_row->clear();
+        serialized_row->reserve(serialized_size);
+        if (!msg->SerializeToString(serialized_row)) {
+            throw std::runtime_error("Failed to serialize message");
+        }
         buffered_rows++;
         buffered_request_bytes += estimated_size_increase;
 
@@ -524,7 +739,7 @@ void BigqueryProtoWriter::WriteMessageField(google::protobuf::Message *msg,
                                             const google::protobuf::Reflection *reflection,
                                             const google::protobuf::FieldDescriptor *field,
                                             const duckdb::LogicalType &col_type,
-                                            duckdb::Value &val) {
+                                            const duckdb::Value &val) {
     // Get the children vals/types
     auto &child_types = StructType::GetChildTypes(col_type);
     auto &child_values = StructValue::GetChildren(val);
@@ -548,11 +763,7 @@ void BigqueryProtoWriter::WriteMessageField(google::protobuf::Message *msg,
         const auto *nested_field = nested_msg->GetDescriptor()->field(j);
         if (child_type.id() == LogicalTypeId::STRUCT) {
             // Handle nested STRUCT types
-            WriteMessageField(nested_msg,
-                              nested_reflection,
-                              nested_field,
-                              child_type,
-                              const_cast<duckdb::Value &>(child_value));
+            WriteMessageField(nested_msg, nested_reflection, nested_field, child_type, child_value);
         } else {
             WriteField(nested_msg, nested_reflection, nested_field, child_type, child_value);
         }
@@ -563,17 +774,18 @@ void BigqueryProtoWriter::WriteRepeatedField(google::protobuf::Message *msg,
                                              const google::protobuf::Reflection *reflection,
                                              const google::protobuf::FieldDescriptor *field,
                                              const duckdb::LogicalType &col_type,
-                                             duckdb::Value &val) {
+                                             const duckdb::Value &val) {
     // Get the children vals/types
     duckdb::LogicalType child_type;
-    duckdb::vector<duckdb::Value> children;
+    const duckdb::vector<duckdb::Value> *children_ptr = nullptr;
     if (col_type.id() == LogicalTypeId::ARRAY) {
         child_type = ArrayType::GetChildType(col_type);
-        children = ArrayValue::GetChildren(val);
+        children_ptr = &ArrayValue::GetChildren(val);
     } else {
         child_type = ListType::GetChildType(col_type);
-        children = ListValue::GetChildren(val);
+        children_ptr = &ListValue::GetChildren(val);
     }
+    const auto &children = *children_ptr;
     if (children.empty()) {
         return;
     }
@@ -690,9 +902,9 @@ void BigqueryProtoWriter::WriteRepeatedField(google::protobuf::Message *msg,
     case LogicalTypeId::TIMESTAMP: {
         for (const auto &item : children) {
             if (!item.IsNull()) {
-                reflection->AddInt64(msg,
-                                     field,
-                                     Timestamp::GetEpochMicroSeconds(val.GetValueUnsafe<duckdb::timestamp_t>()));
+                auto value = item.GetValueUnsafe<duckdb::timestamp_t>();
+                ValidateTimestampRange(value);
+                reflection->AddInt64(msg, field, Timestamp::GetEpochMicroSeconds(value));
             }
         }
         break;
@@ -783,6 +995,15 @@ void BigqueryProtoWriter::WriteRepeatedField(google::protobuf::Message *msg,
                 if (!item.IsNull()) {
                     reflection->AddString(msg, field, UUID::ToString(item.GetValueUnsafe<hugeint_t>()));
                 }
+            }
+        }
+        break;
+    }
+    case LogicalTypeId::GEOMETRY: {
+        for (const auto &item : children) {
+            if (!item.IsNull()) {
+                auto geometry_value = string_t(StringValue::Get(item));
+                reflection->AddString(msg, field, GeometryToBigqueryText(geometry_value));
             }
         }
         break;
@@ -946,6 +1167,11 @@ void BigqueryProtoWriter::WriteField(google::protobuf::Message *msg,
     case LogicalTypeId::UUID: {
         auto value = val.GetValueUnsafe<hugeint_t>();
         reflection->SetString(msg, field, UUID::ToString(value));
+        break;
+    }
+    case LogicalTypeId::GEOMETRY: {
+        auto geometry_value = string_t(StringValue::Get(val));
+        reflection->SetString(msg, field, GeometryToBigqueryText(geometry_value));
         break;
     }
     case LogicalTypeId::VARCHAR: {

--- a/src/include/bigquery_geography.hpp
+++ b/src/include/bigquery_geography.hpp
@@ -15,6 +15,7 @@ void RegisterGeographyCast(DatabaseInstance &db);
 /// can be done unambiguously, including split collinear boundary segments.
 /// Non-polygon geometry types are passed through unchanged.
 bool NormalizeGeography(const string_t &input_geom, string_t &result_geom, Vector &result_vector);
+bool NormalizeGeography(const string_t &input_geom, string_t &result_geom, string &result_storage);
 
 /// DuckDB scalar function entry point for
 /// bigquery_normalize_geography(GEOMETRY) -> GEOMETRY

--- a/src/include/bigquery_proto_writer.hpp
+++ b/src/include/bigquery_proto_writer.hpp
@@ -4,6 +4,7 @@
 #undef NO_DATA
 
 #include "google/protobuf/descriptor.h"
+#include "google/protobuf/dynamic_message.h"
 #include "storage/bigquery_table_entry.hpp"
 
 namespace duckdb {
@@ -19,17 +20,17 @@ public:
                                const string &field_name,
                                const std::vector<std::pair<std::string, LogicalType>> &child_types);
 
-    void WriteChunk(DataChunk &chunk, const std::map<std::string, idx_t> &column_idxs);
+    void WriteChunk(DataChunk &chunk, const vector<idx_t> &target_column_idxs);
     void WriteMessageField(google::protobuf::Message *msg,
                            const google::protobuf::Reflection *reflection,
                            const google::protobuf::FieldDescriptor *field,
                            const duckdb::LogicalType &col_type,
-                           duckdb::Value &val);
+                           const duckdb::Value &val);
     void WriteRepeatedField(google::protobuf::Message *msg,
                             const google::protobuf::Reflection *reflection,
                             const google::protobuf::FieldDescriptor *field,
                             const duckdb::LogicalType &col_type,
-                            duckdb::Value &val);
+                            const duckdb::Value &val);
     void WriteField(google::protobuf::Message *msg,
                     const google::protobuf::Reflection *reflection,
                     const google::protobuf::FieldDescriptor *field,
@@ -51,7 +52,7 @@ private:
     static constexpr idx_t DEFAULT_APPEND_ROWS_SOFT_LIMIT = 9728 * 1024; // 9.5MB
     static constexpr idx_t APPEND_ROWS_ROW_OVERHEAD = 32;
 
-    void InitializeColumnBindings(const DataChunk &chunk, const std::map<std::string, idx_t> &column_idxs);
+    void InitializeColumnBindings(const DataChunk &chunk, const vector<idx_t> &target_column_idxs);
     void EnsureRequestInitialized();
     void FlushBufferedRequest();
     void SendAppendRequest(const google::cloud::bigquery::storage::v1::AppendRowsRequest &request);
@@ -67,6 +68,11 @@ private:
     idx_t buffered_rows = 0;
     size_t buffered_request_bytes = 0;
     bool buffered_request_initialized = false;
+
+    unique_ptr<google::protobuf::DynamicMessageFactory> msg_factory;
+    const google::protobuf::Message *msg_prototype = nullptr;
+    unique_ptr<google::protobuf::Message> row_message;
+    const google::protobuf::Reflection *row_reflection = nullptr;
 
     unique_ptr<google::cloud::bigquery_storage_v1::BigQueryWriteClient> write_client;
     google::cloud::bigquery::storage::v1::WriteStream write_stream;

--- a/src/storage/bigquery_insert.cpp
+++ b/src/storage/bigquery_insert.cpp
@@ -1,7 +1,6 @@
 #include "duckdb/execution/operator/projection/physical_projection.hpp"
 #include "duckdb/planner/expression.hpp"
 #include "duckdb/planner/expression/bound_cast_expression.hpp"
-#include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_create_table.hpp"
 #include "duckdb/planner/operator/logical_insert.hpp"
@@ -13,7 +12,6 @@
 #include <google/protobuf/dynamic_message.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
 
-#include "bigquery_geography.hpp"
 #include "bigquery_proto_writer.hpp"
 #include "bigquery_utils.hpp"
 #include "storage/bigquery_catalog.hpp"
@@ -54,7 +52,7 @@ public:
     DataChunk varchar_chunk;
 
     shared_ptr<BigqueryProtoWriter> writer;
-    std::map<std::string, idx_t> column_name_to_index;
+    vector<idx_t> target_column_indexes;
 };
 
 vector<string> GetInsertColumns(const duckdb::bigquery::BigqueryInsert &insert, BigqueryTableEntry &entry) {
@@ -100,18 +98,19 @@ unique_ptr<GlobalSinkState> BigqueryInsert::GetGlobalSinkState(ClientContext &co
     result->writer = bq_client->CreateProtoWriter(insert_table);
 
     auto insert_columns = GetInsertColumns(*this, *insert_table);
-    std::map<std::string, idx_t> column_name_to_index;
+    vector<idx_t> target_column_indexes;
+    target_column_indexes.reserve(insert_columns.size());
     for (idx_t i = 0; i < insert_columns.size(); i++) {
-        column_name_to_index[insert_columns[i]] = insert_table->GetColumnIndex(insert_columns[i]).index;
+        target_column_indexes.push_back(insert_table->GetColumnIndex(insert_columns[i]).index);
     }
-    result->column_name_to_index = column_name_to_index;
+    result->target_column_indexes = std::move(target_column_indexes);
     return std::move(result);
 }
 
 // ### SINK
 SinkResultType BigqueryInsert::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
     auto &gstate = sink_state->Cast<BigqueryInsertGlobalState>();
-    gstate.writer->WriteChunk(chunk, gstate.column_name_to_index);
+    gstate.writer->WriteChunk(chunk, gstate.target_column_indexes);
     gstate.insert_count += chunk.size();
     return SinkResultType::NEED_MORE_INPUT;
 }
@@ -186,64 +185,6 @@ PhysicalOperator &AddCastToBigqueryTypes(ClientContext &context,
     return proj;
 }
 
-PhysicalOperator &AddGeometryAsTextProjection(ClientContext &context,
-                                              PhysicalPlanGenerator &planner,
-                                              PhysicalOperator &plan) {
-    auto &child_types = plan.GetTypes();
-
-    // Skip if no geometry types
-    bool has_geometry = false;
-    for (auto &type : child_types) {
-        if (BigqueryUtils::IsGeometryType(type)) {
-            has_geometry = true;
-            break;
-        }
-    }
-    if (!has_geometry) {
-        return plan; // nothing to do
-    }
-
-    vector<LogicalType> projected_types;
-    vector<unique_ptr<Expression>> select_list;
-    projected_types.reserve(child_types.size());
-    select_list.reserve(child_types.size());
-
-    // Internal scalar function to normalize polygon topology before GEOMETRY -> VARCHAR serialization.
-    ScalarFunction normalize_geography_func("bigquery_normalize_geography",
-                                            {LogicalType::GEOMETRY()},
-                                            LogicalType::GEOMETRY(),
-                                            bigquery::BqNormalizeGeographyFunction);
-
-    for (idx_t i = 0; i < child_types.size(); i++) {
-        auto &type = child_types[i];
-        if (!BigqueryUtils::IsGeometryType(type)) {
-            select_list.push_back(make_uniq<BoundReferenceExpression>(type, i));
-            projected_types.push_back(type);
-            continue;
-        }
-
-        auto geom_ref = make_uniq<BoundReferenceExpression>(type, i);
-        vector<unique_ptr<Expression>> normalize_args;
-        normalize_args.push_back(std::move(geom_ref));
-        unique_ptr<Expression> bound;
-        bound = make_uniq<BoundFunctionExpression>(normalize_geography_func.return_type,
-                                                   normalize_geography_func,
-                                                   std::move(normalize_args),
-                                                   nullptr,
-                                                   false);
-        bound = BoundCastExpression::AddCastToType(context, std::move(bound), LogicalType::VARCHAR);
-
-        projected_types.push_back(LogicalType::VARCHAR);
-        select_list.push_back(std::move(bound));
-    }
-
-    auto &proj = planner.Make<PhysicalProjection>(std::move(projected_types),
-                                                  std::move(select_list),
-                                                  plan.estimated_cardinality);
-    proj.children.push_back(plan);
-    return proj;
-}
-
 PhysicalOperator &BigqueryCatalog::PlanInsert(ClientContext &context,
                                               PhysicalPlanGenerator &planner,
                                               LogicalInsert &op,
@@ -256,8 +197,7 @@ PhysicalOperator &BigqueryCatalog::PlanInsert(ClientContext &context,
     }
 
     D_ASSERT(plan);
-    auto &geom_proj = AddGeometryAsTextProjection(context, planner, *plan);
-    auto &child_plan = AddCastToBigqueryTypes(context, planner, geom_proj);
+    auto &child_plan = AddCastToBigqueryTypes(context, planner, *plan);
     auto &insert = planner.Make<BigqueryInsert>(op, op.table, op.column_index_map);
     insert.children.push_back(child_plan);
     return insert;
@@ -267,8 +207,7 @@ PhysicalOperator &BigqueryCatalog::PlanCreateTableAs(ClientContext &context,
                                                      PhysicalPlanGenerator &planner,
                                                      LogicalCreateTable &op,
                                                      PhysicalOperator &plan) {
-    auto &geom_proj = AddGeometryAsTextProjection(context, planner, plan);
-    auto &child_plan = AddCastToBigqueryTypes(context, planner, geom_proj); // retain existing cast behavior
+    auto &child_plan = AddCastToBigqueryTypes(context, planner, plan); // retain existing cast behavior
     auto &insert = planner.Make<BigqueryInsert>(op, op.schema, std::move(op.info));
     insert.children.push_back(child_plan);
     return insert;


### PR DESCRIPTION
This PR optimizes the BigQuery protobuf write path by reducing per-row/per-field overhead in serialization. It removes the extra GEOMETRY -> VARCHAR projection from the insert plan, moves geography normalization and WKT conversion into the writer, and adds a scalar fast path based on UnifiedVectorFormat to avoid repeated duckdb::Value materialization for common types.

It also reuses protobuf descriptor/message state across chunks, preserves target column order without string-keyed maps, and fixes a few write-path inefficiencies in repeated/nested handling. Overall, the change is aimed at lowering CPU overhead and avoiding unnecessary memory churn in the BigQuery insert path.