### PR TITLE
Add bigquery_load support for GCS source URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ The `bigquery_execute` function supports the following named parameters:
 
 ### `bigquery_load` Function
 
-The `bigquery_load` function submits a BigQuery load job that writes data into a destination BigQuery table. The source can either be a local Parquet file (`source_file`) or a DuckDB table/view (`source_table`).
+The `bigquery_load` function submits a BigQuery load job that writes data into a destination BigQuery table. The source can be a local Parquet file (`source_file`), one or more Cloud Storage Parquet URIs (`source_uris`), or a DuckDB table/view (`source_table`).
 
 ```sql
 D SELECT * FROM bigquery_load(
@@ -407,12 +407,20 @@ D CALL bigquery_load(
 ├─────────┼──────────────────────────────┼────────────────┼──────────┼──────────────────────────────────────────────┼─────────────┼──────────────────┤
 │ true    │ job_duckdb_load_wifsj1ffusqo │ my_gcp_project │ EU       │ my_gcp_project.my_dataset.target_table       │       10878 │ {"state":"DONE"} │
 └─────────┴──────────────────────────────┴────────────────┴──────────┴──────────────────────────────────────────────┴─────────────┴──────────────────┘
+
+D CALL bigquery_load(
+    'bq',
+    'my_dataset.target_table',
+    source_uris := ['gs://my_bucket/path/part-1.parquet', 'gs://my_bucket/path/part-2.parquet'],
+    write_disposition := 'WRITE_APPEND',
+    location := 'EU'
+);
 ```
 
 Compared to `CREATE TABLE ... AS` or `INSERT INTO ...`, `bigquery_load` uses a different write path:
 
 - `CREATE TABLE ... AS` and `INSERT INTO bq...` use the BigQuery Storage Write API and stream rows with `AppendRows`.
-- `bigquery_load` uses a BigQuery load job. With `source_file` it loads a Parquet file directly; with `source_table` it first stages the DuckDB relation as a temporary Parquet file and then submits the load job.
+- `bigquery_load` uses a BigQuery load job. With a local `source_file` it uploads a Parquet file directly; with `source_uris` it passes Cloud Storage URIs directly to BigQuery; with `source_table` it first stages the DuckDB relation as a temporary Parquet file and then submits the load job.
 
 Use `CREATE TABLE ... AS` when you want the normal streaming write path from a DuckDB query result. Use `bigquery_load` when you already have Parquet files or when you explicitly want load-job semantics such as `write_disposition` and `create_disposition`.
 
@@ -420,13 +428,14 @@ The `bigquery_load` function supports the following named parameters:
 
 | Parameter            | Type      | Description                                                                            |
 | -------------------- | --------- | -------------------------------------------------------------------------------------- |
-| `source_file`        | `VARCHAR` | Path to a local Parquet file to load.                                                  |
+| `source_file`        | `VARCHAR` | Path to a local Parquet file to upload, or a single `gs://` Parquet URI to load directly from Cloud Storage. |
+| `source_uris`        | `VARCHAR` or `LIST<VARCHAR>` | One or more `gs://` Parquet URIs to load directly from Cloud Storage. Each URI can contain one `*` wildcard after the bucket name. |
 | `source_table`       | `VARCHAR` | Name of a DuckDB table or view to load.                                                |
 | `write_disposition`  | `VARCHAR` | BigQuery write behavior: `WRITE_TRUNCATE` (default), `WRITE_APPEND`, or `WRITE_EMPTY`. |
 | `create_disposition` | `VARCHAR` | BigQuery create behavior: `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`.              |
 | `location`           | `VARCHAR` | BigQuery job location.                                                                 |
 
-Exactly one of `source_file` or `source_table` must be provided.
+Exactly one of `source_file`, `source_uris`, or `source_table` must be provided. For Cloud Storage loads, the BigQuery job identity needs permission to read the objects, and the bucket location must be compatible with the destination dataset location.
 
 ### `bigquery_jobs` Function
 

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -23,13 +23,13 @@
 #include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 
-#include "google/cloud/bigquery/v2/job_config.pb.h"
 #include "google/cloud/bigquery/storage/v1/arrow.pb.h"
 #include "google/cloud/bigquery/storage/v1/bigquery_read_client.h"
 #include "google/cloud/bigquery/storage/v1/bigquery_read_options.h"
 #include "google/cloud/bigquery/storage/v1/bigquery_write_options.h"
 #include "google/cloud/bigquery/storage/v1/storage.pb.h"
 #include "google/cloud/bigquery/storage/v1/stream.pb.h"
+#include "google/cloud/bigquery/v2/job_config.pb.h"
 
 #include "google/cloud/bigquerycontrol/v2/dataset_client.h"
 #include "google/cloud/bigquerycontrol/v2/job_client.h"
@@ -593,6 +593,50 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryT
     return WaitForJobCompletion(response->job_reference());
 }
 
+google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryTableRef &destination_table,
+                                                                 const vector<string> &source_uris,
+                                                                 const string &write_disposition,
+                                                                 const string &create_disposition,
+                                                                 const string &location) {
+    if (source_uris.empty()) {
+        throw BinderException("At least one source URI must be provided for a BigQuery load job");
+    }
+    for (const auto &source_uri : source_uris) {
+        if (source_uri.empty()) {
+            throw BinderException("BigQuery load source URIs cannot be empty");
+        }
+        if (!StringUtil::CIStartsWith(source_uri, "gs://")) {
+            throw BinderException("BigQuery Parquet load source URI must use the gs:// scheme: %s", source_uri);
+        }
+    }
+
+    CheckAuthentication();
+
+    auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
+        google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+
+    auto response = InsertLoadJobFromUrisInternal(client,
+                                                  destination_table,
+                                                  source_uris,
+                                                  write_disposition,
+                                                  create_disposition,
+                                                  location);
+    if (!response.ok()) {
+        ThrowOnErrorStatus(response.status());
+
+        if (CheckSSLError(response.status())) {
+            return LoadParquetUris(destination_table, source_uris, write_disposition, create_disposition, location);
+        }
+
+        throw BinderException("Load job submission failed: " + response.status().message());
+    }
+
+    if (!response->has_job_reference()) {
+        throw BinderException("Load job submission succeeded but did not return a job reference");
+    }
+    return WaitForJobCompletion(response->job_reference());
+}
+
 google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &table_name,
                                                                  const BigqueryTableRef &destination_table,
                                                                  const string &write_disposition,
@@ -1082,23 +1126,11 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::QueryResponse> BigqueryClie
     return job_client.Query(request);
 }
 
-google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::InsertLoadJobInternal(
-    google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
+google::cloud::bigquery::v2::InsertJobRequest BigqueryClient::BuildLoadJobRequest(
     const BigqueryTableRef &destination_table,
-    const string &file_path,
     const string &write_disposition,
     const string &create_disposition,
     const string &location) {
-    if (!context) {
-        throw InternalException("InsertLoadJobInternal requires an active DuckDB client context");
-    }
-
-    auto &fs = FileSystem::GetFileSystem(*context);
-    auto absolute_file_path = fs.ExpandPath(file_path);
-    if (!fs.FileExists(absolute_file_path)) {
-        throw IOException("Parquet file not found: %s", absolute_file_path);
-    }
-
     google::cloud::bigquery::v2::Job job;
     auto *job_reference = job.mutable_job_reference();
     job_reference->set_project_id(config.BillingProject());
@@ -1119,8 +1151,45 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::Insert
     google::cloud::bigquery::v2::InsertJobRequest request;
     request.set_project_id(config.BillingProject());
     *request.mutable_job() = job;
+    return request;
+}
+
+google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::InsertLoadJobInternal(
+    google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
+    const BigqueryTableRef &destination_table,
+    const string &file_path,
+    const string &write_disposition,
+    const string &create_disposition,
+    const string &location) {
+    if (!context) {
+        throw InternalException("InsertLoadJobInternal requires an active DuckDB client context");
+    }
+
+    auto &fs = FileSystem::GetFileSystem(*context);
+    auto absolute_file_path = fs.ExpandPath(file_path);
+    if (!fs.FileExists(absolute_file_path)) {
+        throw IOException("Parquet file not found: %s", absolute_file_path);
+    }
+
+    auto request = BuildLoadJobRequest(destination_table, write_disposition, create_disposition, location);
 
     return job_client.InsertJobUpload(request, absolute_file_path);
+}
+
+google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::InsertLoadJobFromUrisInternal(
+    google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
+    const BigqueryTableRef &destination_table,
+    const vector<string> &source_uris,
+    const string &write_disposition,
+    const string &create_disposition,
+    const string &location) {
+    auto request = BuildLoadJobRequest(destination_table, write_disposition, create_disposition, location);
+    auto *load_config = request.mutable_job()->mutable_configuration()->mutable_load();
+    for (const auto &source_uri : source_uris) {
+        load_config->add_source_uris(source_uri);
+    }
+
+    return job_client.InsertJob(request);
 }
 
 google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> BigqueryClient::GetQueryResultsInternal(

--- a/src/bigquery_load.cpp
+++ b/src/bigquery_load.cpp
@@ -2,15 +2,15 @@
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/file_system.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/execution/executor.hpp"
+#include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/client_config.hpp"
 #include "duckdb/main/database_manager.hpp"
 #include "duckdb/main/extension_helper.hpp"
-#include "duckdb/execution/executor.hpp"
-#include "duckdb/execution/physical_plan_generator.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
-#include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
+#include "duckdb/parser/parser.hpp"
 #include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/planner/planner.hpp"
 
@@ -34,6 +34,7 @@ struct BigQueryLoadBindData : public TableFunctionData {
     shared_ptr<BigqueryClient> bq_client;
     BigqueryTableRef destination_table;
     std::optional<string> source_file;
+    vector<string> source_uris;
     std::optional<string> source_table;
     string write_disposition;
     string create_disposition;
@@ -50,6 +51,7 @@ struct BigQueryLoadBindData : public TableFunctionData {
 
 struct BigQueryLoadParameters {
     std::optional<string> source_file;
+    vector<string> source_uris;
     std::optional<string> source_table;
     string write_disposition = "WRITE_TRUNCATE";
     string create_disposition = "CREATE_IF_NEEDED";
@@ -89,6 +91,33 @@ static std::optional<string> ParseOptionalStringParameter(const named_parameter_
     return entry->second.GetValue<string>();
 }
 
+static std::optional<vector<string>> ParseOptionalSourceUrisParameter(const named_parameter_map_t &named_parameters,
+                                                                      const string &parameter_name) {
+    auto entry = named_parameters.find(parameter_name);
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return std::nullopt;
+    }
+
+    if (entry->second.type().id() == LogicalTypeId::VARCHAR) {
+        return vector<string>{entry->second.GetValue<string>()};
+    }
+    if (entry->second.type().id() != LogicalTypeId::LIST) {
+        throw BinderException("Parameter '%s' must be a VARCHAR or LIST<VARCHAR>", parameter_name);
+    }
+
+    vector<string> result;
+    for (const auto &child : ListValue::GetChildren(entry->second)) {
+        if (child.IsNull()) {
+            throw BinderException("Null entries are not allowed in parameter '%s'", parameter_name);
+        }
+        if (child.type().id() != LogicalTypeId::VARCHAR) {
+            throw BinderException("Parameter '%s' must contain only VARCHAR entries", parameter_name);
+        }
+        result.push_back(child.GetValue<string>());
+    }
+    return result;
+}
+
 static std::optional<string> ParseOptionalAliasedStringParameter(const named_parameter_map_t &named_parameters,
                                                                  const string &parameter_name,
                                                                  const string &legacy_parameter_name) {
@@ -106,6 +135,13 @@ static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &n
     BigQueryLoadParameters params;
     params.source_file = ParseOptionalAliasedStringParameter(named_parameters, "source_file", "file");
     params.source_table = ParseOptionalAliasedStringParameter(named_parameters, "source_table", "table");
+    auto source_uris = ParseOptionalSourceUrisParameter(named_parameters, "source_uris");
+    if (source_uris) {
+        params.source_uris = *source_uris;
+    }
+    if (source_uris && source_uris->empty()) {
+        throw BinderException("Parameter 'source_uris' must contain at least one URI");
+    }
     params.location = ParseOptionalStringParameter(named_parameters, "location");
     auto api_endpoint = ParseOptionalStringParameter(named_parameters, "api_endpoint");
     params.api_endpoint = api_endpoint ? *api_endpoint : string();
@@ -118,14 +154,30 @@ static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &n
                                                    "CREATE_IF_NEEDED",
                                                    {"CREATE_IF_NEEDED", "CREATE_NEVER"});
 
-    const auto source_count =
-        static_cast<int>(params.source_file.has_value()) + static_cast<int>(params.source_table.has_value());
+    const auto source_count = static_cast<int>(params.source_file.has_value()) +
+                              static_cast<int>(params.source_table.has_value()) +
+                              static_cast<int>(source_uris.has_value());
     if (source_count != 1) {
-        throw BinderException(
-            "Exactly one of the named parameters 'source_file'/'file' or 'source_table'/'table' must be provided");
+        throw BinderException("Exactly one of the named parameters 'source_file'/'file', 'source_uris', or "
+                              "'source_table'/'table' must be provided");
     }
 
     return params;
+}
+
+static bool IsGcsUri(const string &source) {
+    return StringUtil::CIStartsWith(source, "gs://");
+}
+
+static void ValidateGcsSourceUris(const vector<string> &source_uris) {
+    for (const auto &source_uri : source_uris) {
+        if (source_uri.empty()) {
+            throw BinderException("BigQuery load source URIs cannot be empty");
+        }
+        if (!IsGcsUri(source_uri)) {
+            throw BinderException("BigQuery Parquet load source URI must use the gs:// scheme: %s", source_uri);
+        }
+    }
 }
 
 static string GetLoadStagingDirectory(FileSystem &fs) {
@@ -253,6 +305,7 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
     bind_data->write_disposition = params.write_disposition;
     bind_data->create_disposition = params.create_disposition;
     bind_data->source_file = params.source_file;
+    bind_data->source_uris = params.source_uris;
     bind_data->source_table = params.source_table;
     bind_data->location = params.location ? *params.location : BigquerySettings::DefaultLocation();
 
@@ -285,6 +338,14 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
     destination_table.project_id = bind_data->config.project_id;
     bind_data->destination_table = std::move(destination_table);
 
+    if (bind_data->source_file.has_value() && IsGcsUri(*bind_data->source_file)) {
+        bind_data->source_uris.push_back(*bind_data->source_file);
+        bind_data->source_file.reset();
+    }
+    if (!bind_data->source_uris.empty()) {
+        ValidateGcsSourceUris(bind_data->source_uris);
+    }
+
     if (bind_data->source_table.has_value()) {
         bind_data->source_file = MaterializeSourceTableToParquet(context, *bind_data->source_table);
         bind_data->source_table.reset();
@@ -308,12 +369,14 @@ static void BigQueryLoadFunc(ClientContext &context, TableFunctionInput &data_p,
                                               data.write_disposition,
                                               data.create_disposition,
                                               data.location);
-    } else {
-        job = data.bq_client->LoadDuckDBTable(*data.source_table,
-                                              data.destination_table,
+    } else if (!data.source_uris.empty()) {
+        job = data.bq_client->LoadParquetUris(data.destination_table,
+                                              data.source_uris,
                                               data.write_disposition,
                                               data.create_disposition,
                                               data.location);
+    } else {
+        throw InternalException("bigquery_load has no source to load");
     }
 
     std::string status_json;
@@ -346,6 +409,7 @@ BigQueryLoadFunction::BigQueryLoadFunction()
                     BigQueryLoadBind) {
     named_parameters["source_file"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["file"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["source_uris"] = LogicalType::ANY;
     named_parameters["source_table"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["table"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["write_disposition"] = LogicalType(LogicalTypeId::VARCHAR);

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -80,6 +80,11 @@ public:
                                                      const string &write_disposition = "WRITE_TRUNCATE",
                                                      const string &create_disposition = "CREATE_IF_NEEDED",
                                                      const string &location = "");
+    google::cloud::bigquery::v2::Job LoadParquetUris(const BigqueryTableRef &destination_table,
+                                                     const vector<string> &source_uris,
+                                                     const string &write_disposition = "WRITE_TRUNCATE",
+                                                     const string &create_disposition = "CREATE_IF_NEEDED",
+                                                     const string &location = "");
     google::cloud::bigquery::v2::Job LoadDuckDBTable(const string &table_name,
                                                      const BigqueryTableRef &destination_table,
                                                      const string &write_disposition = "WRITE_TRUNCATE",
@@ -129,10 +134,21 @@ private:
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const google::cloud::bigquery::v2::JobReference &job_ref,
         const string &page_token = "");
+    google::cloud::bigquery::v2::InsertJobRequest BuildLoadJobRequest(const BigqueryTableRef &destination_table,
+                                                                      const string &write_disposition,
+                                                                      const string &create_disposition,
+                                                                      const string &location);
     google::cloud::StatusOr<google::cloud::bigquery::v2::Job> InsertLoadJobInternal(
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const BigqueryTableRef &destination_table,
         const string &file_path,
+        const string &write_disposition,
+        const string &create_disposition,
+        const string &location);
+    google::cloud::StatusOr<google::cloud::bigquery::v2::Job> InsertLoadJobFromUrisInternal(
+        google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
+        const BigqueryTableRef &destination_table,
+        const vector<string> &source_uris,
         const string &write_disposition,
         const string &create_disposition,
         const string &location);


### PR DESCRIPTION
Adds support for loading Parquet files from `gs://` URIs through `bigquery_load` without local staging. `source_uris` now accepts a single URI or a list of URIs and passes them directly to BigQuery load jobs via `configuration.load.source_uris`; local `source_file` uploads and `source_table` staging keep their existing behavior.

```sql
-- Single GCS object
CALL bigquery_load(
    'bq',
    'my_dataset.target_table',
    source_uris := 'gs://my_bucket/path/data.parquet',
    write_disposition := 'WRITE_TRUNCATE',
    location := 'EU'
);

-- Multiple GCS objects
CALL bigquery_load(
    'bq',
    'my_dataset.target_table',
    source_uris := [
        'gs://my_bucket/path/part-000.parquet',
        'gs://my_bucket/path/part-001.parquet'
    ],
    write_disposition := 'WRITE_APPEND',
    location := 'EU'
);
```