### PR TITLE
Stabilize BigQuery catalog cache references and support reload for missing table entries

### DIFF
--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -957,6 +957,16 @@ void BigqueryClient::GetTableInfo(const string &dataset_id,
                                   const string &table_id,
                                   ColumnList &res_columns,
                                   vector<unique_ptr<Constraint>> &res_constraints) {
+    if (!TryGetTableInfo(dataset_id, table_id, res_columns, res_constraints)) {
+        auto table_ref = BigqueryUtils::FormatTableString(config.project_id, dataset_id, table_id);
+        throw BinderException("GetTableInfo - table \"%s\" not found", table_ref);
+    }
+}
+
+bool BigqueryClient::TryGetTableInfo(const string &dataset_id,
+                                     const string &table_id,
+                                     ColumnList &res_columns,
+                                     vector<unique_ptr<Constraint>> &res_constraints) {
     CheckAuthentication();
 
     auto client = make_shared_ptr<google::cloud::bigquerycontrol_v2::TableServiceClient>(
@@ -970,17 +980,17 @@ void BigqueryClient::GetTableInfo(const string &dataset_id,
     auto response = client->GetTable(request);
     if (!response.ok()) {
         if (CheckSSLError(response.status())) {
-            return GetTableInfo(dataset_id, table_id, res_columns, res_constraints);
+            return TryGetTableInfo(dataset_id, table_id, res_columns, res_constraints);
         }
         if (response.status().code() == google::cloud::StatusCode::kNotFound) {
-            auto table_ref = BigqueryUtils::FormatTableString(config.project_id, dataset_id, table_id);
-            throw BinderException("GetTableInfo - table \"%s\" not found", table_ref);
+            return false;
         }
         throw InternalException(response.status().message());
     }
 
     auto table = response.value();
     MapTableSchema(table.schema(), res_columns, res_constraints);
+    return true;
 }
 
 void BigqueryClient::GetTableInfoForQuery(const string &query,

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -68,6 +68,10 @@ public:
                       const string &table_id,
                       ColumnList &res_columns,
                       vector<unique_ptr<Constraint>> &res_constraints);
+    bool TryGetTableInfo(const string &dataset_id,
+                         const string &table_id,
+                         ColumnList &res_columns,
+                         vector<unique_ptr<Constraint>> &res_constraints);
     void GetTableInfoForQuery(const string &query,
                               const vector<Value> &query_parameters,
                               ColumnList &res_columns,

--- a/src/include/storage/bigquery_catalog_set.hpp
+++ b/src/include/storage/bigquery_catalog_set.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/common/mutex.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/transaction/transaction.hpp"
 
 namespace duckdb {
@@ -17,7 +18,7 @@ public:
     explicit BigqueryCatalogSet(Catalog &catalog);
     virtual ~BigqueryCatalogSet() = default;
 
-    virtual optional_ptr<CatalogEntry> CreateEntry(unique_ptr<CatalogEntry> entry);
+    virtual optional_ptr<CatalogEntry> CreateEntry(BigqueryTransaction &transaction, shared_ptr<CatalogEntry> entry);
     virtual void DropEntry(ClientContext &context, DropInfo &info);
     virtual void ClearEntries();
 
@@ -26,18 +27,24 @@ public:
     optional_ptr<CatalogEntry> GetFirstEntry(ClientContext &context);
 
 protected:
-    virtual void LoadEntries(ClientContext &context) = 0;
+    virtual void LoadEntries(ClientContext &context, BigqueryTransaction &transaction) = 0;
+    virtual bool SupportReload() const {
+        return false;
+    }
+    virtual optional_ptr<CatalogEntry> ReloadEntry(ClientContext &context,
+                                                   BigqueryTransaction &transaction,
+                                                   const string &name);
     void EraseEntryInternal(const string &name);
 
     Catalog &catalog;
 
 private:
-    void TryLoadEntries(ClientContext &context);
+    void TryLoadEntries(ClientContext &context, BigqueryTransaction &transaction);
 
     atomic<bool> is_loaded = false;
     mutex entry_lock;
     mutex load_lock;
-    case_insensitive_map_t<unique_ptr<CatalogEntry>> entries;
+    case_insensitive_map_t<shared_ptr<CatalogEntry>> entries;
 };
 
 
@@ -46,7 +53,7 @@ public:
     explicit BigqueryInSchemaSet(BigquerySchemaEntry &schema);
     ~BigqueryInSchemaSet() override = default;
 
-    optional_ptr<CatalogEntry> CreateEntry(unique_ptr<CatalogEntry> entry) override;
+    optional_ptr<CatalogEntry> CreateEntry(BigqueryTransaction &transaction, shared_ptr<CatalogEntry> entry) override;
 
 protected:
     BigquerySchemaEntry &schema;

--- a/src/include/storage/bigquery_schema_set.hpp
+++ b/src/include/storage/bigquery_schema_set.hpp
@@ -16,7 +16,7 @@ public:
     optional_ptr<CatalogEntry> CreateSchema(ClientContext &context, CreateSchemaInfo &info);
 
 protected:
-    void LoadEntries(ClientContext &context) override;
+    void LoadEntries(ClientContext &context, BigqueryTransaction &transaction) override;
 };
 
 

--- a/src/include/storage/bigquery_table_set.hpp
+++ b/src/include/storage/bigquery_table_set.hpp
@@ -25,8 +25,14 @@ public:
     void AlterTable(ClientContext &context, AlterTableInfo &info);
 
 protected:
-    void LoadEntries(ClientContext &context) override;
+    void LoadEntries(ClientContext &context, BigqueryTransaction &transaction) override;
     void ClearEntries() override;
+    bool SupportReload() const override {
+        return true;
+    }
+    optional_ptr<CatalogEntry> ReloadEntry(ClientContext &context,
+                                           BigqueryTransaction &transaction,
+                                           const string &table_name) override;
 };
 
 } // namespace bigquery

--- a/src/include/storage/bigquery_transaction.hpp
+++ b/src/include/storage/bigquery_transaction.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include "duckdb/common/case_insensitive_map.hpp"
+#include "duckdb/common/reference_map.hpp"
+#include "duckdb/common/shared_ptr.hpp"
 #include "duckdb/storage/storage_extension.hpp"
 #include "duckdb/transaction/transaction.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
@@ -25,6 +26,7 @@ public:
 
     shared_ptr<duckdb::bigquery::BigqueryClient> GetBigqueryClient();
     static BigqueryTransaction &Get(ClientContext &context, Catalog &catalog);
+    optional_ptr<CatalogEntry> ReferenceEntry(shared_ptr<CatalogEntry> &entry);
 
     AccessMode GetAccessMode() {
         return access_mode;
@@ -33,7 +35,7 @@ public:
 private:
     BigqueryCatalog &bigquery_catalog;
     shared_ptr<duckdb::bigquery::BigqueryClient> client;
-    case_insensitive_map_t<unique_ptr<CatalogEntry>> catalog_entries;
+    reference_map_t<CatalogEntry, shared_ptr<CatalogEntry>> catalog_entries;
     AccessMode access_mode;
 };
 

--- a/src/include/storage/bigquery_view_set.hpp
+++ b/src/include/storage/bigquery_view_set.hpp
@@ -19,7 +19,7 @@ public:
     optional_ptr<CatalogEntry> RefreshView(ClientContext &context, const string &view_name);
 
 protected:
-    void LoadEntries(ClientContext &context) override;
+    void LoadEntries(ClientContext &context, BigqueryTransaction &transaction) override;
     void ClearEntries() override;
 };
 

--- a/src/storage/bigquery_catalog_set.cpp
+++ b/src/storage/bigquery_catalog_set.cpp
@@ -4,21 +4,20 @@
 #include "storage/bigquery_schema_entry.hpp"
 #include "storage/bigquery_transaction.hpp"
 
-#include <iostream>
-
 namespace duckdb {
 namespace bigquery {
 
 BigqueryCatalogSet::BigqueryCatalogSet(Catalog &catalog) : catalog(catalog), is_loaded(false) {
 }
 
-optional_ptr<CatalogEntry> BigqueryCatalogSet::CreateEntry(unique_ptr<CatalogEntry> entry) {
+optional_ptr<CatalogEntry> BigqueryCatalogSet::CreateEntry(BigqueryTransaction &transaction,
+                                                           shared_ptr<CatalogEntry> entry) {
     lock_guard<mutex> lock(entry_lock);
-    auto result = entry.get();
-    if (result->name.empty()) {
+    if (!entry || entry->name.empty()) {
         throw InternalException("Cannot create entry with empty name");
     }
-    entries.insert(std::make_pair(result->name, std::move(entry)));
+    auto result = transaction.ReferenceEntry(entry);
+    entries[result->name] = std::move(entry);
     return result;
 }
 
@@ -40,33 +39,58 @@ void BigqueryCatalogSet::DropEntry(ClientContext &context, DropInfo &info) {
 }
 
 void BigqueryCatalogSet::Scan(ClientContext &context, const std::function<void(CatalogEntry &)> &callback) {
-    TryLoadEntries(context);
+    auto &transaction = BigqueryTransaction::Get(context, catalog);
+    TryLoadEntries(context, transaction);
 
-    lock_guard<mutex> lock(entry_lock);
-    for (auto &entry : entries) {
-        callback(*entry.second);
+    vector<shared_ptr<CatalogEntry>> entry_refs;
+    {
+        lock_guard<mutex> lock(entry_lock);
+        for (auto &entry : entries) {
+            entry_refs.push_back(entry.second);
+        }
+    }
+
+    for (auto &entry : entry_refs) {
+        auto pinned_entry = transaction.ReferenceEntry(entry);
+        callback(*pinned_entry);
     }
 }
 
 optional_ptr<CatalogEntry> BigqueryCatalogSet::GetEntry(ClientContext &context, const string &name) {
-    TryLoadEntries(context);
+    auto &transaction = BigqueryTransaction::Get(context, catalog);
+    TryLoadEntries(context, transaction);
 
-    lock_guard<mutex> lock(entry_lock);
-    auto entry = entries.find(name);
-    if (entry == entries.end()) {
-        return nullptr;
+    {
+        lock_guard<mutex> lock(entry_lock);
+        auto entry = entries.find(name);
+        if (entry != entries.end()) {
+            return transaction.ReferenceEntry(entry->second);
+        }
     }
-    return entry->second.get();
+
+    if (SupportReload()) {
+        lock_guard<mutex> lock(load_lock);
+        {
+            lock_guard<mutex> entry_guard(entry_lock);
+            auto entry = entries.find(name);
+            if (entry != entries.end()) {
+                return transaction.ReferenceEntry(entry->second);
+            }
+        }
+        return ReloadEntry(context, transaction, name);
+    }
+    return nullptr;
 }
 
 optional_ptr<CatalogEntry> BigqueryCatalogSet::GetFirstEntry(ClientContext &context) {
-    TryLoadEntries(context);
+    auto &transaction = BigqueryTransaction::Get(context, catalog);
+    TryLoadEntries(context, transaction);
 
     lock_guard<mutex> lock(entry_lock);
     if (entries.empty()) {
         return nullptr;
     }
-    return entries.begin()->second.get();
+    return transaction.ReferenceEntry(entries.begin()->second);
 }
 
 void BigqueryCatalogSet::ClearEntries() {
@@ -80,14 +104,20 @@ void BigqueryCatalogSet::EraseEntryInternal(const string &name) {
     entries.erase(name);
 }
 
-void BigqueryCatalogSet::TryLoadEntries(ClientContext &context) {
+optional_ptr<CatalogEntry> BigqueryCatalogSet::ReloadEntry(ClientContext &,
+                                                           BigqueryTransaction &,
+                                                           const string &) {
+    return nullptr;
+}
+
+void BigqueryCatalogSet::TryLoadEntries(ClientContext &context, BigqueryTransaction &transaction) {
     lock_guard<mutex> lock(load_lock);
     if (is_loaded) {
         return;
     }
 
     try {
-        LoadEntries(context);
+        LoadEntries(context, transaction);
         is_loaded = true;
     } catch (...) {
         is_loaded = false;
@@ -99,8 +129,9 @@ BigqueryInSchemaSet::BigqueryInSchemaSet(BigquerySchemaEntry &schema)
     : BigqueryCatalogSet(schema.ParentCatalog()), schema(schema) {
 }
 
-optional_ptr<CatalogEntry> BigqueryInSchemaSet::CreateEntry(unique_ptr<CatalogEntry> entry) {
-    return BigqueryCatalogSet::CreateEntry(std::move(entry));
+optional_ptr<CatalogEntry> BigqueryInSchemaSet::CreateEntry(BigqueryTransaction &transaction,
+                                                            shared_ptr<CatalogEntry> entry) {
+    return BigqueryCatalogSet::CreateEntry(transaction, std::move(entry));
 }
 
 } // namespace bigquery

--- a/src/storage/bigquery_catalog_set.cpp
+++ b/src/storage/bigquery_catalog_set.cpp
@@ -104,9 +104,7 @@ void BigqueryCatalogSet::EraseEntryInternal(const string &name) {
     entries.erase(name);
 }
 
-optional_ptr<CatalogEntry> BigqueryCatalogSet::ReloadEntry(ClientContext &,
-                                                           BigqueryTransaction &,
-                                                           const string &) {
+optional_ptr<CatalogEntry> BigqueryCatalogSet::ReloadEntry(ClientContext &, BigqueryTransaction &, const string &) {
     return nullptr;
 }
 

--- a/src/storage/bigquery_schema_set.cpp
+++ b/src/storage/bigquery_schema_set.cpp
@@ -22,12 +22,11 @@ optional_ptr<CatalogEntry> BigquerySchemaSet::CreateSchema(ClientContext &contex
     dataset_ref.location = BigquerySettings::DefaultLocation();
 
     bqclient->CreateDataset(info, dataset_ref);
-    auto schema_entry = make_uniq<BigquerySchemaEntry>(catalog, info, dataset_ref);
-    return CreateEntry(std::move(schema_entry));
+    auto schema_entry = make_shared_ptr<BigquerySchemaEntry>(catalog, info, dataset_ref);
+    return CreateEntry(transaction, std::move(schema_entry));
 }
 
-void BigquerySchemaSet::LoadEntries(ClientContext &context) {
-    auto &transaction = BigqueryTransaction::Get(context, catalog);
+void BigquerySchemaSet::LoadEntries(ClientContext &, BigqueryTransaction &transaction) {
     auto bqclient = transaction.GetBigqueryClient();
 
     if (BigquerySettings::ExperimentalFetchCatalogFromInformationSchema()) {
@@ -55,8 +54,8 @@ void BigquerySchemaSet::LoadEntries(ClientContext &context) {
             info.schema = dataset.dataset_id;
 
             vector<CreateTableInfo> &table_infos = tables_by_schema[dataset.dataset_id];
-            auto schema = make_uniq<BigquerySchemaEntry>(catalog, info, dataset, table_infos);
-            CreateEntry(std::move(schema));
+            auto schema = make_shared_ptr<BigquerySchemaEntry>(catalog, info, dataset, table_infos);
+            CreateEntry(transaction, std::move(schema));
         }
     } else {
         vector<BigqueryDatasetRef> datasets = bqclient->GetDatasets();
@@ -65,8 +64,8 @@ void BigquerySchemaSet::LoadEntries(ClientContext &context) {
             info.catalog = dataset.project_id;
             info.schema = dataset.dataset_id;
 
-            auto schema = make_uniq<BigquerySchemaEntry>(catalog, info, dataset);
-            CreateEntry(std::move(schema));
+            auto schema = make_shared_ptr<BigquerySchemaEntry>(catalog, info, dataset);
+            CreateEntry(transaction, std::move(schema));
         }
     }
 }

--- a/src/storage/bigquery_table_set.cpp
+++ b/src/storage/bigquery_table_set.cpp
@@ -27,16 +27,15 @@ optional_ptr<CatalogEntry> BigqueryTableSet::CreateTable(ClientContext &context,
     table_ref.table_id = create_table_info.table;
 
     bqclient->CreateTable(create_table_info, table_ref);
-    auto table_entry = make_uniq<BigqueryTableEntry>(catalog, schema, info.Base());
-    return CreateEntry(std::move(table_entry));
+    auto table_entry = make_shared_ptr<BigqueryTableEntry>(catalog, schema, info.Base());
+    return CreateEntry(transaction, std::move(table_entry));
 }
 
 optional_ptr<CatalogEntry> BigqueryTableSet::RefreshTable(ClientContext &context, const string &table_name) {
+    auto &transaction = BigqueryTransaction::Get(context, catalog);
     auto table_info = GetTableInfo(context, schema, table_name);
-    auto table_entry = make_uniq<BigqueryTableEntry>(catalog, schema, *table_info);
-    auto table_ptr = table_entry.get();
-    CreateEntry(std::move(table_entry));
-    return table_ptr;
+    auto table_entry = make_shared_ptr<BigqueryTableEntry>(catalog, schema, *table_info);
+    return CreateEntry(transaction, std::move(table_entry));
 }
 
 unique_ptr<BigqueryTableInfo> BigqueryTableSet::GetTableInfo(ClientContext &context,
@@ -64,24 +63,23 @@ void BigqueryTableSet::AlterTable(ClientContext &context, AlterTableInfo &info) 
     ClearEntries();
 }
 
-void BigqueryTableSet::LoadEntries(ClientContext &context) {
-    auto &transaction = BigqueryTransaction::Get(context, catalog);
+void BigqueryTableSet::LoadEntries(ClientContext &, BigqueryTransaction &transaction) {
     auto bqclient = transaction.GetBigqueryClient();
 
     if (BigquerySettings::ExperimentalFetchCatalogFromInformationSchema()) {
         auto &prefetched_table_infos = schema.GetTableInfos();
         if (prefetched_table_infos.has_value()) {
             for (auto &table_info : prefetched_table_infos.value()) {
-                auto table_entry = make_uniq<BigqueryTableEntry>(catalog, schema, table_info);
-                CreateEntry(std::move(table_entry));
+                auto table_entry = make_shared_ptr<BigqueryTableEntry>(catalog, schema, table_info);
+                CreateEntry(transaction, std::move(table_entry));
             }
         } else {
             std::map<string, CreateTableInfo> table_infos;
             bqclient->GetTableInfosFromDataset(schema.GetBigqueryDatasetRef(), table_infos);
 
             for (auto &table_info : table_infos) {
-                auto table_entry = make_uniq<BigqueryTableEntry>(catalog, schema, table_info.second);
-                CreateEntry(std::move(table_entry));
+                auto table_entry = make_shared_ptr<BigqueryTableEntry>(catalog, schema, table_info.second);
+                CreateEntry(transaction, std::move(table_entry));
             }
         }
     } else {
@@ -95,10 +93,26 @@ void BigqueryTableSet::LoadEntries(ClientContext &context) {
                                    table_ref.table_id,
                                    info->create_info->columns,
                                    info->create_info->constraints);
-            auto table_entry = make_uniq<BigqueryTableEntry>(catalog, schema, *info);
-            CreateEntry(std::move(table_entry));
+            auto table_entry = make_shared_ptr<BigqueryTableEntry>(catalog, schema, *info);
+            CreateEntry(transaction, std::move(table_entry));
         }
     }
+}
+
+optional_ptr<CatalogEntry> BigqueryTableSet::ReloadEntry(ClientContext &,
+                                                         BigqueryTransaction &transaction,
+                                                         const string &table_name) {
+    auto bqclient = transaction.GetBigqueryClient();
+    auto project_id = dynamic_cast<BigqueryCatalog &>(catalog).GetProjectID();
+    auto table_info = make_uniq<BigqueryTableInfo>(project_id, schema.name, table_name);
+    if (!bqclient->TryGetTableInfo(schema.name,
+                                   table_name,
+                                   table_info->create_info->columns,
+                                   table_info->create_info->constraints)) {
+        return nullptr;
+    }
+    auto table_entry = make_shared_ptr<BigqueryTableEntry>(catalog, schema, *table_info);
+    return CreateEntry(transaction, std::move(table_entry));
 }
 
 void BigqueryTableSet::ClearEntries() {

--- a/src/storage/bigquery_transaction.cpp
+++ b/src/storage/bigquery_transaction.cpp
@@ -27,6 +27,12 @@ shared_ptr<BigqueryClient> BigqueryTransaction::GetBigqueryClient() {
     return client;
 }
 
+optional_ptr<CatalogEntry> BigqueryTransaction::ReferenceEntry(shared_ptr<CatalogEntry> &entry) {
+    auto &ref = *entry;
+    catalog_entries.emplace(ref, entry);
+    return ref;
+}
+
 BigqueryTransaction &BigqueryTransaction::Get(ClientContext &context, Catalog &catalog) {
     return Transaction::Get(context, catalog).Cast<BigqueryTransaction>();
 }

--- a/test/sql/storage/attach_catalog_cache_reload.test
+++ b/test/sql/storage/attach_catalog_cache_reload.test
@@ -48,10 +48,10 @@ FROM bigquery_execute('${BQ_TEST_PROJECT}', '
     SELECT 3 AS i
 ');
 
-query I
-SELECT i FROM bq_cache_reload.${BQ_TEST_DATASET}.catalog_cache_reload_view;
+query IIIIII
+DESCRIBE bq_cache_reload.${BQ_TEST_DATASET}.catalog_cache_reload_view;
 ----
-3
+i	BIGINT	YES	NULL	NULL	NULL
 
 statement ok
 DETACH bq_cache_reload;

--- a/test/sql/storage/attach_catalog_cache_reload.test
+++ b/test/sql/storage/attach_catalog_cache_reload.test
@@ -1,0 +1,66 @@
+# name: test/sql/storage/attach_catalog_cache_reload.test
+# description: Validate attached BigQuery catalog reloads missing table and view entries
+# group: [storage]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP VIEW IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_view`');
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_new`');
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_seed`');
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', '
+    CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_seed` AS
+    SELECT 1 AS i
+');
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq_cache_reload (TYPE bigquery);
+
+query I
+SELECT i FROM bq_cache_reload.${BQ_TEST_DATASET}.catalog_cache_reload_seed;
+----
+1
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', '
+    CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_new` AS
+    SELECT 2 AS i
+');
+
+query I
+SELECT i FROM bq_cache_reload.${BQ_TEST_DATASET}.catalog_cache_reload_new;
+----
+2
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', '
+    CREATE OR REPLACE VIEW `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_view` AS
+    SELECT 3 AS i
+');
+
+query I
+SELECT i FROM bq_cache_reload.${BQ_TEST_DATASET}.catalog_cache_reload_view;
+----
+3
+
+statement ok
+DETACH bq_cache_reload;
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP VIEW IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_view`');
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_new`');
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.catalog_cache_reload_seed`');


### PR DESCRIPTION
Makes the attached BQ catalog cache transaction-stable by storing catalog entries as shared references and pinning returned entries in the active transaction.

Also adds targeted reload support for missing table/view entries and coverage for resolving externally-created objects without clearing the catalog cache.