### PR TITLE
Return DML affected row counts

### DIFF
--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -52,6 +52,7 @@
 #include <chrono>
 #include <cstring>
 #include <iostream>
+#include <optional>
 
 
 namespace duckdb {
@@ -229,6 +230,71 @@ static google::cloud::bigquery::v2::QueryParameter BuildPositionalQueryParameter
     }
 
     return parameter;
+}
+
+static const char *DmlStatementName(BigqueryDmlStatementType statement_type) {
+    switch (statement_type) {
+    case BigqueryDmlStatementType::UPDATE:
+        return "UPDATE";
+    case BigqueryDmlStatementType::DELETE:
+        return "DELETE";
+    }
+    throw InternalException("Unknown BigQuery DML statement type");
+}
+
+static std::optional<int64_t> ExtractDmlStatsAffectedRows(const google::cloud::bigquery::v2::DmlStats &dml_stats,
+                                                          BigqueryDmlStatementType statement_type) {
+    switch (statement_type) {
+    case BigqueryDmlStatementType::UPDATE:
+        if (dml_stats.has_updated_row_count()) {
+            return dml_stats.updated_row_count().value();
+        }
+        return std::nullopt;
+    case BigqueryDmlStatementType::DELETE:
+        if (dml_stats.has_deleted_row_count()) {
+            return dml_stats.deleted_row_count().value();
+        }
+        return std::nullopt;
+    }
+    throw InternalException("Unknown BigQuery DML statement type");
+}
+
+static std::optional<int64_t> ExtractDmlAffectedRows(
+    const google::cloud::bigquery::v2::QueryResponse &response,
+    BigqueryDmlStatementType statement_type) {
+    if (response.has_dml_stats()) {
+        auto affected_rows = ExtractDmlStatsAffectedRows(response.dml_stats(), statement_type);
+        if (affected_rows.has_value()) {
+            return affected_rows;
+        }
+    }
+    if (response.has_num_dml_affected_rows()) {
+        return response.num_dml_affected_rows().value();
+    }
+    return std::nullopt;
+}
+
+static std::optional<int64_t> ExtractDmlAffectedRows(
+    const google::cloud::bigquery::v2::JobStatistics2 &query_statistics,
+    BigqueryDmlStatementType statement_type) {
+    if (query_statistics.has_dml_stats()) {
+        auto affected_rows = ExtractDmlStatsAffectedRows(query_statistics.dml_stats(), statement_type);
+        if (affected_rows.has_value()) {
+            return affected_rows;
+        }
+    }
+    if (query_statistics.has_num_dml_affected_rows()) {
+        return query_statistics.num_dml_affected_rows().value();
+    }
+    return std::nullopt;
+}
+
+static idx_t CastDmlAffectedRows(int64_t affected_rows, BigqueryDmlStatementType statement_type) {
+    if (affected_rows < 0) {
+        throw InternalException("BigQuery %s statement returned a negative DML affected-row count",
+                                DmlStatementName(statement_type));
+    }
+    return static_cast<idx_t>(affected_rows);
 }
 
 static string GetLoadStagingDirectory(FileSystem &fs) {
@@ -1104,6 +1170,26 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
     }
 
     return *response;
+}
+
+idx_t BigqueryClient::ExecuteDmlQuery(const string &query,
+                                      BigqueryDmlStatementType statement_type,
+                                      const string &location) {
+    auto result = ExecuteQuery(query, location);
+    auto affected_rows = ExtractDmlAffectedRows(result, statement_type);
+
+    if (!affected_rows.has_value() && result.has_job_reference()) {
+        auto job = GetJobByReference(result.job_reference());
+        if (job.has_statistics() && job.statistics().has_query()) {
+            affected_rows = ExtractDmlAffectedRows(job.statistics().query(), statement_type);
+        }
+    }
+
+    if (!affected_rows.has_value()) {
+        throw InternalException("BigQuery %s statement did not return a DML affected-row count",
+                                DmlStatementName(statement_type));
+    }
+    return CastDmlAffectedRows(affected_rows.value(), statement_type);
 }
 
 google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryResults(

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -234,9 +234,9 @@ static google::cloud::bigquery::v2::QueryParameter BuildPositionalQueryParameter
 
 static const char *DmlStatementName(BigqueryDmlStatementType statement_type) {
     switch (statement_type) {
-    case BigqueryDmlStatementType::UPDATE:
+    case BigqueryDmlStatementType::DML_UPDATE:
         return "UPDATE";
-    case BigqueryDmlStatementType::DELETE:
+    case BigqueryDmlStatementType::DML_DELETE:
         return "DELETE";
     }
     throw InternalException("Unknown BigQuery DML statement type");
@@ -245,12 +245,12 @@ static const char *DmlStatementName(BigqueryDmlStatementType statement_type) {
 static std::optional<int64_t> ExtractDmlStatsAffectedRows(const google::cloud::bigquery::v2::DmlStats &dml_stats,
                                                           BigqueryDmlStatementType statement_type) {
     switch (statement_type) {
-    case BigqueryDmlStatementType::UPDATE:
+    case BigqueryDmlStatementType::DML_UPDATE:
         if (dml_stats.has_updated_row_count()) {
             return dml_stats.updated_row_count().value();
         }
         return std::nullopt;
-    case BigqueryDmlStatementType::DELETE:
+    case BigqueryDmlStatementType::DML_DELETE:
         if (dml_stats.has_deleted_row_count()) {
             return dml_stats.deleted_row_count().value();
         }

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -259,9 +259,8 @@ static std::optional<int64_t> ExtractDmlStatsAffectedRows(const google::cloud::b
     throw InternalException("Unknown BigQuery DML statement type");
 }
 
-static std::optional<int64_t> ExtractDmlAffectedRows(
-    const google::cloud::bigquery::v2::QueryResponse &response,
-    BigqueryDmlStatementType statement_type) {
+static std::optional<int64_t> ExtractDmlAffectedRows(const google::cloud::bigquery::v2::QueryResponse &response,
+                                                     BigqueryDmlStatementType statement_type) {
     if (response.has_dml_stats()) {
         auto affected_rows = ExtractDmlStatsAffectedRows(response.dml_stats(), statement_type);
         if (affected_rows.has_value()) {

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -37,6 +37,8 @@ struct ListJobsParams {
     std::optional<std::string> parent_job_id;
 };
 
+enum class BigqueryDmlStatementType { UPDATE, DELETE };
+
 class BigqueryClient {
 public:
     explicit BigqueryClient(ClientContext &context, const BigqueryConfig &config);
@@ -104,6 +106,9 @@ public:
                                                             const bool &dry_run = false,
                                                             const vector<Value> &query_parameters = {},
                                                             const bool &optional_job_creation = false);
+    idx_t ExecuteDmlQuery(const string &query,
+                          BigqueryDmlStatementType statement_type,
+                          const string &location = "");
     google::cloud::bigquery::v2::GetQueryResultsResponse GetQueryResults(
         const google::cloud::bigquery::v2::JobReference &job_ref,
         const string &page_token = "");

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -37,7 +37,7 @@ struct ListJobsParams {
     std::optional<std::string> parent_job_id;
 };
 
-enum class BigqueryDmlStatementType { UPDATE, DELETE };
+enum class BigqueryDmlStatementType { DML_UPDATE, DML_DELETE };
 
 class BigqueryClient {
 public:

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -106,9 +106,7 @@ public:
                                                             const bool &dry_run = false,
                                                             const vector<Value> &query_parameters = {},
                                                             const bool &optional_job_creation = false);
-    idx_t ExecuteDmlQuery(const string &query,
-                          BigqueryDmlStatementType statement_type,
-                          const string &location = "");
+    idx_t ExecuteDmlQuery(const string &query, BigqueryDmlStatementType statement_type, const string &location = "");
     google::cloud::bigquery::v2::GetQueryResultsResponse GetQueryResults(
         const google::cloud::bigquery::v2::JobReference &job_ref,
         const string &page_token = "");

--- a/src/storage/bigquery_delete.cpp
+++ b/src/storage/bigquery_delete.cpp
@@ -34,7 +34,7 @@ SinkFinalizeType BigqueryDelete::Finalize(Pipeline &pipeline,
     auto &gstate = input.global_state.Cast<BigqueryDeleteGlobalState>();
     auto &transaction = BigqueryTransaction::Get(context, table.catalog);
     auto bq_client = transaction.GetBigqueryClient();
-    gstate.deleted_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::DELETE);
+    gstate.deleted_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::DML_DELETE);
     return SinkFinalizeType::READY;
 }
 

--- a/src/storage/bigquery_delete.cpp
+++ b/src/storage/bigquery_delete.cpp
@@ -34,8 +34,7 @@ SinkFinalizeType BigqueryDelete::Finalize(Pipeline &pipeline,
     auto &gstate = input.global_state.Cast<BigqueryDeleteGlobalState>();
     auto &transaction = BigqueryTransaction::Get(context, table.catalog);
     auto bq_client = transaction.GetBigqueryClient();
-    auto result = bq_client->ExecuteQuery(query); // TODO
-    gstate.deleted_count = result.total_rows().value();
+    gstate.deleted_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::DELETE);
     return SinkFinalizeType::READY;
 }
 

--- a/src/storage/bigquery_update.cpp
+++ b/src/storage/bigquery_update.cpp
@@ -35,7 +35,7 @@ SinkFinalizeType BigqueryUpdate::Finalize(Pipeline &pipeline,
     auto &gstate = input.global_state.Cast<BigqueryUpdateGlobalState>();
     auto &transaction = BigqueryTransaction::Get(context, table.catalog);
     auto bq_client = transaction.GetBigqueryClient();
-    gstate.updated_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::UPDATE);
+    gstate.updated_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::DML_UPDATE);
     return SinkFinalizeType::READY;
 }
 

--- a/src/storage/bigquery_update.cpp
+++ b/src/storage/bigquery_update.cpp
@@ -35,11 +35,7 @@ SinkFinalizeType BigqueryUpdate::Finalize(Pipeline &pipeline,
     auto &gstate = input.global_state.Cast<BigqueryUpdateGlobalState>();
     auto &transaction = BigqueryTransaction::Get(context, table.catalog);
     auto bq_client = transaction.GetBigqueryClient();
-    auto result = bq_client->ExecuteQuery(query);
-
-    const auto &total_rows = result.total_rows();
-    uint64_t extracted_value = total_rows.value();
-    gstate.updated_count = extracted_value;
+    gstate.updated_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::UPDATE);
     return SinkFinalizeType::READY;
 }
 

--- a/test/sql/storage/attach_dml_statements.test
+++ b/test/sql/storage/attach_dml_statements.test
@@ -20,8 +20,10 @@ CREATE OR REPLACE TABLE bq.${BQ_TEST_DATASET}.dml_statements (i INTEGER);
 statement ok
 INSERT INTO bq.${BQ_TEST_DATASET}.dml_statements FROM range(5);
 
-statement ok
+query I
 UPDATE bq.${BQ_TEST_DATASET}.dml_statements SET i=10 WHERE 1=1;
+----
+5
 
 query I
 SELECT * FROM bq.${BQ_TEST_DATASET}.dml_statements;
@@ -32,8 +34,10 @@ SELECT * FROM bq.${BQ_TEST_DATASET}.dml_statements;
 10
 10
 
-statement ok
+query I
 DELETE FROM bq.${BQ_TEST_DATASET}.dml_statements WHERE 1=1;
+----
+5
 
 query I
 SELECT * FROM bq.${BQ_TEST_DATASET}.dml_statements;


### PR DESCRIPTION
Use BQ DML metadata for UPDATE/DELETE row counts, preferring statement-specific `dml_stats` with fallbacks to `num_dml_affected_rows` and job statistics. Adds storage DML assertions for affected rows.