### PR TITLE
Avoid BQ scans for remote DML

### DIFF
--- a/src/bigquery_sql.cpp
+++ b/src/bigquery_sql.cpp
@@ -1,12 +1,12 @@
 #include "duckdb.hpp"
 #include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
-#include "duckdb/execution/operator/filter/physical_filter.hpp"
-#include "duckdb/execution/operator/projection/physical_projection.hpp"
-#include "duckdb/execution/operator/scan/physical_table_scan.hpp"
 #include "duckdb/parser/parsed_data/create_view_info.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "duckdb/planner/operator/logical_delete.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_projection.hpp"
 
 #include "duckdb/planner/filter/conjunction_filter.hpp"
 #include "duckdb/planner/filter/constant_filter.hpp"
@@ -22,39 +22,48 @@
 namespace duckdb {
 namespace bigquery {
 
-
-std::string BigquerySQL::ExtractFilters(PhysicalOperator &child) {
+std::string BigquerySQL::ExtractFilters(LogicalOperator &child) {
     switch (child.type) {
-    case PhysicalOperatorType::FILTER: {
-        auto &filter = child.Cast<PhysicalFilter>();
-        std::string filter_exp = filter.expression->ToString();
+    case LogicalOperatorType::LOGICAL_FILTER: {
+        auto &filter = child.Cast<LogicalFilter>();
+        vector<string> filter_entries;
+        for (auto &expression : filter.expressions) {
+            filter_entries.push_back(expression->ToString());
+        }
         if (!child.children.empty()) {
-            std::string result = ExtractFilters(child.children[0]);
-            if (!result.empty()) {
-                filter_exp += " AND " + result;
+            auto child_filters = ExtractFilters(*child.children[0]);
+            if (!child_filters.empty()) {
+                filter_entries.push_back(child_filters);
             }
         }
-        return filter_exp;
+        return StringUtil::Join(filter_entries, " AND ");
     }
-    case PhysicalOperatorType::TABLE_SCAN: {
-        auto &table_scan = child.Cast<PhysicalTableScan>();
-        if (!table_scan.table_filters) {
-            return std::string();
+    case LogicalOperatorType::LOGICAL_PROJECTION:
+        if (child.children.empty()) {
+            return string();
         }
-        std::string table_filters_exp = "";
-        for (auto &filter : table_scan.table_filters->filters) {
+        return ExtractFilters(*child.children[0]);
+    case LogicalOperatorType::LOGICAL_GET: {
+        auto &get = child.Cast<LogicalGet>();
+        if (get.table_filters.filters.empty()) {
+            return string();
+        }
+        auto &column_ids = get.GetColumnIds();
+        string table_filters_exp;
+        for (auto &filter : get.table_filters.filters) {
             if (!table_filters_exp.empty()) {
                 table_filters_exp += " AND ";
             }
-            auto column_id = table_scan.column_ids[filter.first];
-            auto &column_name = table_scan.names[column_id.GetPrimaryIndex()];
-            auto filter_exp = TransformFilter(column_name, *filter.second);
-            table_filters_exp += filter_exp;
+            auto column_id = column_ids[filter.first];
+            auto &column_name = get.names[column_id.GetPrimaryIndex()];
+            table_filters_exp += TransformFilter(column_name, *filter.second);
         }
         return table_filters_exp;
     }
+    case LogicalOperatorType::LOGICAL_EMPTY_RESULT:
+        return "false";
     default:
-        throw NotImplementedException("Unsupported operator type " + PhysicalOperatorToString(child.type));
+        throw NotImplementedException("Unsupported logical operator type " + LogicalOperatorToString(child.type));
     }
 }
 
@@ -346,11 +355,11 @@ string BigquerySQL::DropInfoToSQL(const string &project_id, const DropInfo &info
     return query;
 }
 
-string BigquerySQL::LogicalUpdateToSQL(const string &project_id, LogicalUpdate &lu, PhysicalOperator &child) {
-    if (child.type != PhysicalOperatorType::PROJECTION) {
+string BigquerySQL::LogicalUpdateToSQL(const string &project_id, LogicalUpdate &lu) {
+    if (lu.children.empty() || lu.children[0]->type != LogicalOperatorType::LOGICAL_PROJECTION) {
         throw NotImplementedException("BigQuery: This type of UPDATE not supported.");
     }
-    auto &proj = child.Cast<PhysicalProjection>();
+    auto &proj = lu.children[0]->Cast<LogicalProjection>();
     auto table_string = BigqueryUtils::FormatTableStringSimple(project_id, //
                                                                lu.table.schema.name,
                                                                lu.table.name);
@@ -373,10 +382,13 @@ string BigquerySQL::LogicalUpdateToSQL(const string &project_id, LogicalUpdate &
             throw NotImplementedException("BigQuery UPDATE - Expected a bound reference expression");
         }
         auto &ref = lu.expressions[c]->Cast<BoundReferenceExpression>();
-        sql += proj.select_list[ref.index]->ToString();
+        if (ref.index >= proj.expressions.size()) {
+            throw InternalException("BigQuery UPDATE - Projection reference index out of range");
+        }
+        sql += proj.expressions[ref.index]->ToString();
     }
 
-    auto filters = ExtractFilters(child.children[0]);
+    auto filters = proj.children.empty() ? string() : ExtractFilters(*proj.children[0]);
     if (!filters.empty()) {
         sql += " WHERE " + filters;
     } else {
@@ -386,7 +398,7 @@ string BigquerySQL::LogicalUpdateToSQL(const string &project_id, LogicalUpdate &
     return sql;
 }
 
-string BigquerySQL::LogicalDeleteToSQL(const string &project_id, LogicalDelete &ld, PhysicalOperator &child) {
+string BigquerySQL::LogicalDeleteToSQL(const string &project_id, LogicalDelete &ld) {
     auto table_string = BigqueryUtils::FormatTableStringSimple(project_id, //
                                                                ld.table.schema.name,
                                                                ld.table.name);
@@ -394,17 +406,17 @@ string BigquerySQL::LogicalDeleteToSQL(const string &project_id, LogicalDelete &
     sql << "DELETE FROM ";
     sql << BigqueryUtils::WriteQuotedIdentifier(table_string);
     try {
-        auto filters = ExtractFilters(child);
+        auto filters = ld.children.empty() ? string() : ExtractFilters(*ld.children[0]);
         if (!filters.empty()) {
             sql << " WHERE " + filters;
         } else {
-            // Each UPDATE statement must have a WHERE clause
+            // Each DELETE statement must have a WHERE clause
             sql << " WHERE true";
         }
     } catch (const NotImplementedException &e) {
         throw NotImplementedException(std::string(e.what()) +
                                       " in DELETE statement - only simple deletes (e.g. DELETE FROM tbl WHERE x=y) are "
-                                      "supported in the MySQL connector");
+                                      "supported in the BigQuery connector");
     }
     return sql.str();
 }

--- a/src/include/bigquery_sql.hpp
+++ b/src/include/bigquery_sql.hpp
@@ -6,6 +6,7 @@
 #include "duckdb/parser/parsed_data/create_schema_info.hpp"
 #include "duckdb/parser/parsed_data/create_table_info.hpp"
 #include "duckdb/parser/parsed_data/drop_info.hpp"
+#include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/operator/logical_delete.hpp"
 #include "duckdb/planner/operator/logical_update.hpp"
 
@@ -16,7 +17,7 @@ namespace bigquery {
 
 struct BigquerySQL {
 public:
-    static string ExtractFilters(PhysicalOperator &child);
+    static string ExtractFilters(LogicalOperator &child);
     static string TransformFilter(const string &column_name, TableFilter &filter);
     static string CreateExpression(const string &column_name,
                                    vector<unique_ptr<TableFilter>> &filters,
@@ -28,8 +29,8 @@ public:
     static string CreateViewInfoToSQL(const string &project_id, const CreateViewInfo &info);
     static string DropInfoToSQL(const string &project_id, const DropInfo &info);
 
-    static string LogicalUpdateToSQL(const string &project_id, LogicalUpdate &lu, PhysicalOperator &child);
-    static string LogicalDeleteToSQL(const string &project_id, LogicalDelete &ld, PhysicalOperator &child);
+    static string LogicalUpdateToSQL(const string &project_id, LogicalUpdate &lu);
+    static string LogicalDeleteToSQL(const string &project_id, LogicalDelete &ld);
 
     static string BigqueryColumnToSQL(const ColumnDefinition &column);
     static string BigqueryColumnsToSQL(const ColumnList &columns, const vector<unique_ptr<Constraint>> &constraints);

--- a/src/include/storage/bigquery_catalog.hpp
+++ b/src/include/storage/bigquery_catalog.hpp
@@ -48,10 +48,12 @@ public:
                                  PhysicalPlanGenerator &planner,
                                  LogicalDelete &op,
                                  PhysicalOperator &plan) override;
+    PhysicalOperator &PlanDelete(ClientContext &context, PhysicalPlanGenerator &planner, LogicalDelete &op) override;
     PhysicalOperator &PlanUpdate(ClientContext &context,
                                  PhysicalPlanGenerator &planner,
                                  LogicalUpdate &op,
                                  PhysicalOperator &plan) override;
+    PhysicalOperator &PlanUpdate(ClientContext &context, PhysicalPlanGenerator &planner, LogicalUpdate &op) override;
     unique_ptr<LogicalOperator> BindCreateIndex(Binder &binder,
                                                 CreateStatement &stmt,
                                                 TableCatalogEntry &table,

--- a/src/include/storage/bigquery_delete.hpp
+++ b/src/include/storage/bigquery_delete.hpp
@@ -5,13 +5,6 @@
 namespace duckdb {
 namespace bigquery {
 
-class BigqueryDeleteGlobalState : public GlobalSinkState {
-public:
-    explicit BigqueryDeleteGlobalState() : deleted_count(0) {
-    }
-    idx_t deleted_count;
-};
-
 class BigqueryDelete : public PhysicalOperator {
 public:
     BigqueryDelete(PhysicalPlan &physical_plan, LogicalOperator &op, TableCatalogEntry &table, string query);
@@ -21,29 +14,13 @@ public:
 
 public:
     // Source Interface
+    unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
     SourceResultType GetDataInternal(ExecutionContext &context,
                                      DataChunk &chunk,
                                      OperatorSourceInput &input) const override;
 
     bool IsSource() const override {
         return true;
-    }
-
-public:
-    // Sink Interface
-    unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-    SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
-    SinkFinalizeType Finalize(Pipeline &pipeline,
-                              Event &event,
-                              ClientContext &context,
-                              OperatorSinkFinalizeInput &input) const override;
-
-    bool IsSink() const override {
-        return true;
-    }
-
-    bool ParallelSink() const override {
-        return false;
     }
 
     string GetName() const override;

--- a/src/include/storage/bigquery_update.hpp
+++ b/src/include/storage/bigquery_update.hpp
@@ -18,29 +18,13 @@ public:
 
 public:
     // Source Interface
+    unique_ptr<GlobalSourceState> GetGlobalSourceState(ClientContext &context) const override;
     SourceResultType GetDataInternal(ExecutionContext &context,
                                      DataChunk &chunk,
                                      OperatorSourceInput &input) const override;
 
     bool IsSource() const override {
         return true;
-    }
-
-public:
-    // Sink interface
-    unique_ptr<GlobalSinkState> GetGlobalSinkState(ClientContext &context) const override;
-    SinkResultType Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const override;
-    SinkFinalizeType Finalize(Pipeline &pipeline,
-                              Event &event,
-                              ClientContext &context,
-                              OperatorSinkFinalizeInput &input) const override;
-
-    bool IsSink() const override {
-        return true;
-    }
-
-    bool ParallelSink() const override {
-        return false;
     }
 
     string GetName() const override;

--- a/src/storage/bigquery_delete.cpp
+++ b/src/storage/bigquery_delete.cpp
@@ -14,34 +14,35 @@
 namespace duckdb {
 namespace bigquery {
 
+struct BigqueryDeleteGlobalSourceState : public GlobalSourceState {
+    explicit BigqueryDeleteGlobalSourceState() : finished(false), deleted_count(0) {
+    }
+    bool finished;
+    idx_t deleted_count;
+};
+
 BigqueryDelete::BigqueryDelete(PhysicalPlan &physical_plan, LogicalOperator &op, TableCatalogEntry &table, string query)
     : PhysicalOperator(physical_plan, PhysicalOperatorType::EXTENSION, op.types, 1), table(table),
       query(std::move(query)) {
 }
 
-unique_ptr<GlobalSinkState> BigqueryDelete::GetGlobalSinkState(ClientContext &context) const {
-    return make_uniq<BigqueryDeleteGlobalState>();
-}
-
-SinkResultType BigqueryDelete::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
-    return SinkResultType::FINISHED;
-}
-
-SinkFinalizeType BigqueryDelete::Finalize(Pipeline &pipeline,
-                                          Event &event,
-                                          ClientContext &context,
-                                          OperatorSinkFinalizeInput &input) const {
-    auto &gstate = input.global_state.Cast<BigqueryDeleteGlobalState>();
-    auto &transaction = BigqueryTransaction::Get(context, table.catalog);
-    auto bq_client = transaction.GetBigqueryClient();
-    gstate.deleted_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::DML_DELETE);
-    return SinkFinalizeType::READY;
+unique_ptr<GlobalSourceState> BigqueryDelete::GetGlobalSourceState(ClientContext &context) const {
+    return make_uniq<BigqueryDeleteGlobalSourceState>();
 }
 
 SourceResultType BigqueryDelete::GetDataInternal(ExecutionContext &context,
                                                  DataChunk &chunk,
                                                  OperatorSourceInput &input) const {
-    auto &gstate = sink_state->Cast<BigqueryDeleteGlobalState>();
+    auto &gstate = input.global_state.Cast<BigqueryDeleteGlobalSourceState>();
+    if (gstate.finished) {
+        return SourceResultType::FINISHED;
+    }
+
+    auto &transaction = BigqueryTransaction::Get(context.client, table.catalog);
+    auto bq_client = transaction.GetBigqueryClient();
+    gstate.deleted_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::DML_DELETE);
+    gstate.finished = true;
+
     chunk.SetCardinality(1);
     chunk.SetValue(0, 0, Value::BIGINT(gstate.deleted_count));
     return SourceResultType::FINISHED;
@@ -61,13 +62,19 @@ PhysicalOperator &BigqueryCatalog::PlanDelete(ClientContext &context,
                                               PhysicalPlanGenerator &planner,
                                               LogicalDelete &op,
                                               PhysicalOperator &plan) {
+    (void)plan;
+    return PlanDelete(context, planner, op);
+}
+
+PhysicalOperator &BigqueryCatalog::PlanDelete(ClientContext &context,
+                                              PhysicalPlanGenerator &planner,
+                                              LogicalDelete &op) {
     BigqueryTransaction::CheckReadWrite(context, *this, "delete from tables");
     if (op.return_chunk) {
         throw BinderException("RETURNING clause is not supported.");
     }
-    auto query = BigquerySQL::LogicalDeleteToSQL(GetProjectID(), op, plan);
+    auto query = BigquerySQL::LogicalDeleteToSQL(GetProjectID(), op);
     auto &delete_op = planner.Make<BigqueryDelete>(op, op.table, query);
-    delete_op.children.push_back(plan);
     return delete_op;
 }
 

--- a/src/storage/bigquery_update.cpp
+++ b/src/storage/bigquery_update.cpp
@@ -9,9 +9,10 @@
 namespace duckdb {
 namespace bigquery {
 
-struct BigqueryUpdateGlobalState : public GlobalSinkState {
-    explicit BigqueryUpdateGlobalState() : updated_count(0) {
+struct BigqueryUpdateGlobalSourceState : public GlobalSourceState {
+    explicit BigqueryUpdateGlobalSourceState() : finished(false), updated_count(0) {
     }
+    bool finished;
     idx_t updated_count;
 };
 
@@ -20,29 +21,23 @@ BigqueryUpdate::BigqueryUpdate(PhysicalPlan &physical_plan, LogicalOperator &op,
       query(std::move(query)) {
 }
 
-unique_ptr<GlobalSinkState> BigqueryUpdate::GetGlobalSinkState(ClientContext &context) const {
-    return make_uniq<BigqueryUpdateGlobalState>();
-}
-
-SinkResultType BigqueryUpdate::Sink(ExecutionContext &context, DataChunk &chunk, OperatorSinkInput &input) const {
-    return SinkResultType::FINISHED;
-}
-
-SinkFinalizeType BigqueryUpdate::Finalize(Pipeline &pipeline,
-                                          Event &event,
-                                          ClientContext &context,
-                                          OperatorSinkFinalizeInput &input) const {
-    auto &gstate = input.global_state.Cast<BigqueryUpdateGlobalState>();
-    auto &transaction = BigqueryTransaction::Get(context, table.catalog);
-    auto bq_client = transaction.GetBigqueryClient();
-    gstate.updated_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::DML_UPDATE);
-    return SinkFinalizeType::READY;
+unique_ptr<GlobalSourceState> BigqueryUpdate::GetGlobalSourceState(ClientContext &context) const {
+    return make_uniq<BigqueryUpdateGlobalSourceState>();
 }
 
 SourceResultType BigqueryUpdate::GetDataInternal(ExecutionContext &context,
                                                  DataChunk &chunk,
                                                  OperatorSourceInput &input) const {
-    auto &gstate = sink_state->Cast<BigqueryUpdateGlobalState>();
+    auto &gstate = input.global_state.Cast<BigqueryUpdateGlobalSourceState>();
+    if (gstate.finished) {
+        return SourceResultType::FINISHED;
+    }
+
+    auto &transaction = BigqueryTransaction::Get(context.client, table.catalog);
+    auto bq_client = transaction.GetBigqueryClient();
+    gstate.updated_count = bq_client->ExecuteDmlQuery(query, BigqueryDmlStatementType::DML_UPDATE);
+    gstate.finished = true;
+
     chunk.SetCardinality(1);
     chunk.SetValue(0, 0, Value::BIGINT(gstate.updated_count));
     return SourceResultType::FINISHED;
@@ -62,13 +57,19 @@ PhysicalOperator &BigqueryCatalog::PlanUpdate(ClientContext &context,
                                               PhysicalPlanGenerator &planner,
                                               LogicalUpdate &op,
                                               PhysicalOperator &plan) {
+    (void)plan;
+    return PlanUpdate(context, planner, op);
+}
+
+PhysicalOperator &BigqueryCatalog::PlanUpdate(ClientContext &context,
+                                              PhysicalPlanGenerator &planner,
+                                              LogicalUpdate &op) {
     BigqueryTransaction::CheckReadWrite(context, *this, "update tables");
     if (op.return_chunk) {
         throw NotImplementedException("RETURNING clause not supported.");
     }
-    auto query = BigquerySQL::LogicalUpdateToSQL(GetProjectID(), op, plan);
+    auto query = BigquerySQL::LogicalUpdateToSQL(GetProjectID(), op);
     auto &update = planner.Make<BigqueryUpdate>(op, op.table, query);
-    update.children.push_back(plan);
     return update;
 }
 

--- a/test/sql/storage/attach_dml_no_scan_plan.test
+++ b/test/sql/storage/attach_dml_no_scan_plan.test
@@ -1,0 +1,41 @@
+# name: test/sql/storage/attach_dml_no_scan_plan.test
+# description: Verify BigQuery UPDATE/DELETE planning does not attach a scan child
+# group: [storage]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
+
+statement ok
+PRAGMA explain_output='physical_only';
+
+statement ok
+CREATE OR REPLACE TABLE bq.${BQ_TEST_DATASET}.dml_no_scan_plan (i INTEGER);
+
+query II
+EXPLAIN UPDATE bq.${BQ_TEST_DATASET}.dml_no_scan_plan SET i=10 WHERE i=1;
+----
+physical_plan	<REGEX>:.*BIGQUERY_UPDATE.*
+
+query II
+EXPLAIN UPDATE bq.${BQ_TEST_DATASET}.dml_no_scan_plan SET i=10 WHERE i=1;
+----
+physical_plan	<!REGEX>:.*BIGQUERY_SCAN.*
+
+query II
+EXPLAIN DELETE FROM bq.${BQ_TEST_DATASET}.dml_no_scan_plan WHERE i=1;
+----
+physical_plan	<REGEX>:.*BIGQUERY_DELETE.*
+
+query II
+EXPLAIN DELETE FROM bq.${BQ_TEST_DATASET}.dml_no_scan_plan WHERE i=1;
+----
+physical_plan	<!REGEX>:.*BIGQUERY_SCAN.*
+
+statement ok
+DROP TABLE bq.${BQ_TEST_DATASET}.dml_no_scan_plan;


### PR DESCRIPTION
This change plans BigQuery `UPDATE and `DELETE` as childless remote DML operators instead of attaching an unused BQ scan child.

It derives the remote DML SQL from the logical plan, removes the obsolete physical-plan SQL helpers, and adds an `EXPLAIN` test to verify `UPDATE`/`DELETE` plans contain `BIGQUERY_UPDATE`/`BIGQUERY_DELETE` without `BIGQUERY_SCAN`.

