### PR TITLE
Enforce read-only BigQuery storage attachments

### DIFF
--- a/src/bigquery_storage.cpp
+++ b/src/bigquery_storage.cpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/catalog/catalog_entry/schema_catalog_entry.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/main/settings.hpp"
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
 
@@ -22,6 +23,10 @@ static unique_ptr<Catalog> BigqueryAttach(optional_ptr<StorageExtensionInfo> sto
                                           const string &name,
                                           AttachInfo &info,
                                           AttachOptions &attach_options) {
+    if (!Settings::Get<EnableExternalAccessSetting>(context)) {
+        throw PermissionException("Attaching BigQuery databases is disabled through configuration");
+    }
+
     BigqueryOptions options;
     options.access_mode = attach_options.access_mode;
     return duckdb::make_uniq<BigqueryCatalog>(db, info.path, options);

--- a/src/include/storage/bigquery_transaction.hpp
+++ b/src/include/storage/bigquery_transaction.hpp
@@ -26,9 +26,11 @@ public:
     shared_ptr<duckdb::bigquery::BigqueryClient> GetBigqueryClient();
     static BigqueryTransaction &Get(ClientContext &context, Catalog &catalog);
 
-    AccessMode GetAccessMode() {
+    AccessMode GetAccessMode() const {
         return access_mode;
     }
+
+    static void CheckReadWrite(ClientContext &context, Catalog &catalog, const string &operation);
 
 private:
     BigqueryCatalog &bigquery_catalog;

--- a/src/storage/bigquery_catalog.cpp
+++ b/src/storage/bigquery_catalog.cpp
@@ -70,6 +70,7 @@ void BigqueryCatalog::ScanSchemas(ClientContext &context, std::function<void(Sch
 }
 
 optional_ptr<CatalogEntry> BigqueryCatalog::CreateSchema(CatalogTransaction transaction, CreateSchemaInfo &info) {
+    BigqueryTransaction::CheckReadWrite(transaction.GetContext(), *this, "create schemas");
     if (info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
         throw BinderException("BigQuery does not support REPLACE ON CONFLICT");
     }
@@ -104,6 +105,7 @@ optional_ptr<SchemaCatalogEntry> BigqueryCatalog::LookupSchema(CatalogTransactio
 }
 
 void BigqueryCatalog::DropSchema(ClientContext &context, DropInfo &info) {
+    BigqueryTransaction::CheckReadWrite(context, *this, "drop schemas");
     return schemas.DropEntry(context, info);
 }
 

--- a/src/storage/bigquery_catalog_set.cpp
+++ b/src/storage/bigquery_catalog_set.cpp
@@ -23,6 +23,7 @@ optional_ptr<CatalogEntry> BigqueryCatalogSet::CreateEntry(unique_ptr<CatalogEnt
 }
 
 void BigqueryCatalogSet::DropEntry(ClientContext &context, DropInfo &info) {
+    BigqueryTransaction::CheckReadWrite(context, catalog, "drop entries");
     auto &transaction = BigqueryTransaction::Get(context, catalog);
     auto bqclient = transaction.GetBigqueryClient();
 

--- a/src/storage/bigquery_delete.cpp
+++ b/src/storage/bigquery_delete.cpp
@@ -62,6 +62,7 @@ PhysicalOperator &BigqueryCatalog::PlanDelete(ClientContext &context,
                                               PhysicalPlanGenerator &planner,
                                               LogicalDelete &op,
                                               PhysicalOperator &plan) {
+    BigqueryTransaction::CheckReadWrite(context, *this, "delete from tables");
     if (op.return_chunk) {
         throw BinderException("RETURNING clause is not supported.");
     }

--- a/src/storage/bigquery_insert.cpp
+++ b/src/storage/bigquery_insert.cpp
@@ -189,6 +189,7 @@ PhysicalOperator &BigqueryCatalog::PlanInsert(ClientContext &context,
                                               PhysicalPlanGenerator &planner,
                                               LogicalInsert &op,
                                               optional_ptr<PhysicalOperator> plan) {
+    BigqueryTransaction::CheckReadWrite(context, *this, "insert into tables");
     if (op.return_chunk) {
         throw BinderException("RETURNING clause not supported.");
     }
@@ -207,6 +208,7 @@ PhysicalOperator &BigqueryCatalog::PlanCreateTableAs(ClientContext &context,
                                                      PhysicalPlanGenerator &planner,
                                                      LogicalCreateTable &op,
                                                      PhysicalOperator &plan) {
+    BigqueryTransaction::CheckReadWrite(context, *this, "create tables");
     auto &child_plan = AddCastToBigqueryTypes(context, planner, plan); // retain existing cast behavior
     auto &insert = planner.Make<BigqueryInsert>(op, op.schema, std::move(op.info));
     insert.children.push_back(child_plan);

--- a/src/storage/bigquery_schema_entry.cpp
+++ b/src/storage/bigquery_schema_entry.cpp
@@ -28,6 +28,7 @@ void BigquerySchemaEntry::TryDropEntry(ClientContext &context, CatalogType type,
 
 optional_ptr<CatalogEntry> BigquerySchemaEntry::CreateTable(CatalogTransaction transaction,
                                                             BoundCreateTableInfo &info) {
+    BigqueryTransaction::CheckReadWrite(transaction.GetContext(), catalog, "create tables");
     auto &create_table_info = info.Base();
     auto table_name = create_table_info.table;
     if (create_table_info.on_conflict == OnCreateConflict::REPLACE_ON_CONFLICT) {
@@ -54,6 +55,7 @@ optional_ptr<CatalogEntry> BigquerySchemaEntry::CreateIndex(CatalogTransaction t
 }
 
 optional_ptr<CatalogEntry> BigquerySchemaEntry::CreateView(CatalogTransaction transaction, CreateViewInfo &info) {
+    BigqueryTransaction::CheckReadWrite(transaction.GetContext(), catalog, "create views");
     if (info.sql.empty()) {
         throw BinderException("Cannot create view in BigQuery from an empty SQL statement.");
     }
@@ -110,6 +112,7 @@ optional_ptr<CatalogEntry> BigquerySchemaEntry::CreateType(CatalogTransaction tr
 }
 
 void BigquerySchemaEntry::Alter(CatalogTransaction transaction, AlterInfo &info) {
+    BigqueryTransaction::CheckReadWrite(transaction.GetContext(), catalog, "alter tables");
     if (info.type != AlterType::ALTER_TABLE) {
         throw BinderException("Only altering tables is supported.");
     }
@@ -136,6 +139,7 @@ void BigquerySchemaEntry::Scan(CatalogType type, const std::function<void(Catalo
 }
 
 void BigquerySchemaEntry::DropEntry(ClientContext &context, DropInfo &info) {
+    BigqueryTransaction::CheckReadWrite(context, catalog, "drop entries");
     info.schema = name;
     GetCatalogSet(info.type).DropEntry(context, info);
 }

--- a/src/storage/bigquery_schema_set.cpp
+++ b/src/storage/bigquery_schema_set.cpp
@@ -12,6 +12,7 @@ BigquerySchemaSet::BigquerySchemaSet(Catalog &catalog) : BigqueryCatalogSet(cata
 }
 
 optional_ptr<CatalogEntry> BigquerySchemaSet::CreateSchema(ClientContext &context, CreateSchemaInfo &info) {
+    BigqueryTransaction::CheckReadWrite(context, catalog, "create schemas");
     auto &transaction = BigqueryTransaction::Get(context, catalog);
     auto &bq_catalog = dynamic_cast<BigqueryCatalog &>(catalog);
     auto bqclient = transaction.GetBigqueryClient();

--- a/src/storage/bigquery_table_set.cpp
+++ b/src/storage/bigquery_table_set.cpp
@@ -16,6 +16,7 @@ BigqueryTableSet::BigqueryTableSet(BigquerySchemaEntry &schema) : BigqueryInSche
 }
 
 optional_ptr<CatalogEntry> BigqueryTableSet::CreateTable(ClientContext &context, BoundCreateTableInfo &info) {
+    BigqueryTransaction::CheckReadWrite(context, catalog, "create tables");
     auto &transaction = BigqueryTransaction::Get(context, catalog);
     auto &bq_catalog = dynamic_cast<BigqueryCatalog &>(catalog);
     auto bqclient = transaction.GetBigqueryClient();
@@ -55,6 +56,7 @@ unique_ptr<BigqueryTableInfo> BigqueryTableSet::GetTableInfo(ClientContext &cont
 }
 
 void BigqueryTableSet::AlterTable(ClientContext &context, AlterTableInfo &info) {
+    BigqueryTransaction::CheckReadWrite(context, catalog, "alter tables");
     auto &transaction = BigqueryTransaction::Get(context, catalog);
     auto &bq_catalog = dynamic_cast<BigqueryCatalog &>(catalog);
     auto bqclient = transaction.GetBigqueryClient();

--- a/src/storage/bigquery_transaction.cpp
+++ b/src/storage/bigquery_transaction.cpp
@@ -31,6 +31,13 @@ BigqueryTransaction &BigqueryTransaction::Get(ClientContext &context, Catalog &c
     return Transaction::Get(context, catalog).Cast<BigqueryTransaction>();
 }
 
+void BigqueryTransaction::CheckReadWrite(ClientContext &context, Catalog &catalog, const string &operation) {
+    auto &transaction = BigqueryTransaction::Get(context, catalog);
+    if (transaction.GetAccessMode() == AccessMode::READ_ONLY) {
+        throw BinderException("Cannot %s in a read-only BigQuery catalog", operation);
+    }
+}
+
 // ########################################################################
 // # TransactionManager
 // ########################################################################

--- a/src/storage/bigquery_update.cpp
+++ b/src/storage/bigquery_update.cpp
@@ -66,6 +66,7 @@ PhysicalOperator &BigqueryCatalog::PlanUpdate(ClientContext &context,
                                               PhysicalPlanGenerator &planner,
                                               LogicalUpdate &op,
                                               PhysicalOperator &plan) {
+    BigqueryTransaction::CheckReadWrite(context, *this, "update tables");
     if (op.return_chunk) {
         throw NotImplementedException("RETURNING clause not supported.");
     }

--- a/test/sql/storage/attach_read_only.test
+++ b/test/sql/storage/attach_read_only.test
@@ -71,15 +71,6 @@ statement ok
 DETACH bq_ro;
 
 statement ok
-FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP VIEW IF EXISTS `${BQ_TEST_DATASET}.read_only_guard_view`');
-
-statement ok
-FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_DATASET}.read_only_new_table`');
-
-statement ok
-FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_DATASET}.read_only_ctas`');
-
-statement ok
 FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_DATASET}.read_only_guard`');
 
 statement ok

--- a/test/sql/storage/attach_read_only.test
+++ b/test/sql/storage/attach_read_only.test
@@ -1,0 +1,91 @@
+# name: test/sql/storage/attach_read_only.test
+# description: Validate READ_ONLY BigQuery attachments reject storage mutations
+# group: [storage]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', '
+    CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.read_only_guard` AS
+    SELECT 1 AS i
+');
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq_ro (TYPE bigquery, READ_ONLY);
+
+statement error
+CREATE SCHEMA bq_ro.read_only_guard_schema;
+----
+read-only
+
+statement error
+DROP SCHEMA bq_ro.${BQ_TEST_DATASET};
+----
+read-only
+
+statement error
+CREATE TABLE bq_ro.${BQ_TEST_DATASET}.read_only_new_table(i INTEGER);
+----
+read-only
+
+statement error
+CREATE TABLE bq_ro.${BQ_TEST_DATASET}.read_only_ctas AS SELECT 1 AS i;
+----
+read-only
+
+statement error
+CREATE VIEW bq_ro.${BQ_TEST_DATASET}.read_only_guard_view AS SELECT 1 AS i;
+----
+read-only
+
+statement error
+INSERT INTO bq_ro.${BQ_TEST_DATASET}.read_only_guard VALUES (2);
+----
+read-only
+
+statement error
+UPDATE bq_ro.${BQ_TEST_DATASET}.read_only_guard SET i=2 WHERE i=1;
+----
+read-only
+
+statement error
+DELETE FROM bq_ro.${BQ_TEST_DATASET}.read_only_guard WHERE i=1;
+----
+read-only
+
+statement error
+ALTER TABLE bq_ro.${BQ_TEST_DATASET}.read_only_guard ADD COLUMN j INTEGER;
+----
+read-only
+
+statement error
+DROP TABLE bq_ro.${BQ_TEST_DATASET}.read_only_guard;
+----
+read-only
+
+statement ok
+DETACH bq_ro;
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP VIEW IF EXISTS `${BQ_TEST_DATASET}.read_only_guard_view`');
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_DATASET}.read_only_new_table`');
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_DATASET}.read_only_ctas`');
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_DATASET}.read_only_guard`');
+
+statement ok
+SET enable_external_access=false
+
+statement error
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq_disabled (TYPE bigquery)
+----
+Permission Error


### PR DESCRIPTION
Enforces read-only BigQuery attachments across mutating storage paths and blocks BigQuery ATTACH when external access is disabled. Adds test coverage for read-only DDL/DML guards.