### PR TITLE
Add job labels support to bigquery_load

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,26 +424,17 @@ D CALL bigquery_load(
 └─────────┴──────────────────────────────┴────────────────┴──────────┴──────────────────────────────────────────────┴─────────────┴──────────────────┘
 
 D CALL bigquery_load(
-    'bq',
+    'my_storage_project',
     'my_dataset.target_table',
     source_uris := ['gs://my_bucket/path/part-1.parquet', 'gs://my_bucket/path/part-2.parquet'],
     write_disposition := 'WRITE_APPEND',
-    location := 'EU'
-);
-```
-
-To bill the load job to a separate project when calling `bigquery_load` with a project ID, pass `billing_project`:
-
-```sql
-D CALL bigquery_load(
-    'my_storage_project',
-    'my_dataset.target_table',
-    source_file := '/path/to/data.parquet',
+    location := 'EU',
+    labels := MAP {'pipeline': 'daily_load', 'env': 'prod'},
     billing_project := 'my_billing_project'
 );
 ```
 
-For attached databases, configure cross-project billing in the `ATTACH` string instead of passing `billing_project` to `bigquery_load`.
+Use `source_uris` to load one or more Cloud Storage objects directly. To attach labels to the BigQuery load job for billing or audit workflows, pass `labels` as a `MAP(VARCHAR, VARCHAR)`. When calling `bigquery_load` with a project ID, pass `billing_project` to bill the load job to a separate project. For attached databases, configure cross-project billing in the `ATTACH` string instead of passing `billing_project` to `bigquery_load`.
 
 Compared to `CREATE TABLE ... AS` or `INSERT INTO ...`, `bigquery_load` uses a different write path:
 
@@ -463,6 +454,7 @@ The `bigquery_load` function supports the following named parameters:
 | `create_disposition` | `VARCHAR` | BigQuery create behavior: `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`.              |
 | `location`           | `VARCHAR` | BigQuery job location.                                                                 |
 | `billing_project`    | `VARCHAR` | Project ID to bill for the load job. Only supported for direct project-ID calls.       |
+| `labels`             | `MAP(VARCHAR, VARCHAR)` | BigQuery job labels to attach to the load job.                                         |
 
 Exactly one of `source_file`, `source_uris`, or `source_table` must be provided. For Cloud Storage loads, the BigQuery job identity needs permission to read the objects, and the bucket location must be compatible with the destination dataset location.
 

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -567,19 +567,30 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryT
                                                                  const string &file_path,
                                                                  const string &write_disposition,
                                                                  const string &create_disposition,
-                                                                 const string &location) {
+                                                                 const string &location,
+                                                                 const std::map<string, string> &labels) {
     CheckAuthentication();
 
     auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
         google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
 
-    auto response =
-        InsertLoadJobInternal(client, destination_table, file_path, write_disposition, create_disposition, location);
+    auto response = InsertLoadJobInternal(client,
+                                          destination_table,
+                                          file_path,
+                                          write_disposition,
+                                          create_disposition,
+                                          location,
+                                          labels);
     if (!response.ok()) {
         ThrowOnErrorStatus(response.status());
 
         if (CheckSSLError(response.status())) {
-            return LoadParquetFile(destination_table, file_path, write_disposition, create_disposition, location);
+            return LoadParquetFile(destination_table,
+                                   file_path,
+                                   write_disposition,
+                                   create_disposition,
+                                   location,
+                                   labels);
         }
 
         throw BinderException("Load job submission failed: " + response.status().message());
@@ -595,7 +606,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryT
                                                                  const vector<string> &source_uris,
                                                                  const string &write_disposition,
                                                                  const string &create_disposition,
-                                                                 const string &location) {
+                                                                 const string &location,
+                                                                 const std::map<string, string> &labels) {
     if (source_uris.empty()) {
         throw BinderException("At least one source URI must be provided for a BigQuery load job");
     }
@@ -618,12 +630,18 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryT
                                                   source_uris,
                                                   write_disposition,
                                                   create_disposition,
-                                                  location);
+                                                  location,
+                                                  labels);
     if (!response.ok()) {
         ThrowOnErrorStatus(response.status());
 
         if (CheckSSLError(response.status())) {
-            return LoadParquetUris(destination_table, source_uris, write_disposition, create_disposition, location);
+            return LoadParquetUris(destination_table,
+                                   source_uris,
+                                   write_disposition,
+                                   create_disposition,
+                                   location,
+                                   labels);
         }
 
         throw BinderException("Load job submission failed: " + response.status().message());
@@ -639,7 +657,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &t
                                                                  const BigqueryTableRef &destination_table,
                                                                  const string &write_disposition,
                                                                  const string &create_disposition,
-                                                                 const string &location) {
+                                                                 const string &location,
+                                                                 const std::map<string, string> &labels) {
     if (!context) {
         throw InternalException("LoadDuckDBTable requires an active DuckDB client context");
     }
@@ -665,7 +684,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &t
             result->ThrowError("Failed to materialize DuckDB source table for bigquery_load: ");
         }
 
-        auto job = LoadParquetFile(destination_table, temp_file_path, write_disposition, create_disposition, location);
+        auto job =
+            LoadParquetFile(destination_table, temp_file_path, write_disposition, create_disposition, location, labels);
         fs.TryRemoveFile(temp_file_path);
         return job;
     } catch (...) {
@@ -1128,7 +1148,8 @@ google::cloud::bigquery::v2::InsertJobRequest BigqueryClient::BuildLoadJobReques
     const BigqueryTableRef &destination_table,
     const string &write_disposition,
     const string &create_disposition,
-    const string &location) {
+    const string &location,
+    const std::map<string, string> &labels) {
     google::cloud::bigquery::v2::Job job;
     auto *job_reference = job.mutable_job_reference();
     job_reference->set_project_id(config.BillingProject());
@@ -1137,7 +1158,15 @@ google::cloud::bigquery::v2::InsertJobRequest BigqueryClient::BuildLoadJobReques
         job_reference->mutable_location()->set_value(location);
     }
 
-    auto *load_config = job.mutable_configuration()->mutable_load();
+    auto *job_config = job.mutable_configuration();
+    if (!labels.empty()) {
+        auto *job_labels = job_config->mutable_labels();
+        for (const auto &label : labels) {
+            (*job_labels)[label.first] = label.second;
+        }
+    }
+
+    auto *load_config = job_config->mutable_load();
     load_config->set_source_format("PARQUET");
     load_config->set_create_disposition(create_disposition);
     load_config->set_write_disposition(write_disposition);
@@ -1158,7 +1187,8 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::Insert
     const string &file_path,
     const string &write_disposition,
     const string &create_disposition,
-    const string &location) {
+    const string &location,
+    const std::map<string, string> &labels) {
     if (!context) {
         throw InternalException("InsertLoadJobInternal requires an active DuckDB client context");
     }
@@ -1169,7 +1199,7 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::Insert
         throw IOException("Parquet file not found: %s", absolute_file_path);
     }
 
-    auto request = BuildLoadJobRequest(destination_table, write_disposition, create_disposition, location);
+    auto request = BuildLoadJobRequest(destination_table, write_disposition, create_disposition, location, labels);
 
     return job_client.InsertJobUpload(request, absolute_file_path);
 }
@@ -1180,8 +1210,9 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::Insert
     const vector<string> &source_uris,
     const string &write_disposition,
     const string &create_disposition,
-    const string &location) {
-    auto request = BuildLoadJobRequest(destination_table, write_disposition, create_disposition, location);
+    const string &location,
+    const std::map<string, string> &labels) {
+    auto request = BuildLoadJobRequest(destination_table, write_disposition, create_disposition, location, labels);
     auto *load_config = request.mutable_job()->mutable_configuration()->mutable_load();
     for (const auto &source_uri : source_uris) {
         load_config->add_source_uris(source_uri);

--- a/src/bigquery_load.cpp
+++ b/src/bigquery_load.cpp
@@ -24,6 +24,7 @@
 #include "storage/bigquery_transaction.hpp"
 
 #include <cstdio>
+#include <map>
 #include <optional>
 
 namespace duckdb {
@@ -39,6 +40,7 @@ struct BigQueryLoadBindData : public TableFunctionData {
     string write_disposition;
     string create_disposition;
     string location;
+    std::map<string, string> labels;
     bool remove_staged_source_file = false;
     bool finished = false;
 
@@ -58,6 +60,7 @@ struct BigQueryLoadParameters {
     std::optional<string> location;
     string billing_project;
     string api_endpoint;
+    std::map<string, string> labels;
 };
 
 static string NormalizeEnumValue(const string &value) {
@@ -132,6 +135,39 @@ static std::optional<string> ParseOptionalAliasedStringParameter(const named_par
     return value ? value : legacy_value;
 }
 
+static std::map<string, string> ParseOptionalLabelsParameter(const named_parameter_map_t &named_parameters) {
+    auto entry = named_parameters.find("labels");
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return {};
+    }
+
+    const auto &labels_value = entry->second;
+    if (labels_value.type().id() != LogicalTypeId::MAP ||
+        MapType::KeyType(labels_value.type()).id() != LogicalTypeId::VARCHAR ||
+        MapType::ValueType(labels_value.type()).id() != LogicalTypeId::VARCHAR) {
+        throw BinderException("Parameter 'labels' must be MAP(VARCHAR, VARCHAR)");
+    }
+
+    std::map<string, string> labels;
+    for (const auto &entry_value : MapValue::GetChildren(labels_value)) {
+        if (entry_value.IsNull()) {
+            throw BinderException("Null entries are not allowed in parameter 'labels'");
+        }
+        const auto &children = StructValue::GetChildren(entry_value);
+        D_ASSERT(children.size() == 2);
+        const auto &key = children[0];
+        const auto &value = children[1];
+        if (key.IsNull()) {
+            throw BinderException("Null label keys are not allowed in parameter 'labels'");
+        }
+        if (value.IsNull()) {
+            throw BinderException("Null label values are not allowed in parameter 'labels'");
+        }
+        labels[key.GetValue<string>()] = value.GetValue<string>();
+    }
+    return labels;
+}
+
 static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &named_parameters) {
     BigQueryLoadParameters params;
     params.source_file = ParseOptionalAliasedStringParameter(named_parameters, "source_file", "file");
@@ -148,6 +184,7 @@ static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &n
     params.billing_project = billing_project ? *billing_project : string();
     auto api_endpoint = ParseOptionalStringParameter(named_parameters, "api_endpoint");
     params.api_endpoint = api_endpoint ? *api_endpoint : string();
+    params.labels = ParseOptionalLabelsParameter(named_parameters);
     params.write_disposition = ParseEnumParameter(named_parameters,
                                                   "write_disposition",
                                                   "WRITE_TRUNCATE",
@@ -311,6 +348,7 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
     bind_data->source_uris = params.source_uris;
     bind_data->source_table = params.source_table;
     bind_data->location = params.location ? *params.location : BigquerySettings::DefaultLocation();
+    bind_data->labels = params.labels;
 
     auto destination_table = BigqueryUtils::ParseDatasetTableString(destination_table_string);
 
@@ -377,13 +415,15 @@ static void BigQueryLoadFunc(ClientContext &context, TableFunctionInput &data_p,
                                               *data.source_file,
                                               data.write_disposition,
                                               data.create_disposition,
-                                              data.location);
+                                              data.location,
+                                              data.labels);
     } else if (!data.source_uris.empty()) {
         job = data.bq_client->LoadParquetUris(data.destination_table,
                                               data.source_uris,
                                               data.write_disposition,
                                               data.create_disposition,
-                                              data.location);
+                                              data.location,
+                                              data.labels);
     } else {
         throw InternalException("bigquery_load has no source to load");
     }
@@ -426,6 +466,7 @@ BigQueryLoadFunction::BigQueryLoadFunction()
     named_parameters["location"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["billing_project"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["api_endpoint"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["labels"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
 }
 
 } // namespace bigquery

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -79,17 +80,20 @@ public:
                                                      const string &file_path,
                                                      const string &write_disposition = "WRITE_TRUNCATE",
                                                      const string &create_disposition = "CREATE_IF_NEEDED",
-                                                     const string &location = "");
+                                                     const string &location = "",
+                                                     const std::map<string, string> &labels = {});
     google::cloud::bigquery::v2::Job LoadParquetUris(const BigqueryTableRef &destination_table,
                                                      const vector<string> &source_uris,
                                                      const string &write_disposition = "WRITE_TRUNCATE",
                                                      const string &create_disposition = "CREATE_IF_NEEDED",
-                                                     const string &location = "");
+                                                     const string &location = "",
+                                                     const std::map<string, string> &labels = {});
     google::cloud::bigquery::v2::Job LoadDuckDBTable(const string &table_name,
                                                      const BigqueryTableRef &destination_table,
                                                      const string &write_disposition = "WRITE_TRUNCATE",
                                                      const string &create_disposition = "CREATE_IF_NEEDED",
-                                                     const string &location = "");
+                                                     const string &location = "",
+                                                     const std::map<string, string> &labels = {});
 
     google::cloud::bigquery::v2::QueryResponse ExecuteQuery(const string &query,
                                                             const string &location = "",
@@ -137,21 +141,24 @@ private:
     google::cloud::bigquery::v2::InsertJobRequest BuildLoadJobRequest(const BigqueryTableRef &destination_table,
                                                                       const string &write_disposition,
                                                                       const string &create_disposition,
-                                                                      const string &location);
+                                                                      const string &location,
+                                                                      const std::map<string, string> &labels);
     google::cloud::StatusOr<google::cloud::bigquery::v2::Job> InsertLoadJobInternal(
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const BigqueryTableRef &destination_table,
         const string &file_path,
         const string &write_disposition,
         const string &create_disposition,
-        const string &location);
+        const string &location,
+        const std::map<string, string> &labels);
     google::cloud::StatusOr<google::cloud::bigquery::v2::Job> InsertLoadJobFromUrisInternal(
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const BigqueryTableRef &destination_table,
         const vector<string> &source_uris,
         const string &write_disposition,
         const string &create_disposition,
-        const string &location);
+        const string &location,
+        const std::map<string, string> &labels);
     google::cloud::bigquery::v2::Job WaitForJobCompletion(const google::cloud::bigquery::v2::JobReference &job_ref);
     void ThrowOnJobStatusError(const google::cloud::bigquery::v2::JobStatus &status, const string &operation_name);
 

--- a/test/sql/functions/function_bigquery_load.test
+++ b/test/sql/functions/function_bigquery_load.test
@@ -28,19 +28,20 @@ CALL bigquery_load(
 	'bq',
 	'${BQ_TEST_DATASET}.load_file_table',
 	source_file := 'test/data/multiple_row_groups.parquet',
-	labels := MAP {'duckdb_load_label': NULL}
+	labels := MAP {'duckdb_load_label': NULL},
+	location := 'europe-west3'
 );
 ----
-<REGEX>:Binder Error: Null label values are not allowed in parameter 'labels'
+Binder Error: Null label values are not allowed in parameter 'labels'
 
 statement ok
 CREATE OR REPLACE TEMP TABLE load_file_job AS
 SELECT *
 FROM bigquery_load(
-	'${BQ_TEST_PROJECT}',
+	'bq',
 	'${BQ_TEST_DATASET}.load_file_table',
 	source_file := 'test/data/multiple_row_groups.parquet',
-	location='europe-west3',
+	location := 'europe-west3',
 	labels := MAP {'duckdb_label_env': 'test', 'duckdb_load_label': 'load_job'}
 );
 
@@ -63,8 +64,8 @@ query I
 SELECT count(*) = 1
 FROM bigquery_jobs('bq', maxResults=50)
 WHERE job_id = (SELECT job_id FROM load_file_job)
-	AND contains(configuration, '"duckdb_label_env":"test"')
-	AND contains(configuration, '"duckdb_load_label":"load_job"');
+	AND contains(configuration::VARCHAR, '"duckdb_label_env":"test"')
+	AND contains(configuration::VARCHAR, '"duckdb_load_label":"load_job"');
 ----
 true
 

--- a/test/sql/functions/function_bigquery_load.test
+++ b/test/sql/functions/function_bigquery_load.test
@@ -23,6 +23,27 @@ statement ok
 CREATE OR REPLACE TEMP TABLE local_load_source AS
 SELECT * FROM read_parquet('test/data/multiple_row_groups.parquet');
 
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/multiple_row_groups.parquet',
+	labels := MAP {'duckdb_load_label': NULL}
+);
+----
+<REGEX>:Binder Error: Null label values are not allowed in parameter 'labels'
+
+statement ok
+CREATE OR REPLACE TEMP TABLE load_file_job AS
+SELECT *
+FROM bigquery_load(
+	'${BQ_TEST_PROJECT}',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/multiple_row_groups.parquet',
+	location='europe-west3',
+	labels := MAP {'duckdb_label_env': 'test', 'duckdb_load_label': 'load_job'}
+);
+
 query IIIIIII
 SELECT
 	success,
@@ -32,14 +53,20 @@ SELECT
 	destination_table = '${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_file_table',
 	output_rows > 0,
 	status = '{"state":"DONE"}'
-FROM bigquery_load(
-	'${BQ_TEST_PROJECT}',
-    '${BQ_TEST_DATASET}.load_file_table',
-    source_file := 'test/data/multiple_row_groups.parquet',
-	location='europe-west3'
-);
+FROM load_file_job;
 ----
 true	true	true	true	true	true	true
+
+sleep 5 seconds
+
+query I
+SELECT count(*) = 1
+FROM bigquery_jobs('bq', maxResults=50)
+WHERE job_id = (SELECT job_id FROM load_file_job)
+	AND contains(configuration, '"duckdb_label_env":"test"')
+	AND contains(configuration, '"duckdb_load_label":"load_job"');
+----
+true
 
 statement ok
 CALL bigquery_load(
@@ -49,7 +76,7 @@ CALL bigquery_load(
 	location='europe-west3'
 );
 
-sleep 2 seconds
+sleep 5 seconds
 
 query I
 SELECT (


### PR DESCRIPTION
Adds support for a `labels` named parameter on `bigquery_load`, allowing callers to attach BigQuery job labels via `MAP(VARCHAR, VARCHAR)`. The labels are forwarded to `JobConfiguration.labels` for load jobs, covering local file, GCS URI, and staged DuckDB table load paths.

```sql
CALL bigquery_load(
    'my_storage_project',
    'my_dataset.target_table',
    source_uris := [
        'gs://my_bucket/path/part-1.parquet',
        'gs://my_bucket/path/part-2.parquet'
    ],
    write_disposition := 'WRITE_APPEND',
    location := 'EU',
    labels := MAP {
        'pipeline': 'daily_load',
        'env': 'prod'
    }
);
```