### PR TITLE
Add billing_project support in bigquery_load

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,19 @@ D CALL bigquery_load(
 └─────────┴──────────────────────────────┴────────────────┴──────────┴──────────────────────────────────────────────┴─────────────┴──────────────────┘
 ```
 
+To bill the load job to a separate project when calling `bigquery_load` with a project ID, pass `billing_project`:
+
+```sql
+D CALL bigquery_load(
+    'my_storage_project',
+    'my_dataset.target_table',
+    source_file := '/path/to/data.parquet',
+    billing_project := 'my_billing_project'
+);
+```
+
+For attached databases, configure cross-project billing in the `ATTACH` string instead of passing `billing_project` to `bigquery_load`.
+
 Compared to `CREATE TABLE ... AS` or `INSERT INTO ...`, `bigquery_load` uses a different write path:
 
 - `CREATE TABLE ... AS` and `INSERT INTO bq...` use the BigQuery Storage Write API and stream rows with `AppendRows`.
@@ -425,6 +438,7 @@ The `bigquery_load` function supports the following named parameters:
 | `write_disposition`  | `VARCHAR` | BigQuery write behavior: `WRITE_TRUNCATE` (default), `WRITE_APPEND`, or `WRITE_EMPTY`. |
 | `create_disposition` | `VARCHAR` | BigQuery create behavior: `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`.              |
 | `location`           | `VARCHAR` | BigQuery job location.                                                                 |
+| `billing_project`    | `VARCHAR` | Project ID to bill for the load job. Only supported for direct project-ID calls.       |
 
 Exactly one of `source_file` or `source_table` must be provided.
 

--- a/src/bigquery_load.cpp
+++ b/src/bigquery_load.cpp
@@ -54,6 +54,7 @@ struct BigQueryLoadParameters {
     string write_disposition = "WRITE_TRUNCATE";
     string create_disposition = "CREATE_IF_NEEDED";
     std::optional<string> location;
+    string billing_project;
     string api_endpoint;
 };
 
@@ -107,6 +108,8 @@ static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &n
     params.source_file = ParseOptionalAliasedStringParameter(named_parameters, "source_file", "file");
     params.source_table = ParseOptionalAliasedStringParameter(named_parameters, "source_table", "table");
     params.location = ParseOptionalStringParameter(named_parameters, "location");
+    auto billing_project = ParseOptionalStringParameter(named_parameters, "billing_project");
+    params.billing_project = billing_project ? *billing_project : string();
     auto api_endpoint = ParseOptionalStringParameter(named_parameters, "api_endpoint");
     params.api_endpoint = api_endpoint ? *api_endpoint : string();
     params.write_disposition = ParseEnumParameter(named_parameters,
@@ -265,6 +268,10 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
         if (catalog.GetCatalogType() != "bigquery") {
             throw BinderException("Database " + dbname_or_project_id + " is not a BigQuery database");
         }
+        if (!params.billing_project.empty()) {
+            throw BinderException("'billing_project' named parameter is not supported for attached databases; "
+                                  "set billing_project in ATTACH instead");
+        }
         if (!params.api_endpoint.empty()) {
             throw BinderException("'api_endpoint' named parameter is not supported for attached databases");
         }
@@ -278,7 +285,9 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
         bind_data->config = bigquery_catalog.config;
         bind_data->bq_client = transaction.GetBigqueryClient();
     } else {
-        bind_data->config = BigqueryConfig(dbname_or_project_id).SetApiEndpoint(params.api_endpoint);
+        bind_data->config = BigqueryConfig(dbname_or_project_id)
+                                .SetBillingProjectId(params.billing_project)
+                                .SetApiEndpoint(params.api_endpoint);
         bind_data->bq_client = make_shared_ptr<BigqueryClient>(context, bind_data->config);
     }
 
@@ -351,6 +360,7 @@ BigQueryLoadFunction::BigQueryLoadFunction()
     named_parameters["write_disposition"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["create_disposition"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["location"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["billing_project"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["api_endpoint"] = LogicalType(LogicalTypeId::VARCHAR);
 }
 


### PR DESCRIPTION
### Summary
- Added billing_project named parameter to `bigquery_load(...)`.
- Direct `bigquery_load(project, ...)` calls now create load jobs under the billing project while keeping the destination table in the storage project.
- Attached BigQuery databases now reject per-call `billing_project` overrides and require billing configuration via `ATTACH`.
- Updated README docs with the new parameter and usage example.