### PR TITLE
Support bq ADC auth from metadata credentials and fix auth timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ This community extension allows [DuckDB](https://duckdb.org) to query data from 
 
 ## Preliminaries
 
-You must configure authentication before using the BigQuery extension. The extension supports three methods. If more than one is available, it uses the first method that works, in this order:
+You must configure authentication before using the BigQuery extension. DuckDB BigQuery secrets take priority when their
+scope matches the target project. Otherwise, the extension uses Google Application Default Credentials (ADC), including
+`GOOGLE_APPLICATION_CREDENTIALS`, gcloud ADC files, and attached service accounts on Google-hosted runtimes such as
+Dataproc or Compute Engine. Common setup paths are:
 
 1. **DuckDB Secrets** ([Option 3](#authentication-option-3-using-duckdb-secrets)) - Best for multi-tenant or server use; per-connection isolation and easy rotation.
-2. **Environment Variable** ([Option 2](#authentication-option-2-configure-adc-with-service-account-keys)) - `GOOGLE_APPLICATION_CREDENTIALS` pointing to a service-account JSON key.
+2. **Service Account ADC** ([Option 2](#authentication-option-2-configure-adc-with-service-account-keys)) - `GOOGLE_APPLICATION_CREDENTIALS` or an attached Google Cloud service account.
 3. **User Account** ([Option 1](#authentication-option-1-configure-adc-with-your-google-account)) - Application Default Credentials created by gcloud auth application-default login.
 
-This priority order prefers explicit, connection-scoped credentials (DuckDB Secrets) over machine-wide settings (environment variables) and developer-local user credentials (gcloud). See [Required Permissions](#required-permissions) for the BigQuery roles and permissions commonly needed by the extension.
+Secrets are explicit and connection-scoped; ADC is resolved by the Google client library after no matching secret is
+found. See [Required Permissions](#required-permissions) for the BigQuery roles and permissions commonly needed by the
+extension.
 
 ### Authentication Option 1: Configure ADC with your Google Account
 
@@ -35,6 +40,9 @@ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/my/service-account-credentials.j
 # On Windows
 set GOOGLE_APPLICATION_CREDENTIALS="C:\path\to\my\service-account-credentials.json"
 ```
+
+On Dataproc, Compute Engine, GKE, and Cloud Run, no service-account key file is required when the runtime has an
+attached service account. ADC can fetch tokens from the metadata server; make sure that service account has the required IAM permissions and access scopes.
 
 ### Authentication Option 3: Using DuckDB Secrets (experimental)
 
@@ -580,6 +588,7 @@ D CREATE TABLE bq.my_dataset.partition_tbl (i BIGINT)
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `bq_bignumeric_as_varchar`                | Compatibility setting kept for older workflows. `BIGNUMERIC` columns are exposed as `VARCHAR` by default in current versions.                                                                        | `true`  |
 | `bq_query_timeout_ms`                     | Timeout for BigQuery queries in milliseconds. If a query exceeds this time, the operation stops waiting.                                                                                           | `90000` |
+| `bq_auth_timeout_ms`                      | Timeout for authentication token fetches in milliseconds. This bounds ADC metadata and OAuth token requests without changing normal BigQuery query timeouts.                                        | `10000` |
 | `bq_debug_show_queries`                   | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                                                                                                                  | `false` |
 | `bq_experimental_filter_pushdown`         | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                                                                                                             | `true`  |
 | `bq_experimental_use_info_schema`         | [EXPERIMENTAL] - Use information schema to fetch catalog info (often faster than REST API)                                                                                                         | `true`  |

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -40,7 +40,8 @@
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/curl_options.h"
-#include "google/cloud/internal/oauth2_google_application_default_credentials_file.h"
+#include "google/cloud/internal/rest_options.h"
+#include "google/cloud/internal/unified_rest_credentials.h"
 
 #include "arrow/api.h"
 #include "arrow/io/api.h"
@@ -48,14 +49,54 @@
 #include "arrow/ipc/writer.h"
 #include "grpcpp/grpcpp.h"
 
+#include <chrono>
 #include <cstring>
-#include <fstream>
 #include <iostream>
 
 
 namespace duckdb {
 namespace bigquery {
 namespace {
+
+static google::cloud::Options BigqueryAuthOptions() {
+    auto options = google::cloud::Options{};
+    auto auth_timeout = BigquerySettings::GetAuthTimeoutSeconds();
+    if (auth_timeout.count() > 0) {
+        options.set<google::cloud::rest_internal::TransferStallTimeoutOption>(auth_timeout);
+        options.set<google::cloud::rest_internal::TransferStallMinimumRateOption>(1);
+        options.set<google::cloud::rest_internal::DownloadStallTimeoutOption>(auth_timeout);
+        options.set<google::cloud::rest_internal::DownloadStallMinimumRateOption>(1);
+    }
+
+    auto ca_path = BigquerySettings::CurlCaBundlePath();
+    if (!ca_path.empty()) {
+        options.set<google::cloud::CARootsFilePathOption>(ca_path);
+    }
+    return options;
+}
+
+static string BigqueryAuthenticationFailureMessage(const string &details) {
+    string message =
+        "BigQuery Authentication Failed\n"
+        "\n"
+        "No usable authentication credentials were found. Please configure one of the following:\n"
+        "\n"
+        "Authentication options:\n"
+        "  1. DuckDB secret for this project:\n"
+        "     - CREATE SECRET (TYPE bigquery, SCOPE 'bq://your-project', ACCESS_TOKEN 'your-token')\n"
+        "  2. Application Default Credentials (ADC):\n"
+        "     - Run: gcloud auth application-default login\n"
+        "     - Or set GOOGLE_APPLICATION_CREDENTIALS to a service account, authorized user, or external account JSON "
+        "file\n"
+        "  3. Attached Google Cloud service account:\n"
+        "     - On Dataproc, Compute Engine, GKE, or Cloud Run, make sure the runtime service account has BigQuery "
+        "permissions\n";
+
+    if (!details.empty()) {
+        message += "\nUnderlying authentication error:\n  " + details;
+    }
+    return message;
+}
 
 static Value CastQueryParameterValue(const Value &value, const LogicalType &target_type, idx_t parameter_index) {
     auto casted = value;
@@ -263,6 +304,7 @@ BigqueryClient::BigqueryClient(ClientContext &context, const BigqueryConfig &con
 
 google::cloud::Options BigqueryClient::OptionsAPI() {
     auto options = google::cloud::Options{};
+    auto auth_options = BigqueryAuthOptions();
     if (!config.api_endpoint.empty()) {
         options.set<google::cloud::EndpointOption>(config.api_endpoint);
     }
@@ -271,7 +313,7 @@ google::cloud::Options BigqueryClient::OptionsAPI() {
     auto secret_match = LookupBigQuerySecret(*context, config.project_id);
     if (secret_match.HasMatch()) {
         auto &bq_secret = dynamic_cast<const BigquerySecret &>(secret_match.GetSecret());
-        auto credentials = CreateGCPCredentialsFromSecret(bq_secret);
+        auto credentials = CreateGCPCredentialsFromSecret(bq_secret, auth_options);
         if (credentials) {
             options.set<google::cloud::UnifiedCredentialsOption>(credentials);
             credentials_set = true;
@@ -286,7 +328,7 @@ google::cloud::Options BigqueryClient::OptionsAPI() {
 
     // Set default credentials if no secret credentials were set
     if (!credentials_set) {
-        options.set<google::cloud::UnifiedCredentialsOption>(google::cloud::MakeGoogleDefaultCredentials(options));
+        options.set<google::cloud::UnifiedCredentialsOption>(google::cloud::MakeGoogleDefaultCredentials(auth_options));
     }
 
     return options;
@@ -294,6 +336,7 @@ google::cloud::Options BigqueryClient::OptionsAPI() {
 
 google::cloud::Options BigqueryClient::OptionsGRPC() {
     auto options = google::cloud::Options{};
+    auto auth_options = BigqueryAuthOptions();
     if (!config.grpc_endpoint.empty()) {
         options.set<google::cloud::EndpointOption>(config.grpc_endpoint);
         if (config.IsDevEnv()) {
@@ -305,7 +348,7 @@ google::cloud::Options BigqueryClient::OptionsGRPC() {
     auto secret_match = LookupBigQuerySecret(*context, config.project_id);
     if (secret_match.HasMatch()) {
         auto &bq_secret = dynamic_cast<const BigquerySecret &>(secret_match.GetSecret());
-        auto credentials = CreateGCPCredentialsFromSecret(bq_secret);
+        auto credentials = CreateGCPCredentialsFromSecret(bq_secret, auth_options);
         if (credentials) {
             options.set<google::cloud::UnifiedCredentialsOption>(credentials);
             credentials_set = true;
@@ -314,7 +357,7 @@ google::cloud::Options BigqueryClient::OptionsGRPC() {
 
     // Set default credentials if no secret credentials were set
     if (!credentials_set) {
-        options.set<google::cloud::UnifiedCredentialsOption>(google::cloud::MakeGoogleDefaultCredentials(options));
+        options.set<google::cloud::UnifiedCredentialsOption>(google::cloud::MakeGoogleDefaultCredentials(auth_options));
     }
 
     return options;
@@ -1325,54 +1368,28 @@ void BigqueryClient::CheckAuthentication() {
         return;
     }
 
-    // Check if we have a DuckDB secret for this project
+    auto auth_options = BigqueryAuthOptions();
+    std::shared_ptr<google::cloud::Credentials> credentials;
+
     auto secret_match = LookupBigQuerySecret(*context, config.project_id);
     if (secret_match.HasMatch()) {
-        authentication_checked = true;
-        return; // If we have a secret, we assume being able to authenticate
-    }
-
-    // Check if ADC environment variables are set
-    auto adc_credential = google::cloud::oauth2_internal::GoogleAdcFilePathFromEnvVarOrEmpty();
-    if (!adc_credential.empty()) {
-        std::ifstream creds_file(adc_credential);
-        if (creds_file.good()) {
-            authentication_checked = true;
-            return; // ADC file exists
+        auto &bq_secret = dynamic_cast<const BigquerySecret &>(secret_match.GetSecret());
+        credentials = CreateGCPCredentialsFromSecret(bq_secret, auth_options);
+        if (!credentials) {
+            throw InvalidInputException(BigqueryAuthenticationFailureMessage(
+                "A matching DuckDB BigQuery secret was found, but credentials could not be created from it."));
         }
+    } else {
+        credentials = google::cloud::MakeGoogleDefaultCredentials(auth_options);
     }
 
-    // Check if gcloud CLI credentials exist
-    auto gcloud_creds_path = google::cloud::oauth2_internal::GoogleAdcFilePathFromWellKnownPathOrEmpty();
-    if (!gcloud_creds_path.empty()) {
-        std::ifstream creds_file(gcloud_creds_path);
-        if (creds_file.good()) {
-            authentication_checked = true;
-            return; // gcloud ADC file exists
-        }
+    auto oauth2_credentials = google::cloud::rest_internal::MapCredentials(*credentials);
+    auto access_token = oauth2_credentials->GetToken(std::chrono::system_clock::now());
+    if (!access_token) {
+        throw InvalidInputException(BigqueryAuthenticationFailureMessage(access_token.status().message()));
     }
 
-    // Check if we're in a GCP environment (i.e., metadata server set)
-    const char *gcp_project = std::getenv("GOOGLE_CLOUD_PROJECT");
-    const char *gce_metadata = std::getenv("GCE_METADATA_ROOT");
-    if (gcp_project || gce_metadata) {
-        authentication_checked = true;
-        return; // Likely running on GCP, should have automatic credentials
-    }
-
-    // No authentication method found
-    throw InvalidInputException(
-        "BigQuery Authentication Failed\n"
-        "\n"
-        "No authentication credentials found. Please configure one of the following:\n"
-        "\n"
-        "Authentication options:\n"
-        "  1. User credentials via Application Default Credentials (ADC):\n"
-        "     • Run: gcloud auth application-default login\n"
-        "  2. Service account key file via environment variable:\n"
-        "     • Set GOOGLE_APPLICATION_CREDENTIALS to your service account key file path\n"
-        "  3. DuckDB secret for this project:\n"
-        "     • Run: CREATE SECRET (TYPE bigquery, SCOPE 'bq://your-project', ACCESS_TOKEN 'your-token')");
+    authentication_checked = true;
 }
 
 void BigqueryClient::ThrowOnJobStatusError(const google::cloud::bigquery::v2::JobStatus &status,

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -436,6 +436,8 @@ vector<BigqueryTableRef> BigqueryClient::GetTables(const string &dataset_id) {
 }
 
 BigqueryDatasetRef BigqueryClient::GetDataset(const string &dataset_id) {
+    CheckAuthentication();
+
     auto client = make_shared_ptr<google::cloud::bigquerycontrol_v2::DatasetServiceClient>(
         google::cloud::bigquerycontrol_v2::MakeDatasetServiceConnectionRest(OptionsAPI()));
 
@@ -555,6 +557,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::GetJobByReference(
         throw BinderException("Job ID cannot be empty");
     }
 
+    CheckAuthentication();
+
     auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
         google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
 
@@ -582,6 +586,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::GetJob(const string &job_id, co
     if (job_id.empty()) {
         throw BinderException("Job ID cannot be empty");
     }
+
+    CheckAuthentication();
 
     auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
         google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
@@ -718,6 +724,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &t
 }
 
 BigqueryTableRef BigqueryClient::GetTable(const string &dataset_id, const string &table_id) {
+    CheckAuthentication();
+
     auto client = make_shared_ptr<google::cloud::bigquerycontrol_v2::TableServiceClient>(
         google::cloud::bigquerycontrol_v2::MakeTableServiceConnectionRest(OptionsAPI()));
 
@@ -746,6 +754,8 @@ BigqueryTableRef BigqueryClient::GetTable(const string &dataset_id, const string
 }
 
 bool BigqueryClient::DatasetExists(const string &dataset_id) {
+    CheckAuthentication();
+
     auto client = google::cloud::bigquerycontrol_v2::DatasetServiceClient(
         google::cloud::bigquerycontrol_v2::MakeDatasetServiceConnectionRest(OptionsAPI()));
 
@@ -767,6 +777,8 @@ bool BigqueryClient::DatasetExists(const string &dataset_id) {
 }
 
 bool BigqueryClient::TableExists(const string &dataset_id, const string &table_id) {
+    CheckAuthentication();
+
     auto client = google::cloud::bigquerycontrol_v2::TableServiceClient(
         google::cloud::bigquerycontrol_v2::MakeTableServiceConnectionRest(OptionsAPI()));
 
@@ -853,9 +865,6 @@ void BigqueryClient::GetTableInfosFromDatasets(const vector<BigqueryDatasetRef> 
         }
         datasets_by_location[dataset_ref.location].push_back(dataset_ref.dataset_id);
     }
-
-    auto job_client = google::cloud::bigquerycontrol_v2::JobServiceClient(
-        google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
 
     for (const auto &datasets_in_loc : datasets_by_location) {
         const auto &location = datasets_in_loc.first;
@@ -1070,6 +1079,8 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
 google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryResults(
     const google::cloud::bigquery::v2::JobReference &job_ref,
     const string &page_token) {
+    CheckAuthentication();
+
     auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
         google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
 
@@ -1094,8 +1105,7 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::GetJob
         throw BinderException("job_id config parameter is empty.");
     }
 
-    auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
-        google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+    CheckAuthentication();
 
     auto request = google::cloud::bigquery::v2::GetJobRequest();
     request.set_project_id(config.BillingProject());
@@ -1104,7 +1114,7 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::GetJob
         request.set_location(location);
     }
 
-    auto response = client.GetJob(request);
+    auto response = job_client.GetJob(request);
     if (!response.ok()) {
         ThrowOnErrorStatus(response.status());
         throw BinderException(response.status().message());

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -88,6 +88,11 @@ static void LoadInternal(ExtensionLoader &loader) {
                               LogicalType::BIGINT,
                               Value(bigquery::BigquerySettings::QueryTimeoutMs()),
                               bigquery::BigquerySettings::SetQueryTimeoutMs);
+    config.AddExtensionOption("bq_auth_timeout_ms",
+                              "Timeout for BigQuery authentication token fetches in milliseconds",
+                              LogicalType::BIGINT,
+                              Value(bigquery::BigquerySettings::AuthTimeoutMs()),
+                              bigquery::BigquerySettings::SetAuthTimeoutMs);
     config.AddExtensionOption("bq_experimental_filter_pushdown",
                               "Whether to use filter pushdown (currently experimental)",
                               LogicalType::BOOLEAN,

--- a/src/bigquery_secrets.cpp
+++ b/src/bigquery_secrets.cpp
@@ -253,10 +253,11 @@ void ValidateCredentialInput(const string &param, const string &value) {
     }
 }
 
-std::shared_ptr<google::cloud::Credentials> CreateGCPCredentialsFromSecret(const BigquerySecret &secret) {
+std::shared_ptr<google::cloud::Credentials> CreateGCPCredentialsFromSecret(const BigquerySecret &secret,
+                                                                           google::cloud::Options auth_options) {
     auto access_token = secret.GetAccessToken();
     if (!access_token.empty()) {
-        return google::cloud::MakeAccessTokenCredentials(access_token, {});
+        return google::cloud::MakeAccessTokenCredentials(access_token, {}, auth_options);
     }
 
     auto service_account_path = secret.GetServiceAccountKeyPath();
@@ -268,12 +269,12 @@ std::shared_ptr<google::cloud::Credentials> CreateGCPCredentialsFromSecret(const
         }
         std::string json_content((std::istreambuf_iterator<char>(json_file)), std::istreambuf_iterator<char>());
         json_file.close();
-        return google::cloud::MakeServiceAccountCredentials(json_content);
+        return google::cloud::MakeServiceAccountCredentials(json_content, auth_options);
     }
 
     auto service_account_json = secret.GetServiceAccountKeyJson();
     if (!service_account_json.empty()) {
-        return google::cloud::MakeServiceAccountCredentials(service_account_json);
+        return google::cloud::MakeServiceAccountCredentials(service_account_json, auth_options);
     }
 
     auto external_account_path = secret.GetExternalAccountCredsPath();
@@ -285,12 +286,12 @@ std::shared_ptr<google::cloud::Credentials> CreateGCPCredentialsFromSecret(const
         }
         std::string json_content((std::istreambuf_iterator<char>(json_file)), std::istreambuf_iterator<char>());
         json_file.close();
-        return google::cloud::MakeExternalAccountCredentials(json_content);
+        return google::cloud::MakeExternalAccountCredentials(json_content, auth_options);
     }
 
     auto external_account_json = secret.GetExternalAccountCredsJson();
     if (!external_account_json.empty()) {
-        return google::cloud::MakeExternalAccountCredentials(external_account_json);
+        return google::cloud::MakeExternalAccountCredentials(external_account_json, auth_options);
     }
 
     auto refresh_token = secret.GetRefreshToken();
@@ -298,7 +299,7 @@ std::shared_ptr<google::cloud::Credentials> CreateGCPCredentialsFromSecret(const
     auto client_secret = secret.GetClientSecret();
     auto token_uri = secret.GetTokenUri();
     if (!refresh_token.empty() || !client_id.empty() || !client_secret.empty() || !token_uri.empty()) {
-        return google::cloud::MakeAuthorizedUserCredentials(BuildAuthorizedUserCredentialsJson(secret));
+        return google::cloud::MakeAuthorizedUserCredentials(BuildAuthorizedUserCredentialsJson(secret), auth_options);
     }
 
     return nullptr;

--- a/src/include/bigquery_secrets.hpp
+++ b/src/include/bigquery_secrets.hpp
@@ -71,7 +71,8 @@ void ValidateCredentialInput(const string &param, const string &value);
 
 //! Helper function to create Google Cloud credentials from a BigQuery secret
 //! Returns nullptr if no credentials could be created
-std::shared_ptr<google::cloud::Credentials> CreateGCPCredentialsFromSecret(const BigquerySecret &secret);
+std::shared_ptr<google::cloud::Credentials> CreateGCPCredentialsFromSecret(const BigquerySecret &secret,
+                                                                           google::cloud::Options auth_options = {});
 
 //! Helper function to lookup a secret for a specific project_id using scope bq://project_id or bigquery://project_id
 //! Returns a SecretMatch that owns the secret to prevent use-after-free

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -6,9 +6,11 @@
 
 #include "google/cloud/bigquery/storage/v1/arrow.pb.h"
 
+#include <chrono>
 #include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <limits>
 
 namespace duckdb {
 namespace bigquery {
@@ -140,8 +142,16 @@ public:
         return BIGQUERY_QUERY_TIMEOUT_MS;
     }
 
+    static int GetIntSettingValue(const string &setting, Value &parameter) {
+        auto value = parameter.GetValue<int64_t>();
+        if (value < std::numeric_limits<int>::min() || value > std::numeric_limits<int>::max()) {
+            throw InvalidInputException(setting + " must fit in a 32-bit integer");
+        }
+        return static_cast<int>(value);
+    }
+
     static void SetQueryTimeoutMs(ClientContext &context, SetScope scope, Value &parameter) {
-        int timeout = IntegerValue::Get(parameter);
+        int timeout = GetIntSettingValue("Query timeout", parameter);
         if (timeout < 0) {
             throw InvalidInputException("Query timeout must be non-negative");
         } else if (timeout > 200000) {
@@ -152,6 +162,31 @@ public:
                       << std::endl;
         }
         QueryTimeoutMs() = timeout;
+    }
+
+    static int &AuthTimeoutMs() {
+        static int BIGQUERY_AUTH_TIMEOUT_MS = 10000;
+        return BIGQUERY_AUTH_TIMEOUT_MS;
+    }
+
+    static void SetAuthTimeoutMs(ClientContext &context, SetScope scope, Value &parameter) {
+        int timeout = GetIntSettingValue("Auth timeout", parameter);
+        if (timeout < 0) {
+            throw InvalidInputException("Auth timeout must be non-negative");
+        }
+        AuthTimeoutMs() = timeout;
+    }
+
+    static std::chrono::seconds GetAuthTimeoutSeconds() {
+        auto timeout_ms = std::chrono::milliseconds(AuthTimeoutMs());
+        if (timeout_ms.count() <= 0) {
+            return std::chrono::seconds(0);
+        }
+        auto timeout_seconds = std::chrono::duration_cast<std::chrono::seconds>(timeout_ms);
+        if (timeout_seconds < timeout_ms) {
+            timeout_seconds += std::chrono::seconds(1);
+        }
+        return timeout_seconds;
     }
 
     static bool &BignumericAsVarchar() {
@@ -169,7 +204,7 @@ public:
     }
 
     static void SetMaxReadStreams(ClientContext &context, SetScope scope, Value &parameter) {
-        int max_streams = IntegerValue::Get(parameter);
+        int max_streams = GetIntSettingValue("Max read streams", parameter);
         if (max_streams < 0) {
             throw InvalidInputException("Max read streams must be non-negative (0 or greater). Use 0 to automatically "
                                         "match the number of DuckDB threads.");

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -85,7 +85,9 @@ public:
     // Hilfsmethoden
     bool IsDevEnv() const {
         return api_endpoint.find("localhost") != std::string::npos ||
-               api_endpoint.find("127.0.0.1") != std::string::npos;
+               api_endpoint.find("127.0.0.1") != std::string::npos ||
+               grpc_endpoint.find("localhost") != std::string::npos ||
+               grpc_endpoint.find("127.0.0.1") != std::string::npos;
     }
 
     std::string BillingProject() const {

--- a/test/sql/secrets/secrets_validation.test
+++ b/test/sql/secrets/secrets_validation.test
@@ -5,6 +5,19 @@
 require bigquery
 
 statement ok
+SET bq_auth_timeout_ms=1000;
+
+statement error
+SET bq_auth_timeout_ms=-1;
+----
+Invalid Input Error: Auth timeout must be non-negative
+
+statement ok
+SET bq_auth_timeout_ms=10000;
+
+#################################################################################
+
+statement ok
 CREATE SECRET bq_token_secret (
     TYPE bigquery,
     PROVIDER config,


### PR DESCRIPTION
This lets google-cloud-cpp resolve ADC directly instead of rejecting auth based on missing environment variables. That allows attached service account credentials from the metadata server to work, including on Dataproc/GCE, when no DuckDB bq secret is configured.

It also adds `bq_auth_timeout_ms` to bound token and metadata credential fetches, so missing or unreachable ADC fails quickly with the underlying auth error instead of appearing to hang. 