### PR TITLE
Bigquery load job function

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,58 @@ The `bigquery_execute` function supports the following named parameters:
 | `api_endpoint`  | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
 | `grpc_endpoint` | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
 
+### `bigquery_load` Function
+
+The `bigquery_load` function submits a BigQuery load job that writes data into a destination BigQuery table. The source can either be a local Parquet file (`source_file`) or a DuckDB table/view (`source_table`).
+
+```sql
+D SELECT * FROM bigquery_load(
+    'my_gcp_project',
+    'my_dataset.target_table',
+    source_file := '/path/to/data.parquet',
+    location := 'EU'
+);
+┌─────────┬──────────────────────────────┬────────────────┬──────────┬──────────────────────────────────────────────┬─────────────┬──────────────────┐
+│ success │            job_id            │   project_id   │ location │              destination_table               │ output_rows │      status      │
+│ boolean │           varchar            │    varchar     │ varchar  │                   varchar                    │   uint64    │       json       │
+├─────────┼──────────────────────────────┼────────────────┼──────────┼──────────────────────────────────────────────┼─────────────┼──────────────────┤
+│ true    │ job_duckdb_load_rpamgsjlffwi │ my_gcp_project │ EU       │ my_gcp_project.my_dataset.target_table       │       10878 │ {"state":"DONE"} │
+└─────────┴──────────────────────────────┴────────────────┴──────────┴──────────────────────────────────────────────┴─────────────┴──────────────────┘
+
+D CALL bigquery_load(
+    'bq',
+    'my_dataset.target_table',
+    source_table := 'local_staging_table',
+    write_disposition := 'WRITE_APPEND',
+    location := 'EU'
+);
+┌─────────┬──────────────────────────────┬────────────────┬──────────┬──────────────────────────────────────────────┬─────────────┬──────────────────┐
+│ success │            job_id            │   project_id   │ location │              destination_table               │ output_rows │      status      │
+│ boolean │           varchar            │    varchar     │ varchar  │                   varchar                    │   uint64    │       json       │
+├─────────┼──────────────────────────────┼────────────────┼──────────┼──────────────────────────────────────────────┼─────────────┼──────────────────┤
+│ true    │ job_duckdb_load_wifsj1ffusqo │ my_gcp_project │ EU       │ my_gcp_project.my_dataset.target_table       │       10878 │ {"state":"DONE"} │
+└─────────┴──────────────────────────────┴────────────────┴──────────┴──────────────────────────────────────────────┴─────────────┴──────────────────┘
+```
+
+Compared to `CREATE TABLE ... AS` or `INSERT INTO ...`, `bigquery_load` uses a different write path:
+
+- `CREATE TABLE ... AS` and `INSERT INTO bq...` use the BigQuery Storage Write API and stream rows with `AppendRows`.
+- `bigquery_load` uses a BigQuery load job. With `source_file` it loads a Parquet file directly; with `source_table` it first stages the DuckDB relation as a temporary Parquet file and then submits the load job.
+
+Use `CREATE TABLE ... AS` when you want the normal streaming write path from a DuckDB query result. Use `bigquery_load` when you already have Parquet files or when you explicitly want load-job semantics such as `write_disposition` and `create_disposition`.
+
+The `bigquery_load` function supports the following named parameters:
+
+| Parameter            | Type      | Description                                                                            |
+| -------------------- | --------- | -------------------------------------------------------------------------------------- |
+| `source_file`        | `VARCHAR` | Path to a local Parquet file to load.                                                  |
+| `source_table`       | `VARCHAR` | Name of a DuckDB table or view to load.                                                |
+| `write_disposition`  | `VARCHAR` | BigQuery write behavior: `WRITE_TRUNCATE` (default), `WRITE_APPEND`, or `WRITE_EMPTY`. |
+| `create_disposition` | `VARCHAR` | BigQuery create behavior: `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`.              |
+| `location`           | `VARCHAR` | BigQuery job location.                                                                 |
+
+Exactly one of `source_file` or `source_table` must be provided.
+
 ### `bigquery_jobs` Function
 
 The `bigquery_jobs` fucntion retrieves a list of jobs within the specified project. It displays job metadata such as

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -56,6 +56,7 @@ endif()
 ExternalProject_Add(
     gcp
     URL ${CMAKE_CURRENT_SOURCE_DIR}/vendor/google-cloud-cpp-2.38.0.zip
+    PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patches/google-cloud-cpp-2.38.0-bigquery-load.patch
     # CONFIGURE_HANDLED_BY_BUILD TRUE
     CMAKE_ARGS ${GCP_CMAKE_ARGS}
                -DBUILD_TESTING=OFF

--- a/external/patches/google-cloud-cpp-2.38.0-bigquery-load.patch
+++ b/external/patches/google-cloud-cpp-2.38.0-bigquery-load.patch
@@ -1,0 +1,669 @@
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_rest_connection_impl.cc b/google/cloud/bigquerycontrol/v2/internal/job_rest_connection_impl.cc
+index c71b7316..168cc051 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_rest_connection_impl.cc
++++ b/google/cloud/bigquerycontrol/v2/internal/job_rest_connection_impl.cc
+@@ -81,6 +81,23 @@ JobServiceRestConnectionImpl::InsertJob(
+       *current, request, __func__);
+ }
+ 
++StatusOr<google::cloud::bigquery::v2::Job>
++JobServiceRestConnectionImpl::InsertJobUpload(
++    google::cloud::bigquery::v2::InsertJobRequest const& request,
++    std::string const& upload_file_path) {
++  auto current = google::cloud::internal::SaveCurrentOptions();
++  return google::cloud::rest_internal::RestRetryLoop(
++      retry_policy(*current), backoff_policy(*current),
++      idempotency_policy(*current)->InsertJob(request),
++      [this, upload_file_path](rest_internal::RestContext& rest_context,
++                               Options const& options,
++                               google::cloud::bigquery::v2::InsertJobRequest const& request) {
++        return stub_->InsertJobUpload(rest_context, options, request,
++                                      upload_file_path);
++      },
++      *current, request, __func__);
++}
++
+ Status JobServiceRestConnectionImpl::DeleteJob(
+     google::cloud::bigquery::v2::DeleteJobRequest const& request) {
+   auto current = google::cloud::internal::SaveCurrentOptions();
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_rest_connection_impl.h b/google/cloud/bigquerycontrol/v2/internal/job_rest_connection_impl.h
+index a01de2f7..98ea62c5 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_rest_connection_impl.h
++++ b/google/cloud/bigquerycontrol/v2/internal/job_rest_connection_impl.h
+@@ -31,6 +31,7 @@
+ #include "google/cloud/stream_range.h"
+ #include "google/cloud/version.h"
+ #include <memory>
++#include <string>
+ 
+ namespace google {
+ namespace cloud {
+@@ -57,6 +58,9 @@ class JobServiceRestConnectionImpl
+ 
+   StatusOr<google::cloud::bigquery::v2::Job> InsertJob(
+       google::cloud::bigquery::v2::InsertJobRequest const& request) override;
++  StatusOr<google::cloud::bigquery::v2::Job> InsertJobUpload(
++      google::cloud::bigquery::v2::InsertJobRequest const& request,
++      std::string const& upload_file_path) override;
+ 
+   Status DeleteJob(
+       google::cloud::bigquery::v2::DeleteJobRequest const& request) override;
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_rest_logging_decorator.cc b/google/cloud/bigquerycontrol/v2/internal/job_rest_logging_decorator.cc
+index 05f2fbc3..2da4bc4e 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_rest_logging_decorator.cc
++++ b/google/cloud/bigquerycontrol/v2/internal/job_rest_logging_decorator.cc
+@@ -68,6 +68,21 @@ StatusOr<google::cloud::bigquery::v2::Job> JobServiceRestLogging::InsertJob(
+       rest_context, options, request, __func__, tracing_options_);
+ }
+ 
++StatusOr<google::cloud::bigquery::v2::Job>
++JobServiceRestLogging::InsertJobUpload(
++    rest_internal::RestContext& rest_context, Options const& options,
++    google::cloud::bigquery::v2::InsertJobRequest const& request,
++    std::string const& upload_file_path) {
++  return google::cloud::internal::LogWrapper(
++      [this, upload_file_path](rest_internal::RestContext& rest_context,
++                               Options const& options,
++                               google::cloud::bigquery::v2::InsertJobRequest const& request) {
++        return child_->InsertJobUpload(rest_context, options, request,
++                                       upload_file_path);
++      },
++      rest_context, options, request, __func__, tracing_options_);
++}
++
+ Status JobServiceRestLogging::DeleteJob(
+     rest_internal::RestContext& rest_context, Options const& options,
+     google::cloud::bigquery::v2::DeleteJobRequest const& request) {
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_rest_logging_decorator.h b/google/cloud/bigquerycontrol/v2/internal/job_rest_logging_decorator.h
+index 1eba27bd..87c4899d 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_rest_logging_decorator.h
++++ b/google/cloud/bigquerycontrol/v2/internal/job_rest_logging_decorator.h
+@@ -55,6 +55,11 @@ class JobServiceRestLogging : public JobServiceRestStub {
+       google::cloud::rest_internal::RestContext& rest_context,
+       Options const& options,
+       google::cloud::bigquery::v2::InsertJobRequest const& request) override;
++  StatusOr<google::cloud::bigquery::v2::Job> InsertJobUpload(
++      google::cloud::rest_internal::RestContext& rest_context,
++      Options const& options,
++      google::cloud::bigquery::v2::InsertJobRequest const& request,
++      std::string const& upload_file_path) override;
+ 
+   Status DeleteJob(
+       google::cloud::rest_internal::RestContext& rest_context,
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_rest_metadata_decorator.cc b/google/cloud/bigquerycontrol/v2/internal/job_rest_metadata_decorator.cc
+index a8483fdb..e5a52920 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_rest_metadata_decorator.cc
++++ b/google/cloud/bigquerycontrol/v2/internal/job_rest_metadata_decorator.cc
+@@ -60,6 +60,16 @@ StatusOr<google::cloud::bigquery::v2::Job> JobServiceRestMetadata::InsertJob(
+   return child_->InsertJob(rest_context, options, request);
+ }
+ 
++StatusOr<google::cloud::bigquery::v2::Job>
++JobServiceRestMetadata::InsertJobUpload(
++    rest_internal::RestContext& rest_context, Options const& options,
++    google::cloud::bigquery::v2::InsertJobRequest const& request,
++    std::string const& upload_file_path) {
++  SetMetadata(rest_context, options);
++  return child_->InsertJobUpload(rest_context, options, request,
++                                 upload_file_path);
++}
++
+ Status JobServiceRestMetadata::DeleteJob(
+     rest_internal::RestContext& rest_context, Options const& options,
+     google::cloud::bigquery::v2::DeleteJobRequest const& request) {
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_rest_metadata_decorator.h b/google/cloud/bigquerycontrol/v2/internal/job_rest_metadata_decorator.h
+index 0f4e6897..38f4bbd3 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_rest_metadata_decorator.h
++++ b/google/cloud/bigquerycontrol/v2/internal/job_rest_metadata_decorator.h
+@@ -52,6 +52,11 @@ class JobServiceRestMetadata : public JobServiceRestStub {
+       google::cloud::rest_internal::RestContext& rest_context,
+       Options const& options,
+       google::cloud::bigquery::v2::InsertJobRequest const& request) override;
++  StatusOr<google::cloud::bigquery::v2::Job> InsertJobUpload(
++      google::cloud::rest_internal::RestContext& rest_context,
++      Options const& options,
++      google::cloud::bigquery::v2::InsertJobRequest const& request,
++      std::string const& upload_file_path) override;
+ 
+   Status DeleteJob(
+       google::cloud::rest_internal::RestContext& rest_context,
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_rest_stub.cc b/google/cloud/bigquerycontrol/v2/internal/job_rest_stub.cc
+index 2a468e83..c3e649a9 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_rest_stub.cc
++++ b/google/cloud/bigquerycontrol/v2/internal/job_rest_stub.cc
+@@ -87,6 +87,42 @@ StatusOr<google::cloud::bigquery::v2::Job> DefaultJobServiceRestStub::InsertJob(
+       std::move(query_params));
+ }
+ 
++StatusOr<google::cloud::bigquery::v2::Job>
++DefaultJobServiceRestStub::InsertJobUpload(
++    google::cloud::rest_internal::RestContext& rest_context,
++    Options const& options,
++    google::cloud::bigquery::v2::InsertJobRequest const& request,
++    std::string const& upload_file_path) {
++  auto json_payload = rest_internal::ProtoRequestToJsonPayload(request.job(), false);
++  if (!json_payload.ok()) return std::move(json_payload).status();
++
++  auto boundary =
++      absl::StrCat("duckdb-bigquery-load-", request.job().job_reference().job_id());
++  auto rest_request = rest_internal::CreateRestRequest(
++      absl::StrCat("/", "upload", "/", "bigquery", "/",
++                   rest_internal::DetermineApiVersion("v2", options), "/",
++                   "projects", "/", request.project_id(), "/", "jobs"),
++      {{"uploadType", "multipart"}});
++  rest_request.AddHeader(
++      "content-type",
++      absl::StrCat("multipart/related; boundary=", boundary));
++
++  rest_internal::MultipartUploadRequest payload;
++  payload.payload_prefix = absl::StrCat(
++      "--", boundary, "\r\n",
++      "Content-Type: application/json; charset=UTF-8\r\n\r\n",
++      *json_payload, "\r\n",
++      "--", boundary, "\r\n",
++      "Content-Type: application/octet-stream\r\n\r\n");
++  payload.upload_file_path = upload_file_path;
++  payload.payload_suffix = absl::StrCat("\r\n--", boundary, "--\r\n");
++
++  auto response = service_->PostMultipart(rest_context, rest_request, payload);
++  if (!response.ok()) return response.status();
++  return rest_internal::RestResponseToProto<google::cloud::bigquery::v2::Job>(
++      std::move(**response));
++}
++
+ Status DefaultJobServiceRestStub::DeleteJob(
+     google::cloud::rest_internal::RestContext& rest_context,
+     Options const& options,
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_rest_stub.h b/google/cloud/bigquerycontrol/v2/internal/job_rest_stub.h
+index a6b24b0a..b55104f3 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_rest_stub.h
++++ b/google/cloud/bigquerycontrol/v2/internal/job_rest_stub.h
+@@ -26,6 +26,7 @@
+ #include "google/cloud/version.h"
+ #include <google/cloud/bigquery/v2/job.pb.h>
+ #include <memory>
++#include <string>
+ 
+ namespace google {
+ namespace cloud {
+@@ -50,6 +51,11 @@ class JobServiceRestStub {
+       google::cloud::rest_internal::RestContext& rest_context,
+       Options const& options,
+       google::cloud::bigquery::v2::InsertJobRequest const& request) = 0;
++  virtual StatusOr<google::cloud::bigquery::v2::Job> InsertJobUpload(
++      google::cloud::rest_internal::RestContext& rest_context,
++      Options const& options,
++      google::cloud::bigquery::v2::InsertJobRequest const& request,
++      std::string const& upload_file_path) = 0;
+ 
+   virtual Status DeleteJob(
+       google::cloud::rest_internal::RestContext& rest_context,
+@@ -95,6 +101,11 @@ class DefaultJobServiceRestStub : public JobServiceRestStub {
+       google::cloud::rest_internal::RestContext& rest_context,
+       Options const& options,
+       google::cloud::bigquery::v2::InsertJobRequest const& request) override;
++  StatusOr<google::cloud::bigquery::v2::Job> InsertJobUpload(
++      google::cloud::rest_internal::RestContext& rest_context,
++      Options const& options,
++      google::cloud::bigquery::v2::InsertJobRequest const& request,
++      std::string const& upload_file_path) override;
+ 
+   Status DeleteJob(
+       google::cloud::rest_internal::RestContext& rest_context,
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_tracing_connection.cc b/google/cloud/bigquerycontrol/v2/internal/job_tracing_connection.cc
+index 8a9e1763..a63fd608 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_tracing_connection.cc
++++ b/google/cloud/bigquerycontrol/v2/internal/job_tracing_connection.cc
+@@ -59,6 +59,17 @@ JobServiceTracingConnection::InsertJob(
+   return internal::EndSpan(*span, child_->InsertJob(request));
+ }
+ 
++StatusOr<google::cloud::bigquery::v2::Job>
++JobServiceTracingConnection::InsertJobUpload(
++    google::cloud::bigquery::v2::InsertJobRequest const& request,
++    std::string const& upload_file_path) {
++  auto span = internal::MakeSpan(
++      "bigquerycontrol_v2::JobServiceConnection::InsertJobUpload");
++  auto scope = opentelemetry::trace::Scope(span);
++  return internal::EndSpan(*span,
++                           child_->InsertJobUpload(request, upload_file_path));
++}
++
+ Status JobServiceTracingConnection::DeleteJob(
+     google::cloud::bigquery::v2::DeleteJobRequest const& request) {
+   auto span =
+diff --git a/google/cloud/bigquerycontrol/v2/internal/job_tracing_connection.h b/google/cloud/bigquerycontrol/v2/internal/job_tracing_connection.h
+index ef7c3a09..b681ef46 100644
+--- a/google/cloud/bigquerycontrol/v2/internal/job_tracing_connection.h
++++ b/google/cloud/bigquerycontrol/v2/internal/job_tracing_connection.h
+@@ -22,6 +22,7 @@
+ #include "google/cloud/bigquerycontrol/v2/job_connection.h"
+ #include "google/cloud/version.h"
+ #include <memory>
++#include <string>
+ 
+ namespace google {
+ namespace cloud {
+@@ -48,6 +49,9 @@ class JobServiceTracingConnection
+ 
+   StatusOr<google::cloud::bigquery::v2::Job> InsertJob(
+       google::cloud::bigquery::v2::InsertJobRequest const& request) override;
++  StatusOr<google::cloud::bigquery::v2::Job> InsertJobUpload(
++      google::cloud::bigquery::v2::InsertJobRequest const& request,
++      std::string const& upload_file_path) override;
+ 
+   Status DeleteJob(
+       google::cloud::bigquery::v2::DeleteJobRequest const& request) override;
+diff --git a/google/cloud/bigquerycontrol/v2/job_client.cc b/google/cloud/bigquerycontrol/v2/job_client.cc
+index 1d1d96ef..b1a219ca 100644
+--- a/google/cloud/bigquerycontrol/v2/job_client.cc
++++ b/google/cloud/bigquerycontrol/v2/job_client.cc
+@@ -53,6 +53,13 @@ StatusOr<google::cloud::bigquery::v2::Job> JobServiceClient::InsertJob(
+   return connection_->InsertJob(request);
+ }
+ 
++StatusOr<google::cloud::bigquery::v2::Job> JobServiceClient::InsertJobUpload(
++    google::cloud::bigquery::v2::InsertJobRequest const& request,
++    std::string const& upload_file_path, Options opts) {
++  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
++  return connection_->InsertJobUpload(request, upload_file_path);
++}
++
+ Status JobServiceClient::DeleteJob(
+     google::cloud::bigquery::v2::DeleteJobRequest const& request,
+     Options opts) {
+diff --git a/google/cloud/bigquerycontrol/v2/job_client.h b/google/cloud/bigquerycontrol/v2/job_client.h
+index 705cf0d3..8f351199 100644
+--- a/google/cloud/bigquerycontrol/v2/job_client.h
++++ b/google/cloud/bigquerycontrol/v2/job_client.h
+@@ -190,6 +190,10 @@ class JobServiceClient {
+       google::cloud::bigquery::v2::InsertJobRequest const& request,
+       Options opts = {});
+ 
++  StatusOr<google::cloud::bigquery::v2::Job> InsertJobUpload(
++      google::cloud::bigquery::v2::InsertJobRequest const& request,
++      std::string const& upload_file_path, Options opts = {});
++
+   // clang-format off
+   ///
+   /// Requests the deletion of the metadata of a job. This call returns when the
+diff --git a/google/cloud/bigquerycontrol/v2/job_connection.cc b/google/cloud/bigquerycontrol/v2/job_connection.cc
+index e611d316..526b766e 100644
+--- a/google/cloud/bigquerycontrol/v2/job_connection.cc
++++ b/google/cloud/bigquerycontrol/v2/job_connection.cc
+@@ -52,6 +52,13 @@ StatusOr<google::cloud::bigquery::v2::Job> JobServiceConnection::InsertJob(
+   return Status(StatusCode::kUnimplemented, "not implemented");
+ }
+ 
++StatusOr<google::cloud::bigquery::v2::Job>
++JobServiceConnection::InsertJobUpload(
++    google::cloud::bigquery::v2::InsertJobRequest const&,
++    std::string const&) {
++  return Status(StatusCode::kUnimplemented, "not implemented");
++}
++
+ Status JobServiceConnection::DeleteJob(
+     google::cloud::bigquery::v2::DeleteJobRequest const&) {
+   return Status(StatusCode::kUnimplemented, "not implemented");
+diff --git a/google/cloud/bigquerycontrol/v2/job_connection.h b/google/cloud/bigquerycontrol/v2/job_connection.h
+index df5c6f31..7420a37f 100644
+--- a/google/cloud/bigquerycontrol/v2/job_connection.h
++++ b/google/cloud/bigquerycontrol/v2/job_connection.h
+@@ -29,6 +29,7 @@
+ #include "google/cloud/version.h"
+ #include <google/cloud/bigquery/v2/job.pb.h>
+ #include <memory>
++#include <string>
+ 
+ namespace google {
+ namespace cloud {
+@@ -189,6 +190,9 @@ class JobServiceConnection {
+ 
+   virtual StatusOr<google::cloud::bigquery::v2::Job> InsertJob(
+       google::cloud::bigquery::v2::InsertJobRequest const& request);
++  virtual StatusOr<google::cloud::bigquery::v2::Job> InsertJobUpload(
++      google::cloud::bigquery::v2::InsertJobRequest const& request,
++      std::string const& upload_file_path);
+ 
+   virtual Status DeleteJob(
+       google::cloud::bigquery::v2::DeleteJobRequest const& request);
+diff --git a/google/cloud/internal/curl_impl.cc b/google/cloud/internal/curl_impl.cc
+index a5218bb5..027fcf22 100644
+--- a/google/cloud/internal/curl_impl.cc
++++ b/google/cloud/internal/curl_impl.cc
+@@ -349,6 +349,11 @@ std::string CurlImpl::LastClientIpAddress() const {
+ 
+ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
+                              std::vector<absl::Span<char const>> request) {
++  return MakeRequest(method, context, WriteVector{std::move(request)});
++}
++
++Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
++                             WriteVector request) {
+   Status status;
+   status = handle_.SetOption(CURLOPT_CUSTOMREQUEST, HttpMethodToName(method));
+   if (!status.ok()) return OnTransferError(context, std::move(status));
+@@ -455,12 +460,12 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
+     if (!status.ok()) return OnTransferError(context, std::move(status));
+   }
+ 
+-  if (method == HttpMethod::kDelete || request.empty()) {
++  if (method == HttpMethod::kDelete || request.size() == 0) {
+     return MakeRequestImpl(context);
+   }
+ 
+   if (method == HttpMethod::kPost) {
+-    writev_ = WriteVector{std::move(request)};
++    writev_ = std::move(request);
+     curl_off_t const size = writev_.size();
+     status = handle_.SetOption(CURLOPT_POSTFIELDS, nullptr);
+     if (!status.ok()) return OnTransferError(context, std::move(status));
+@@ -486,7 +491,7 @@ Status CurlImpl::MakeRequest(HttpMethod method, RestContext& context,
+   }
+ 
+   if (method == HttpMethod::kPut || method == HttpMethod::kPatch) {
+-    writev_ = WriteVector{std::move(request)};
++    writev_ = std::move(request);
+     curl_off_t const size = writev_.size();
+     status = handle_.SetOption(CURLOPT_READFUNCTION, &ReadFunction);
+     if (!status.ok()) return OnTransferError(context, std::move(status));
+diff --git a/google/cloud/internal/curl_impl.h b/google/cloud/internal/curl_impl.h
+index 266be569..c3b94994 100644
+--- a/google/cloud/internal/curl_impl.h
++++ b/google/cloud/internal/curl_impl.h
+@@ -101,6 +101,8 @@ class CurlImpl {
+ 
+   Status MakeRequest(HttpMethod method, RestContext& context,
+                      std::vector<absl::Span<char const>> request = {});
++  Status MakeRequest(HttpMethod method, RestContext& context,
++                     WriteVector request);
+ 
+   bool HasUnreadData() const;
+   StatusOr<std::size_t> Read(absl::Span<char> output);
+diff --git a/google/cloud/internal/curl_rest_client.cc b/google/cloud/internal/curl_rest_client.cc
+index d0abda63..70ee68e3 100644
+--- a/google/cloud/internal/curl_rest_client.cc
++++ b/google/cloud/internal/curl_rest_client.cc
+@@ -69,6 +69,19 @@ Status MakeRequestWithPayload(
+   return impl.MakeRequest(http_method, context, payload);
+ }
+ 
++Status MakeRequestWithMultipartPayload(
++    RestContext& context, CurlImpl& impl,
++    MultipartUploadRequest const& payload) {
++  auto writev = WriteVector::FromFileMultipart(payload.payload_prefix,
++                                               payload.upload_file_path,
++                                               payload.payload_suffix);
++  if (!writev.ok()) return std::move(writev).status();
++  impl.SetHeader(HttpHeader("Content-Length",
++                            std::to_string(writev->size())));
++  return impl.MakeRequest(CurlImpl::HttpMethod::kPost, context,
++                          std::move(*writev));
++}
++
+ std::string FormatHostHeaderValue(absl::string_view hostname) {
+   if (!absl::ConsumePrefix(&hostname, "https://")) {
+     absl::ConsumePrefix(&hostname, "http://");
+@@ -199,6 +212,18 @@ StatusOr<std::unique_ptr<RestResponse>> CurlRestClient::Post(
+       new CurlRestResponse(std::move(options), std::move(*impl)))};
+ }
+ 
++StatusOr<std::unique_ptr<RestResponse>> CurlRestClient::PostMultipart(
++    RestContext& context, RestRequest const& request,
++    MultipartUploadRequest const& payload) {
++  auto options = internal::MergeOptions(context.options(), options_);
++  auto impl = CreateCurlImpl(context, request, options);
++  if (!impl.ok()) return impl.status();
++  Status response = MakeRequestWithMultipartPayload(context, **impl, payload);
++  if (!response.ok()) return response;
++  return {std::unique_ptr<CurlRestResponse>(
++      new CurlRestResponse(std::move(options), std::move(*impl)))};
++}
++
+ StatusOr<std::unique_ptr<RestResponse>> CurlRestClient::Post(
+     RestContext& context, RestRequest const& request,
+     std::vector<std::pair<std::string, std::string>> const& form_data) {
+diff --git a/google/cloud/internal/curl_rest_client.h b/google/cloud/internal/curl_rest_client.h
+index d5a3cfdb..9f479dc5 100644
+--- a/google/cloud/internal/curl_rest_client.h
++++ b/google/cloud/internal/curl_rest_client.h
+@@ -62,6 +62,9 @@ class CurlRestClient : public RestClient {
+   StatusOr<std::unique_ptr<RestResponse>> Post(
+       RestContext& context, RestRequest const& request,
+       std::vector<absl::Span<char const>> const& payload) override;
++  StatusOr<std::unique_ptr<RestResponse>> PostMultipart(
++      RestContext& context, RestRequest const& request,
++      MultipartUploadRequest const& payload) override;
+   StatusOr<std::unique_ptr<RestResponse>> Post(
+       RestContext& context, RestRequest const& request,
+       std::vector<std::pair<std::string, std::string>> const& form_data)
+diff --git a/google/cloud/internal/curl_writev.cc b/google/cloud/internal/curl_writev.cc
+index 06ba2a68..682f7db0 100644
+--- a/google/cloud/internal/curl_writev.cc
++++ b/google/cloud/internal/curl_writev.cc
+@@ -13,6 +13,8 @@
+ // limitations under the License.
+ 
+ #include "google/cloud/internal/curl_writev.h"
++#include "google/cloud/internal/make_status.h"
++#include <algorithm>
+ #include <cstdio>
+ 
+ namespace google {
+@@ -20,7 +22,25 @@ namespace cloud {
+ namespace rest_internal {
+ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+ 
++StatusOr<WriteVector> WriteVector::FromFileMultipart(
++    std::string payload_prefix, std::string upload_file_path,
++    std::string payload_suffix) {
++  WriteVector result;
++  result.payload_prefix_ = std::move(payload_prefix);
++  result.upload_file_path_ = std::move(upload_file_path);
++  result.payload_suffix_ = std::move(payload_suffix);
++  if (!result.OpenUploadFile()) {
++    return internal::InvalidArgumentError("Unable to open upload file: " +
++                                          result.upload_file_path_);
++  }
++  return result;
++}
++
+ std::size_t WriteVector::size() const {
++  if (!upload_file_path_.empty()) {
++    return payload_prefix_.size() + upload_file_size_ + payload_suffix_.size() -
++           prefix_offset_ - file_offset_ - suffix_offset_;
++  }
+   std::size_t size = 0;
+   for (auto const& s : writev_) {
+     size += s.size();
+@@ -29,6 +49,9 @@ std::size_t WriteVector::size() const {
+ }
+ 
+ std::size_t WriteVector::MoveTo(absl::Span<char> dst) {
++  if (!upload_file_path_.empty()) {
++    return MoveMultipartTo(dst);
++  }
+   auto const avail = dst.size();
+   while (!writev_.empty()) {
+     auto& src = writev_.front();
+@@ -52,6 +75,9 @@ bool WriteVector::Seek(std::size_t offset, int origin) {
+   // These errors are treated as `StatusCode::kUnavailable` and thus retryable
+   // for most operations.
+   if (origin != SEEK_SET) return false;
++  if (!upload_file_path_.empty()) {
++    return SeekMultipart(offset);
++  }
+   writev_.assign(original_.begin(), original_.end());
+   while (!writev_.empty()) {
+     auto& src = writev_.front();
+@@ -66,6 +92,74 @@ bool WriteVector::Seek(std::size_t offset, int origin) {
+   return offset == 0;
+ }
+ 
++bool WriteVector::OpenUploadFile() {
++  upload_file_.close();
++  upload_file_.clear();
++  upload_file_.open(upload_file_path_, std::ios::binary);
++  if (!upload_file_.is_open()) return false;
++
++  upload_file_.seekg(0, std::ios::end);
++  auto end = upload_file_.tellg();
++  if (end < 0) return false;
++  upload_file_size_ = static_cast<std::size_t>(end);
++  upload_file_.seekg(0, std::ios::beg);
++  prefix_offset_ = 0;
++  file_offset_ = 0;
++  suffix_offset_ = 0;
++  return true;
++}
++
++std::size_t WriteVector::MoveMultipartTo(absl::Span<char> dst) {
++  auto const available = dst.size();
++
++  if (prefix_offset_ < payload_prefix_.size()) {
++    auto const remaining = payload_prefix_.size() - prefix_offset_;
++    auto const to_copy = (std::min)(dst.size(), remaining);
++    std::copy(payload_prefix_.data() + prefix_offset_,
++              payload_prefix_.data() + prefix_offset_ + to_copy, dst.begin());
++    prefix_offset_ += to_copy;
++    dst.remove_prefix(to_copy);
++  }
++
++  while (!dst.empty() && file_offset_ < upload_file_size_) {
++    auto const remaining = upload_file_size_ - file_offset_;
++    auto const to_read = (std::min)(dst.size(), remaining);
++    upload_file_.read(dst.data(), static_cast<std::streamsize>(to_read));
++    auto const read = static_cast<std::size_t>(upload_file_.gcount());
++    file_offset_ += read;
++    dst.remove_prefix(read);
++    if (read < to_read) break;
++  }
++
++  if (suffix_offset_ < payload_suffix_.size() && !dst.empty()) {
++    auto const remaining = payload_suffix_.size() - suffix_offset_;
++    auto const to_copy = (std::min)(dst.size(), remaining);
++    std::copy(payload_suffix_.data() + suffix_offset_,
++              payload_suffix_.data() + suffix_offset_ + to_copy, dst.begin());
++    suffix_offset_ += to_copy;
++    dst.remove_prefix(to_copy);
++  }
++
++  return available - dst.size();
++}
++
++bool WriteVector::SeekMultipart(std::size_t offset) {
++  auto const total_size = payload_prefix_.size() + upload_file_size_ + payload_suffix_.size();
++  if (offset > total_size) return false;
++
++  prefix_offset_ = (std::min)(offset, payload_prefix_.size());
++  offset -= prefix_offset_;
++
++  file_offset_ = (std::min)(offset, upload_file_size_);
++  offset -= file_offset_;
++  suffix_offset_ = offset;
++
++  if (!upload_file_.is_open() && !OpenUploadFile()) return false;
++  upload_file_.clear();
++  upload_file_.seekg(static_cast<std::streamoff>(file_offset_), std::ios::beg);
++  return static_cast<bool>(upload_file_);
++}
++
+ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+ }  // namespace rest_internal
+ }  // namespace cloud
+diff --git a/google/cloud/internal/curl_writev.h b/google/cloud/internal/curl_writev.h
+index 51c26114..b03acfef 100644
+--- a/google/cloud/internal/curl_writev.h
++++ b/google/cloud/internal/curl_writev.h
+@@ -16,8 +16,11 @@
+ #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_CURL_WRITEV_H
+ 
+ #include "google/cloud/version.h"
++#include "google/cloud/status_or.h"
+ #include "absl/types/span.h"
+ #include <deque>
++#include <fstream>
++#include <string>
+ #include <vector>
+ 
+ namespace google {
+@@ -31,6 +34,9 @@ class WriteVector {
+   WriteVector() = default;
+   explicit WriteVector(std::vector<absl::Span<char const>> v)
+       : original_(std::move(v)), writev_(original_.begin(), original_.end()) {}
++  static StatusOr<WriteVector> FromFileMultipart(std::string payload_prefix,
++                                                 std::string upload_file_path,
++                                                 std::string payload_suffix);
+ 
+   /// Returns the number of bytes available in the write vector.
+   std::size_t size() const;
+@@ -47,8 +53,21 @@ class WriteVector {
+   bool Seek(std::size_t offset, int origin);
+ 
+  private:
++  bool OpenUploadFile();
++  std::size_t MoveMultipartTo(absl::Span<char> dst);
++  bool SeekMultipart(std::size_t offset);
++
+   std::vector<absl::Span<char const>> original_;
+   std::deque<absl::Span<char const>> writev_;
++
++  std::string payload_prefix_;
++  std::string upload_file_path_;
++  std::string payload_suffix_;
++  std::ifstream upload_file_;
++  std::size_t upload_file_size_ = 0;
++  std::size_t prefix_offset_ = 0;
++  std::size_t file_offset_ = 0;
++  std::size_t suffix_offset_ = 0;
+ };
+ 
+ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+diff --git a/google/cloud/internal/rest_client.h b/google/cloud/internal/rest_client.h
+index d554d4c6..48c0f0ab 100644
+--- a/google/cloud/internal/rest_client.h
++++ b/google/cloud/internal/rest_client.h
+@@ -32,6 +32,12 @@ namespace cloud {
+ namespace rest_internal {
+ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+ 
++struct MultipartUploadRequest {
++  std::string payload_prefix;
++  std::string upload_file_path;
++  std::string payload_suffix;
++};
++
+ // Provides factory function to create a CurlRestClient that does not manage a
+ // pool of connections.
+ std::unique_ptr<RestClient> MakeDefaultRestClient(std::string endpoint_address,
+@@ -82,6 +88,9 @@ class RestClient {
+   virtual StatusOr<std::unique_ptr<RestResponse>> Post(
+       RestContext& context, RestRequest const& request,
+       std::vector<absl::Span<char const>> const& payload) = 0;
++  virtual StatusOr<std::unique_ptr<RestResponse>> PostMultipart(
++      RestContext& context, RestRequest const& request,
++      MultipartUploadRequest const& payload) = 0;
+   virtual StatusOr<std::unique_ptr<RestResponse>> Post(
+       RestContext& context, RestRequest const& request,
+       std::vector<std::pair<std::string, std::string>> const& form_data) = 0;
+diff --git a/google/cloud/internal/tracing_rest_client.cc b/google/cloud/internal/tracing_rest_client.cc
+index 0badc6ff..94b7d7fb 100644
+--- a/google/cloud/internal/tracing_rest_client.cc
++++ b/google/cloud/internal/tracing_rest_client.cc
+@@ -194,6 +194,16 @@ class TracingRestClient : public RestClient {
+                           });
+   }
+ 
++  StatusOr<std::unique_ptr<RestResponse>> PostMultipart(
++      RestContext& context, RestRequest const& request,
++      MultipartUploadRequest const& payload) override {
++    return WrappedRequest(context, *propagator_, request, "POST",
++                          [this, &payload](auto& context, auto const& request) {
++                            return impl_->PostMultipart(context, request,
++                                                        payload);
++                          });
++  }
++
+   StatusOr<std::unique_ptr<RestResponse>> Post(
+       RestContext& context, RestRequest const& request,
+       std::vector<std::pair<std::string, std::string>> const& form_data)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,7 @@ set(EXTENSION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_scan.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_query.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_execute.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_load.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_client.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_extension.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/bigquery_storage.cpp

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -9,7 +9,10 @@
 
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/time.hpp"
+#include "duckdb/main/extension_helper.hpp"
 #include "duckdb/parser/column_list.hpp"
 #include "duckdb/parser/constraint.hpp"
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
@@ -18,7 +21,9 @@
 #include "duckdb/parser/parsed_data/drop_info.hpp"
 #include "duckdb/parser/parsed_expression.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 
+#include "google/cloud/bigquery/v2/job_config.pb.h"
 #include "google/cloud/bigquery/storage/v1/arrow.pb.h"
 #include "google/cloud/bigquery/storage/v1/bigquery_read_client.h"
 #include "google/cloud/bigquery/storage/v1/bigquery_read_options.h"
@@ -183,6 +188,20 @@ static google::cloud::bigquery::v2::QueryParameter BuildPositionalQueryParameter
     }
 
     return parameter;
+}
+
+static string GetLoadStagingDirectory(FileSystem &fs) {
+    auto temp_dir = FileSystem::GetEnvVariable("TMPDIR");
+    if (temp_dir.empty()) {
+        temp_dir = FileSystem::GetEnvVariable("TEMP");
+    }
+    if (temp_dir.empty()) {
+        temp_dir = FileSystem::GetEnvVariable("TMP");
+    }
+    if (temp_dir.empty()) {
+        temp_dir = FileSystem::GetWorkingDirectory();
+    }
+    return fs.ExpandPath(temp_dir);
 }
 
 } // namespace
@@ -541,6 +560,73 @@ google::cloud::bigquery::v2::Job BigqueryClient::GetJob(const string &job_id, co
 
     auto job = response.value();
     return job;
+}
+
+google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryTableRef &destination_table,
+                                                                 const string &file_path,
+                                                                 const string &write_disposition,
+                                                                 const string &create_disposition,
+                                                                 const string &location) {
+    CheckAuthentication();
+
+    auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
+        google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+
+    auto response =
+        InsertLoadJobInternal(client, destination_table, file_path, write_disposition, create_disposition, location);
+    if (!response.ok()) {
+        ThrowOnErrorStatus(response.status());
+
+        if (CheckSSLError(response.status())) {
+            return LoadParquetFile(destination_table, file_path, write_disposition, create_disposition, location);
+        }
+
+        throw BinderException("Load job submission failed: " + response.status().message());
+    }
+
+    if (!response->has_job_reference()) {
+        throw BinderException("Load job submission succeeded but did not return a job reference");
+    }
+    return WaitForJobCompletion(response->job_reference());
+}
+
+google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &table_name,
+                                                                 const BigqueryTableRef &destination_table,
+                                                                 const string &write_disposition,
+                                                                 const string &create_disposition,
+                                                                 const string &location) {
+    if (!context) {
+        throw InternalException("LoadDuckDBTable requires an active DuckDB client context");
+    }
+
+    auto &fs = FileSystem::GetFileSystem(*context);
+    auto temp_dir = GetLoadStagingDirectory(fs);
+    if (!fs.DirectoryExists(temp_dir)) {
+        fs.CreateDirectoriesRecursive(temp_dir);
+    }
+
+    auto temp_file_name = "duckdb-bigquery-load-" + StringUtil::GenerateRandomName() + ".parquet";
+    auto temp_file_path = fs.JoinPath(temp_dir, temp_file_name);
+    auto escaped_temp_file_path = StringUtil::Replace(temp_file_path, "'", "''");
+    auto relation_name = QualifiedName::Parse(table_name).ToString();
+
+    ExtensionHelper::AutoLoadExtension(*context, "parquet");
+
+    try {
+        auto copy_query =
+            "COPY (SELECT * FROM " + relation_name + ") TO '" + escaped_temp_file_path + "' (FORMAT PARQUET)";
+        auto result = context->Query(copy_query, QueryResultOutputType::FORCE_MATERIALIZED);
+        if (result->HasError()) {
+            result->ThrowError("Failed to materialize DuckDB source table for bigquery_load: ");
+        }
+
+        auto job = LoadParquetFile(destination_table, temp_file_path, write_disposition, create_disposition, location);
+        fs.TryRemoveFile(temp_file_path);
+        return job;
+    } catch (...) {
+        fs.TryRemoveFile(temp_file_path);
+        throw;
+    }
 }
 
 BigqueryTableRef BigqueryClient::GetTable(const string &dataset_id, const string &table_id) {
@@ -980,6 +1066,47 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::QueryResponse> BigqueryClie
     return job_client.Query(request);
 }
 
+google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::InsertLoadJobInternal(
+    google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
+    const BigqueryTableRef &destination_table,
+    const string &file_path,
+    const string &write_disposition,
+    const string &create_disposition,
+    const string &location) {
+    if (!context) {
+        throw InternalException("InsertLoadJobInternal requires an active DuckDB client context");
+    }
+
+    auto &fs = FileSystem::GetFileSystem(*context);
+    auto absolute_file_path = fs.ExpandPath(file_path);
+    if (!fs.FileExists(absolute_file_path)) {
+        throw IOException("Parquet file not found: %s", absolute_file_path);
+    }
+
+    google::cloud::bigquery::v2::Job job;
+    auto *job_reference = job.mutable_job_reference();
+    job_reference->set_project_id(config.BillingProject());
+    job_reference->set_job_id(GenerateJobId("load"));
+    if (!location.empty()) {
+        job_reference->mutable_location()->set_value(location);
+    }
+
+    auto *load_config = job.mutable_configuration()->mutable_load();
+    load_config->set_source_format("PARQUET");
+    load_config->set_create_disposition(create_disposition);
+    load_config->set_write_disposition(write_disposition);
+    auto *destination = load_config->mutable_destination_table();
+    destination->set_project_id(destination_table.project_id);
+    destination->set_dataset_id(destination_table.dataset_id);
+    destination->set_table_id(destination_table.table_id);
+
+    google::cloud::bigquery::v2::InsertJobRequest request;
+    request.set_project_id(config.BillingProject());
+    *request.mutable_job() = job;
+
+    return job_client.InsertJobUpload(request, absolute_file_path);
+}
+
 google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> BigqueryClient::GetQueryResultsInternal(
     google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
     const google::cloud::bigquery::v2::JobReference &job_ref,
@@ -1003,6 +1130,24 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> Bi
         throw BinderException(response.status().message());
     }
     return response;
+}
+
+google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
+    const google::cloud::bigquery::v2::JobReference &job_ref) {
+    if (job_ref.job_id().empty()) {
+        throw BinderException("Load job reference did not contain a job ID");
+    }
+
+    while (true) {
+        auto job = GetJobByReference(job_ref);
+        if (!job.has_status() || job.status().state() == "DONE") {
+            if (job.has_status()) {
+                ThrowOnJobStatusError(job.status(), "Load job");
+            }
+            return job;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
 }
 
 string BigqueryClient::GenerateJobId(const string &prefix) {
@@ -1144,6 +1289,33 @@ void BigqueryClient::CheckAuthentication() {
         "     • Set GOOGLE_APPLICATION_CREDENTIALS to your service account key file path\n"
         "  3. DuckDB secret for this project:\n"
         "     • Run: CREATE SECRET (TYPE bigquery, SCOPE 'bq://your-project', ACCESS_TOKEN 'your-token')");
+}
+
+void BigqueryClient::ThrowOnJobStatusError(const google::cloud::bigquery::v2::JobStatus &status,
+                                           const string &operation_name) {
+    if (!status.has_error_result()) {
+        return;
+    }
+
+    auto message = status.error_result().message();
+    if (message.empty()) {
+        message = operation_name + " failed";
+    }
+
+    if (!status.errors().empty()) {
+        vector<string> additional_errors;
+        additional_errors.reserve(status.errors_size());
+        for (const auto &error : status.errors()) {
+            if (!error.message().empty() && error.message() != message) {
+                additional_errors.push_back(error.message());
+            }
+        }
+        if (!additional_errors.empty()) {
+            message += " | Details: " + StringUtil::Join(additional_errors, " | ");
+        }
+    }
+
+    throw BinderException("%s failed: %s", operation_name, message);
 }
 
 void BigqueryClient::ThrowOnErrorStatus(const google::cloud::Status &status) {

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -18,6 +18,7 @@
 #include "bigquery_extension.hpp"
 #include "bigquery_geography.hpp"
 #include "bigquery_jobs.hpp"
+#include "bigquery_load.hpp"
 #include "bigquery_parser.hpp"
 #include "bigquery_query.hpp"
 #include "bigquery_scan.hpp"
@@ -48,6 +49,9 @@ static void LoadInternal(ExtensionLoader &loader) {
 
     bigquery::BigQueryListJobsFunction bigquery_list_jobs_function;
     loader.RegisterFunction(bigquery_list_jobs_function);
+
+    bigquery::BigQueryLoadFunction bigquery_load_function;
+    loader.RegisterFunction(bigquery_load_function);
 
     ScalarFunction normalize_geography("bigquery_normalize_geography",
                                        {LogicalType::GEOMETRY()},

--- a/src/bigquery_load.cpp
+++ b/src/bigquery_load.cpp
@@ -95,7 +95,8 @@ static std::optional<string> ParseOptionalAliasedStringParameter(const named_par
     auto value = ParseOptionalStringParameter(named_parameters, parameter_name);
     auto legacy_value = ParseOptionalStringParameter(named_parameters, legacy_parameter_name);
     if (value && legacy_value) {
-        throw BinderException("Cannot specify both named parameters '%s' and '%s'", parameter_name,
+        throw BinderException("Cannot specify both named parameters '%s' and '%s'",
+                              parameter_name,
                               legacy_parameter_name);
     }
     return value ? value : legacy_value;
@@ -155,8 +156,7 @@ static string MaterializeSourceTableToParquet(ClientContext &context, const stri
 
     ExtensionHelper::AutoLoadExtension(context, "parquet");
 
-    auto copy_query =
-        "COPY (SELECT * FROM " + relation_name + ") TO '" + escaped_temp_file_path + "' (FORMAT PARQUET)";
+    auto copy_query = "COPY (SELECT * FROM " + relation_name + ") TO '" + escaped_temp_file_path + "' (FORMAT PARQUET)";
 
     try {
         Parser parser(context.GetParserOptions());

--- a/src/bigquery_load.cpp
+++ b/src/bigquery_load.cpp
@@ -1,9 +1,18 @@
 #include "duckdb.hpp"
 #include "duckdb/common/exception.hpp"
+#include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/client_config.hpp"
 #include "duckdb/main/database_manager.hpp"
+#include "duckdb/main/extension_helper.hpp"
+#include "duckdb/execution/executor.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
+#include "duckdb/optimizer/optimizer.hpp"
+#include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/parser/qualified_name.hpp"
+#include "duckdb/planner/planner.hpp"
 
 #include <google/protobuf/util/json_util.h>
 
@@ -14,6 +23,7 @@
 #include "storage/bigquery_catalog.hpp"
 #include "storage/bigquery_transaction.hpp"
 
+#include <cstdio>
 #include <optional>
 
 namespace duckdb {
@@ -28,7 +38,14 @@ struct BigQueryLoadBindData : public TableFunctionData {
     string write_disposition;
     string create_disposition;
     string location;
+    bool remove_staged_source_file = false;
     bool finished = false;
+
+    ~BigQueryLoadBindData() override {
+        if (remove_staged_source_file && source_file.has_value()) {
+            std::remove(source_file->c_str());
+        }
+    }
 };
 
 struct BigQueryLoadParameters {
@@ -72,10 +89,22 @@ static std::optional<string> ParseOptionalStringParameter(const named_parameter_
     return entry->second.GetValue<string>();
 }
 
+static std::optional<string> ParseOptionalAliasedStringParameter(const named_parameter_map_t &named_parameters,
+                                                                 const string &parameter_name,
+                                                                 const string &legacy_parameter_name) {
+    auto value = ParseOptionalStringParameter(named_parameters, parameter_name);
+    auto legacy_value = ParseOptionalStringParameter(named_parameters, legacy_parameter_name);
+    if (value && legacy_value) {
+        throw BinderException("Cannot specify both named parameters '%s' and '%s'", parameter_name,
+                              legacy_parameter_name);
+    }
+    return value ? value : legacy_value;
+}
+
 static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &named_parameters) {
     BigQueryLoadParameters params;
-    params.source_file = ParseOptionalStringParameter(named_parameters, "file");
-    params.source_table = ParseOptionalStringParameter(named_parameters, "table");
+    params.source_file = ParseOptionalAliasedStringParameter(named_parameters, "source_file", "file");
+    params.source_table = ParseOptionalAliasedStringParameter(named_parameters, "source_table", "table");
     params.location = ParseOptionalStringParameter(named_parameters, "location");
     auto api_endpoint = ParseOptionalStringParameter(named_parameters, "api_endpoint");
     params.api_endpoint = api_endpoint ? *api_endpoint : string();
@@ -91,10 +120,102 @@ static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &n
     const auto source_count =
         static_cast<int>(params.source_file.has_value()) + static_cast<int>(params.source_table.has_value());
     if (source_count != 1) {
-        throw BinderException("Exactly one of the named parameters 'file' or 'table' must be provided");
+        throw BinderException(
+            "Exactly one of the named parameters 'source_file'/'file' or 'source_table'/'table' must be provided");
     }
 
     return params;
+}
+
+static string GetLoadStagingDirectory(FileSystem &fs) {
+    auto temp_dir = FileSystem::GetEnvVariable("TMPDIR");
+    if (temp_dir.empty()) {
+        temp_dir = FileSystem::GetEnvVariable("TEMP");
+    }
+    if (temp_dir.empty()) {
+        temp_dir = FileSystem::GetEnvVariable("TMP");
+    }
+    if (temp_dir.empty()) {
+        temp_dir = FileSystem::GetWorkingDirectory();
+    }
+    return fs.ExpandPath(temp_dir);
+}
+
+static string MaterializeSourceTableToParquet(ClientContext &context, const string &table_name) {
+    auto &fs = FileSystem::GetFileSystem(context);
+    auto temp_dir = GetLoadStagingDirectory(fs);
+    if (!fs.DirectoryExists(temp_dir)) {
+        fs.CreateDirectoriesRecursive(temp_dir);
+    }
+
+    auto temp_file_name = "duckdb-bigquery-load-" + StringUtil::GenerateRandomName() + ".parquet";
+    auto temp_file_path = fs.JoinPath(temp_dir, temp_file_name);
+    auto escaped_temp_file_path = StringUtil::Replace(temp_file_path, "'", "''");
+    auto relation_name = QualifiedName::Parse(table_name).ToString();
+
+    ExtensionHelper::AutoLoadExtension(context, "parquet");
+
+    auto copy_query =
+        "COPY (SELECT * FROM " + relation_name + ") TO '" + escaped_temp_file_path + "' (FORMAT PARQUET)";
+
+    try {
+        Parser parser(context.GetParserOptions());
+        parser.ParseQuery(copy_query);
+        if (parser.statements.size() != 1) {
+            throw InternalException("Expected a single COPY statement for source table materialization");
+        }
+
+        Planner logical_planner(context);
+        logical_planner.CreatePlan(std::move(parser.statements[0]));
+        auto logical_plan = std::move(logical_planner.plan);
+        if (!logical_plan) {
+            throw InternalException("Failed to plan source table materialization");
+        }
+
+#ifdef DEBUG
+        logical_plan->Verify(context);
+#endif
+        if (ClientConfig::GetConfig(context).enable_optimizer && logical_plan->RequireOptimizer()) {
+            Optimizer optimizer(*logical_planner.binder, context);
+            logical_plan = optimizer.Optimize(std::move(logical_plan));
+#ifdef DEBUG
+            logical_plan->Verify(context);
+#endif
+        }
+
+        PhysicalPlanGenerator physical_planner(context);
+        auto physical_plan = physical_planner.Plan(std::move(logical_plan));
+
+        Executor executor(context);
+        executor.Initialize(physical_plan->Root());
+
+        while (true) {
+            auto execution_result = executor.ExecuteTask(false);
+            if (execution_result == PendingExecutionResult::BLOCKED) {
+                executor.WaitForTask();
+                continue;
+            }
+            if (execution_result == PendingExecutionResult::RESULT_READY ||
+                execution_result == PendingExecutionResult::EXECUTION_FINISHED) {
+                break;
+            }
+        }
+
+        if (executor.HasResultCollector()) {
+            auto result = executor.GetResult();
+            if (result->HasError()) {
+                result->ThrowError();
+            }
+        }
+
+        return temp_file_path;
+    } catch (std::exception &ex) {
+        fs.TryRemoveFile(temp_file_path);
+        throw BinderException("Failed to materialize DuckDB source table for bigquery_load: %s", ex.what());
+    } catch (...) {
+        fs.TryRemoveFile(temp_file_path);
+        throw;
+    }
 }
 
 static void InitializeNamesAndReturnTypes(vector<LogicalType> &return_types, vector<string> &names) {
@@ -164,6 +285,12 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
     destination_table.project_id = bind_data->config.project_id;
     bind_data->destination_table = std::move(destination_table);
 
+    if (bind_data->source_table.has_value()) {
+        bind_data->source_file = MaterializeSourceTableToParquet(context, *bind_data->source_table);
+        bind_data->source_table.reset();
+        bind_data->remove_staged_source_file = true;
+    }
+
     InitializeNamesAndReturnTypes(return_types, names);
     return bind_data;
 }
@@ -217,7 +344,9 @@ BigQueryLoadFunction::BigQueryLoadFunction()
                     {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR)},
                     BigQueryLoadFunc,
                     BigQueryLoadBind) {
+    named_parameters["source_file"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["file"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["source_table"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["table"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["write_disposition"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["create_disposition"] = LogicalType(LogicalTypeId::VARCHAR);

--- a/src/bigquery_load.cpp
+++ b/src/bigquery_load.cpp
@@ -1,0 +1,229 @@
+#include "duckdb.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/main/attached_database.hpp"
+#include "duckdb/main/database_manager.hpp"
+#include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+
+#include <google/protobuf/util/json_util.h>
+
+#include "absl/status/status.h"
+#include "bigquery_client.hpp"
+#include "bigquery_load.hpp"
+#include "bigquery_settings.hpp"
+#include "storage/bigquery_catalog.hpp"
+#include "storage/bigquery_transaction.hpp"
+
+#include <optional>
+
+namespace duckdb {
+namespace bigquery {
+
+struct BigQueryLoadBindData : public TableFunctionData {
+    BigqueryConfig config;
+    shared_ptr<BigqueryClient> bq_client;
+    BigqueryTableRef destination_table;
+    std::optional<string> source_file;
+    std::optional<string> source_table;
+    string write_disposition;
+    string create_disposition;
+    string location;
+    bool finished = false;
+};
+
+struct BigQueryLoadParameters {
+    std::optional<string> source_file;
+    std::optional<string> source_table;
+    string write_disposition = "WRITE_TRUNCATE";
+    string create_disposition = "CREATE_IF_NEEDED";
+    std::optional<string> location;
+    string api_endpoint;
+};
+
+static string NormalizeEnumValue(const string &value) {
+    return StringUtil::Upper(value);
+}
+
+static string ParseEnumParameter(const named_parameter_map_t &named_parameters,
+                                 const string &parameter_name,
+                                 const string &default_value,
+                                 const vector<string> &allowed_values) {
+    auto entry = named_parameters.find(parameter_name);
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return default_value;
+    }
+
+    auto normalized = NormalizeEnumValue(entry->second.GetValue<string>());
+    for (const auto &allowed_value : allowed_values) {
+        if (normalized == allowed_value) {
+            return normalized;
+        }
+    }
+
+    throw BinderException("Invalid value for parameter '%s': %s", parameter_name, normalized);
+}
+
+static std::optional<string> ParseOptionalStringParameter(const named_parameter_map_t &named_parameters,
+                                                          const string &parameter_name) {
+    auto entry = named_parameters.find(parameter_name);
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return std::nullopt;
+    }
+    return entry->second.GetValue<string>();
+}
+
+static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &named_parameters) {
+    BigQueryLoadParameters params;
+    params.source_file = ParseOptionalStringParameter(named_parameters, "file");
+    params.source_table = ParseOptionalStringParameter(named_parameters, "table");
+    params.location = ParseOptionalStringParameter(named_parameters, "location");
+    auto api_endpoint = ParseOptionalStringParameter(named_parameters, "api_endpoint");
+    params.api_endpoint = api_endpoint ? *api_endpoint : string();
+    params.write_disposition = ParseEnumParameter(named_parameters,
+                                                  "write_disposition",
+                                                  "WRITE_TRUNCATE",
+                                                  {"WRITE_TRUNCATE", "WRITE_APPEND", "WRITE_EMPTY"});
+    params.create_disposition = ParseEnumParameter(named_parameters,
+                                                   "create_disposition",
+                                                   "CREATE_IF_NEEDED",
+                                                   {"CREATE_IF_NEEDED", "CREATE_NEVER"});
+
+    const auto source_count =
+        static_cast<int>(params.source_file.has_value()) + static_cast<int>(params.source_table.has_value());
+    if (source_count != 1) {
+        throw BinderException("Exactly one of the named parameters 'file' or 'table' must be provided");
+    }
+
+    return params;
+}
+
+static void InitializeNamesAndReturnTypes(vector<LogicalType> &return_types, vector<string> &names) {
+    names.emplace_back("success");
+    return_types.emplace_back(LogicalType(LogicalTypeId::BOOLEAN));
+
+    names.emplace_back("job_id");
+    return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+
+    names.emplace_back("project_id");
+    return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+
+    names.emplace_back("location");
+    return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+
+    names.emplace_back("destination_table");
+    return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+
+    names.emplace_back("output_rows");
+    return_types.emplace_back(LogicalType(LogicalTypeId::UBIGINT));
+
+    names.emplace_back("status");
+    return_types.emplace_back(LogicalType::JSON());
+}
+
+static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
+                                                 TableFunctionBindInput &input,
+                                                 vector<LogicalType> &return_types,
+                                                 vector<string> &names) {
+    auto dbname_or_project_id = input.inputs[0].GetValue<string>();
+    auto destination_table_string = input.inputs[1].GetValue<string>();
+    auto params = ParseLoadParameters(input.named_parameters);
+
+    auto bind_data = make_uniq<BigQueryLoadBindData>();
+    bind_data->write_disposition = params.write_disposition;
+    bind_data->create_disposition = params.create_disposition;
+    bind_data->source_file = params.source_file;
+    bind_data->source_table = params.source_table;
+    bind_data->location = params.location ? *params.location : BigquerySettings::DefaultLocation();
+
+    auto destination_table = BigqueryUtils::ParseDatasetTableString(destination_table_string);
+
+    auto &database_manager = DatabaseManager::Get(context);
+    auto database = database_manager.GetDatabase(context, dbname_or_project_id);
+    if (database) {
+        auto &catalog = database->GetCatalog();
+        if (catalog.GetCatalogType() != "bigquery") {
+            throw BinderException("Database " + dbname_or_project_id + " is not a BigQuery database");
+        }
+        if (!params.api_endpoint.empty()) {
+            throw BinderException("'api_endpoint' named parameter is not supported for attached databases");
+        }
+
+        auto &bigquery_catalog = catalog.Cast<BigqueryCatalog>();
+        auto &transaction = BigqueryTransaction::Get(context, bigquery_catalog);
+        if (transaction.GetAccessMode() == AccessMode::READ_ONLY) {
+            throw BinderException("Cannot run BigQuery load jobs in read-only transaction");
+        }
+
+        bind_data->config = bigquery_catalog.config;
+        bind_data->bq_client = transaction.GetBigqueryClient();
+    } else {
+        bind_data->config = BigqueryConfig(dbname_or_project_id).SetApiEndpoint(params.api_endpoint);
+        bind_data->bq_client = make_shared_ptr<BigqueryClient>(context, bind_data->config);
+    }
+
+    destination_table.project_id = bind_data->config.project_id;
+    bind_data->destination_table = std::move(destination_table);
+
+    InitializeNamesAndReturnTypes(return_types, names);
+    return bind_data;
+}
+
+static void BigQueryLoadFunc(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+    auto &data = data_p.bind_data->CastNoConst<BigQueryLoadBindData>();
+    if (data.finished) {
+        return;
+    }
+
+    google::cloud::bigquery::v2::Job job;
+    if (data.source_file.has_value()) {
+        job = data.bq_client->LoadParquetFile(data.destination_table,
+                                              *data.source_file,
+                                              data.write_disposition,
+                                              data.create_disposition,
+                                              data.location);
+    } else {
+        job = data.bq_client->LoadDuckDBTable(*data.source_table,
+                                              data.destination_table,
+                                              data.write_disposition,
+                                              data.create_disposition,
+                                              data.location);
+    }
+
+    std::string status_json;
+    absl::Status status = google::protobuf::util::MessageToJsonString(job.status(), &status_json);
+    if (!status.ok()) {
+        throw BinderException("Failed to convert load job status to JSON");
+    }
+
+    output.SetValue(0, 0, Value::BOOLEAN(true));
+    output.SetValue(1, 0, Value(job.job_reference().job_id()));
+    output.SetValue(2, 0, Value(job.job_reference().project_id()));
+    output.SetValue(3, 0, Value(job.job_reference().location().value()));
+    output.SetValue(4, 0, Value(BigqueryUtils::FormatTableStringSimple(data.destination_table)));
+
+    if (job.statistics().has_load() && job.statistics().load().has_output_rows()) {
+        output.SetValue(5, 0, Value::UBIGINT(job.statistics().load().output_rows().value()));
+    } else {
+        output.SetValue(5, 0, Value());
+    }
+
+    output.SetValue(6, 0, Value(status_json));
+    output.SetCardinality(1);
+    data.finished = true;
+}
+
+BigQueryLoadFunction::BigQueryLoadFunction()
+    : TableFunction("bigquery_load",
+                    {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR)},
+                    BigQueryLoadFunc,
+                    BigQueryLoadBind) {
+    named_parameters["file"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["table"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["write_disposition"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["create_disposition"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["location"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["api_endpoint"] = LogicalType(LogicalTypeId::VARCHAR);
+}
+
+} // namespace bigquery
+} // namespace duckdb

--- a/src/bigquery_proto_writer.cpp
+++ b/src/bigquery_proto_writer.cpp
@@ -48,7 +48,7 @@ string GeometryToBigqueryText(const string_t &input_geom) {
     string_t normalized_geom;
     NormalizeGeography(input_geom, normalized_geom, normalized_geom_storage);
 
-    auto text_vector = Vector(LogicalType::VARCHAR);
+    auto text_vector = Vector(LogicalType(LogicalTypeId::VARCHAR));
     auto text = Geometry::ToString(text_vector, normalized_geom);
     return text.GetString();
 }
@@ -583,7 +583,7 @@ void BigqueryProtoWriter::WriteChunk(DataChunk &chunk, const vector<idx_t> &targ
             continue;
         }
 
-        geometry_text_vectors[binding_idx] = make_uniq<Vector>(LogicalType::VARCHAR);
+        geometry_text_vectors[binding_idx] = make_uniq<Vector>(LogicalType(LogicalTypeId::VARCHAR));
         ConvertGeometryVectorToText(chunk.data[binding.source_col_idx],
                                     chunk.size(),
                                     *geometry_text_vectors[binding_idx]);

--- a/src/bigquery_utils.cpp
+++ b/src/bigquery_utils.cpp
@@ -153,6 +153,20 @@ BigqueryTableRef BigqueryUtils::ParseTableString(const string &table_string) {
     throw std::invalid_argument("Invalid table string: " + table_string);
 }
 
+BigqueryTableRef BigqueryUtils::ParseDatasetTableString(const string &table_string) {
+    std::regex pattern(R"(([^\.]+)\.([^\.]+))");
+    std::smatch matches;
+    if (!std::regex_match(table_string, matches, pattern) || matches.size() != 3) {
+        throw std::invalid_argument("Invalid destination table string: " + table_string +
+                                    ". Expected format: dataset.table");
+    }
+
+    BigqueryTableRef result;
+    result.dataset_id = matches[1].str();
+    result.table_id = matches[2].str();
+    return result;
+}
+
 std::string BigqueryUtils::FormatParentString(const string &project) {
     return "projects/" + project;
 }

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -75,6 +75,16 @@ public:
     vector<google::cloud::bigquery::v2::ListFormatJob> ListJobs(const ListJobsParams &params);
     google::cloud::bigquery::v2::Job GetJob(const string &job_id, const string &location = "");
     google::cloud::bigquery::v2::Job GetJobByReference(const google::cloud::bigquery::v2::JobReference &job_ref);
+    google::cloud::bigquery::v2::Job LoadParquetFile(const BigqueryTableRef &destination_table,
+                                                     const string &file_path,
+                                                     const string &write_disposition = "WRITE_TRUNCATE",
+                                                     const string &create_disposition = "CREATE_IF_NEEDED",
+                                                     const string &location = "");
+    google::cloud::bigquery::v2::Job LoadDuckDBTable(const string &table_name,
+                                                     const BigqueryTableRef &destination_table,
+                                                     const string &write_disposition = "WRITE_TRUNCATE",
+                                                     const string &create_disposition = "CREATE_IF_NEEDED",
+                                                     const string &location = "");
 
     google::cloud::bigquery::v2::QueryResponse ExecuteQuery(const string &query,
                                                             const string &location = "",
@@ -119,6 +129,15 @@ private:
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const google::cloud::bigquery::v2::JobReference &job_ref,
         const string &page_token = "");
+    google::cloud::StatusOr<google::cloud::bigquery::v2::Job> InsertLoadJobInternal(
+        google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
+        const BigqueryTableRef &destination_table,
+        const string &file_path,
+        const string &write_disposition,
+        const string &create_disposition,
+        const string &location);
+    google::cloud::bigquery::v2::Job WaitForJobCompletion(const google::cloud::bigquery::v2::JobReference &job_ref);
+    void ThrowOnJobStatusError(const google::cloud::bigquery::v2::JobStatus &status, const string &operation_name);
 
     void MapTableSchema(const google::cloud::bigquery::v2::TableSchema &schema,
                         ColumnList &res_columns,

--- a/src/include/bigquery_load.hpp
+++ b/src/include/bigquery_load.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+namespace bigquery {
+
+class BigQueryLoadFunction : public TableFunction {
+public:
+    BigQueryLoadFunction();
+};
+
+} // namespace bigquery
+} // namespace duckdb

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -158,6 +158,7 @@ struct BigqueryUtils {
 public:
     // static ConnectionDetails ParseConnectionString(const string &connection_string);
     static BigqueryTableRef ParseTableString(const string &table_string);
+    static BigqueryTableRef ParseDatasetTableString(const string &table_string);
 
     static std::string FormatParentString(const string &project_id);
     static std::string FormatTableString(const std::string &project_id,

--- a/test/sql/functions/function_bigquery_load.test
+++ b/test/sql/functions/function_bigquery_load.test
@@ -36,7 +36,7 @@ FROM bigquery_load(
 	'${BQ_TEST_PROJECT}',
     '${BQ_TEST_DATASET}.load_file_table',
     source_file := 'test/data/multiple_row_groups.parquet',
-	location='us-central1'
+	location='europe-west3'
 );
 ----
 true	true	true	true	true	true	true
@@ -46,7 +46,7 @@ CALL bigquery_load(
 	'bq',
 	'${BQ_TEST_DATASET}.load_file_table',
 	source_table := 'local_load_source',
-	location='us-central1'
+	location='europe-west3'
 );
 
 sleep 2 seconds
@@ -66,7 +66,7 @@ CALL bigquery_load(
 	'bq',
 	'${BQ_TEST_DATASET}.load_table_table',
 	source_table := 'local_load_source',
-	location='us-central1'
+	location='europe-west3'
 );
 
 sleep 2 seconds

--- a/test/sql/functions/function_bigquery_load.test
+++ b/test/sql/functions/function_bigquery_load.test
@@ -1,0 +1,97 @@
+# name: test/sql/functions/function_bigquery_load.test
+# description: Tests the bigquery_load(...) function
+# group: [functions]
+
+require bigquery
+require parquet
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
+
+statement ok
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`')
+
+statement ok
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_table_table`')
+
+statement ok
+CREATE OR REPLACE TEMP TABLE local_load_source AS
+SELECT *
+FROM read_parquet('test/data/multiple_row_groups.parquet');
+
+query IIIIIII
+SELECT success,
+       job_id <> '',
+       project_id = '${BQ_TEST_PROJECT}',
+       location <> '',
+       destination_table = '${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table',
+       output_rows > 0,
+       json_extract_string(status, '$.state') = 'DONE'
+FROM bigquery_load('${BQ_TEST_PROJECT}',
+                   '${BQ_TEST_DATASET}.load_file_table',
+                   file='test/data/multiple_row_groups.parquet');
+----
+true	true	true	true	true	true	true
+
+query I
+SELECT (SELECT count(*)
+        FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`'))
+       =
+       (SELECT count(*) FROM local_load_source);
+----
+true
+
+statement ok
+CREATE OR REPLACE TEMP TABLE local_single_row AS
+SELECT *
+FROM local_load_source
+LIMIT 1;
+
+statement ok
+CALL bigquery_load('bq', '${BQ_TEST_DATASET}.load_file_table', table='local_single_row');
+
+query I
+SELECT count(*) = 1
+FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`');
+----
+true
+
+statement ok
+CREATE OR REPLACE TEMP TABLE load_job_info AS
+SELECT job_id
+FROM bigquery_load('bq', '${BQ_TEST_DATASET}.load_table_table', table='local_load_source');
+
+query I
+SELECT (SELECT count(*)
+        FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_table_table`'))
+       =
+       (SELECT count(*) FROM local_load_source);
+----
+true
+
+query II
+SELECT state, job_type
+FROM bigquery_jobs('bq', maxResults=20)
+WHERE job_id = (SELECT job_id FROM load_job_info);
+----
+Completed	LOAD
+
+statement ok
+COPY (SELECT 'not parquet') TO '/tmp/bigquery_load_invalid_${BQ_TEST_PROJECT}.csv' (FORMAT CSV, HEADER false);
+
+statement error
+CALL bigquery_load('${BQ_TEST_PROJECT}',
+                   '${BQ_TEST_DATASET}.load_invalid_table',
+                   file='/tmp/bigquery_load_invalid_${BQ_TEST_PROJECT}.csv');
+----
+<REGEX>:Binder Error: Load job failed: .+
+
+statement ok
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`')
+
+statement ok
+CALL bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_table_table`')

--- a/test/sql/functions/function_bigquery_load.test
+++ b/test/sql/functions/function_bigquery_load.test
@@ -3,6 +3,7 @@
 # group: [functions]
 
 require bigquery
+
 require parquet
 
 require-env BQ_TEST_PROJECT
@@ -13,85 +14,75 @@ statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
 statement ok
-CALL bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`')
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_file_table;
 
 statement ok
-CALL bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_table_table`')
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_table_table;
 
 statement ok
 CREATE OR REPLACE TEMP TABLE local_load_source AS
-SELECT *
-FROM read_parquet('test/data/multiple_row_groups.parquet');
+SELECT * FROM read_parquet('test/data/multiple_row_groups.parquet');
 
 query IIIIIII
-SELECT success,
-       job_id <> '',
-       project_id = '${BQ_TEST_PROJECT}',
-       location <> '',
-       destination_table = '${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table',
-       output_rows > 0,
-       json_extract_string(status, '$.state') = 'DONE'
-FROM bigquery_load('${BQ_TEST_PROJECT}',
-                   '${BQ_TEST_DATASET}.load_file_table',
-                   file='test/data/multiple_row_groups.parquet');
+SELECT
+	success,
+	job_id <> '',
+	project_id = '${BQ_TEST_PROJECT}',
+	location <> '',
+	destination_table = '${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table',
+	output_rows > 0,
+	status = '{"state":"DONE"}'
+FROM bigquery_load(
+	'${BQ_TEST_PROJECT}',
+    '${BQ_TEST_DATASET}.load_file_table',
+    source_file := 'test/data/multiple_row_groups.parquet',
+	location='us-central1'
+);
 ----
 true	true	true	true	true	true	true
 
+statement ok
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_table := 'local_load_source',
+	location='us-central1'
+);
+
+sleep 2 seconds
+
 query I
-SELECT (SELECT count(*)
-        FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`'))
-       =
-       (SELECT count(*) FROM local_load_source);
+SELECT (
+	SELECT count(*)
+	FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`')
+) = (
+	SELECT count(*) FROM local_load_source
+);
 ----
 true
 
 statement ok
-CREATE OR REPLACE TEMP TABLE local_single_row AS
-SELECT *
-FROM local_load_source
-LIMIT 1;
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_table_table',
+	source_table := 'local_load_source',
+	location='us-central1'
+);
 
-statement ok
-CALL bigquery_load('bq', '${BQ_TEST_DATASET}.load_file_table', table='local_single_row');
+sleep 2 seconds
 
 query I
-SELECT count(*) = 1
-FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`');
+SELECT (
+	SELECT count(*)
+    FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_table_table`')
+) = (
+	SELECT count(*) FROM local_load_source
+);
 ----
 true
 
 statement ok
-CREATE OR REPLACE TEMP TABLE load_job_info AS
-SELECT job_id
-FROM bigquery_load('bq', '${BQ_TEST_DATASET}.load_table_table', table='local_load_source');
-
-query I
-SELECT (SELECT count(*)
-        FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_table_table`'))
-       =
-       (SELECT count(*) FROM local_load_source);
-----
-true
-
-query II
-SELECT state, job_type
-FROM bigquery_jobs('bq', maxResults=20)
-WHERE job_id = (SELECT job_id FROM load_job_info);
-----
-Completed	LOAD
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_file_table;
 
 statement ok
-COPY (SELECT 'not parquet') TO '/tmp/bigquery_load_invalid_${BQ_TEST_PROJECT}.csv' (FORMAT CSV, HEADER false);
-
-statement error
-CALL bigquery_load('${BQ_TEST_PROJECT}',
-                   '${BQ_TEST_DATASET}.load_invalid_table',
-                   file='/tmp/bigquery_load_invalid_${BQ_TEST_PROJECT}.csv');
-----
-<REGEX>:Binder Error: Load job failed: .+
-
-statement ok
-CALL bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table`')
-
-statement ok
-CALL bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_table_table`')
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_table_table;


### PR DESCRIPTION
This PR adds `bigquery_load`, a new table function for loading local Parquet data into BigQuery through BigQuery load jobs.

The main goal is to support a write path that does not go through the Storage Write API and does not require a GCS bucket as an intermediate step. Instead, the extension now submits a BigQuery load job using the upload endpoint and sends the file contents directly as multipart job upload data.

What is included in this PR:

- A new `bigquery_load(...)` table function
- Support for loading from a local Parquet file via `file := '...'`
- Support for loading from a local DuckDB table or view via `table := '...'`
- Polling of the submitted load job until `DONE`
- Propagation of BigQuery load job errors back to DuckDB
- Integration tests for file-based loads, table-based loads, overwrite behavior, job visibility, and failure cases

The function has the following shape:

```sql
bigquery_load(
  db_or_project,
  destination_table,
  file := NULL,
  table := NULL,
  write_disposition := 'WRITE_TRUNCATE',
  create_disposition := 'CREATE_IF_NEEDED',
  location := NULL,
  api_endpoint := NULL
)