### PR TITLE
Rebind BigQuery catalog on stale columns

### DIFF
--- a/src/bigquery_clear_cache.cpp
+++ b/src/bigquery_clear_cache.cpp
@@ -1,7 +1,6 @@
 #include "duckdb.hpp"
 #include "duckdb/main/attached_database.hpp"
 #include "duckdb/main/database_manager.hpp"
-#include <iostream>
 
 #include "bigquery_clear_cache.hpp"
 #include "storage/bigquery_catalog.hpp"
@@ -24,7 +23,7 @@ static unique_ptr<FunctionData> BigQueryClearCacheBind(ClientContext &context,
     return std::move(result);
 }
 
-static void ClearBigqueryCaches(ClientContext &context) {
+void BigqueryClearCacheFunction::ClearBigqueryCaches(ClientContext &context) {
     auto databases = DatabaseManager::Get(context).GetDatabases(context);
     for (auto &db_ptr : databases) {
         if (!db_ptr) {
@@ -35,7 +34,6 @@ static void ClearBigqueryCaches(ClientContext &context) {
         if (catalog.GetCatalogType() != "bigquery") {
             continue;
         }
-        std::cout << "Clearing BigQuery Cache for Database: " << db.GetName() << std::endl;
         catalog.Cast<BigqueryCatalog>().ClearCache();
     }
 }
@@ -45,7 +43,7 @@ static void ClearBigqueryCachesFunction(ClientContext &context, TableFunctionInp
     if (data.finished) {
         return;
     }
-    ClearBigqueryCaches(context);
+    BigqueryClearCacheFunction::ClearBigqueryCaches(context);
     // Emit a single row indicating success
     output.SetCardinality(1);
     output.SetValue(0, 0, Value::BOOLEAN(true));

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -2,11 +2,16 @@
 
 #include "duckdb.hpp"
 #include "duckdb/catalog/catalog.hpp"
+#include "duckdb/common/error_data.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/function/scalar_function.hpp"
+#include "duckdb/main/client_context.hpp"
+#include "duckdb/main/client_context_state.hpp"
+#include "duckdb/main/connection_manager.hpp"
 #include "duckdb/main/secret/secret.hpp"
 #include "duckdb/main/secret/secret_manager.hpp"
+#include "duckdb/planner/extension_callback.hpp"
 
 // OpenSSL linked through vcpkg
 #include <openssl/opensslv.h>
@@ -26,9 +31,39 @@
 #include "bigquery_settings.hpp"
 #include "bigquery_storage.hpp"
 
-#include <iostream>
-
 namespace duckdb {
+
+static constexpr const char *BIGQUERY_EXTENSION_STATE = "bigquery_extension";
+
+class BigqueryExtensionState : public ClientContextState {
+public:
+    bool CanRequestRebind() override {
+        return true;
+    }
+
+    RebindQueryInfo OnPlanningError(ClientContext &context, SQLStatement &statement, ErrorData &error) override {
+        (void)statement;
+        if (error.Type() != ExceptionType::BINDER) {
+            return RebindQueryInfo::DO_NOT_REBIND;
+        }
+
+        auto &extra_info = error.ExtraInfo();
+        auto entry = extra_info.find("error_subtype");
+        if (entry == extra_info.end() || entry->second != "COLUMN_NOT_FOUND") {
+            return RebindQueryInfo::DO_NOT_REBIND;
+        }
+
+        bigquery::BigqueryClearCacheFunction::ClearBigqueryCaches(context);
+        return RebindQueryInfo::ATTEMPT_TO_REBIND;
+    }
+};
+
+class BigqueryExtensionCallback : public ExtensionCallback {
+public:
+    void OnConnectionOpened(ClientContext &context) override {
+        context.registered_state->Insert(BIGQUERY_EXTENSION_STATE, make_shared_ptr<BigqueryExtensionState>());
+    }
+};
 
 static void LoadInternal(ExtensionLoader &loader) {
 
@@ -61,6 +96,10 @@ static void LoadInternal(ExtensionLoader &loader) {
 
     auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
     StorageExtension::Register(config, "bigquery", make_shared_ptr<bigquery::BigqueryStorageExtension>());
+    ExtensionCallback::Register(config, make_shared_ptr<BigqueryExtensionCallback>());
+    for (auto &connection : ConnectionManager::Get(loader.GetDatabaseInstance()).GetConnectionList()) {
+        connection->registered_state->Insert(BIGQUERY_EXTENSION_STATE, make_shared_ptr<BigqueryExtensionState>());
+    }
 
     bigquery::RegisterBigquerySecretType(loader.GetDatabaseInstance());
 

--- a/src/include/bigquery_clear_cache.hpp
+++ b/src/include/bigquery_clear_cache.hpp
@@ -9,6 +9,7 @@ class BigqueryClearCacheFunction : public TableFunction {
 public:
     BigqueryClearCacheFunction();
 
+    static void ClearBigqueryCaches(ClientContext &context);
     static void ClearCache(ClientContext &context, SetScope scope, Value &parameter);
 };
 

--- a/test/sql/storage/attach_stale_cache_rebind.test
+++ b/test/sql/storage/attach_stale_cache_rebind.test
@@ -1,0 +1,32 @@
+# name: test/sql/storage/attach_stale_cache_rebind.test
+# description: Verify stale BigQuery catalog cache is cleared and rebound on missing columns
+# group: [storage]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.stale_cache_rebind`');
+
+sleep 2 seconds
+
+statement ok
+ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq_stale_cache (TYPE bigquery);
+
+statement ok
+CREATE OR REPLACE TABLE bq_stale_cache.${BQ_TEST_DATASET}.stale_cache_rebind (i INTEGER);
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'ALTER TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.stale_cache_rebind` ADD COLUMN j INT64');
+
+statement ok
+EXPLAIN SELECT j FROM bq_stale_cache.${BQ_TEST_DATASET}.stale_cache_rebind;
+
+statement ok
+DETACH bq_stale_cache;
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.stale_cache_rebind`');


### PR DESCRIPTION
Adds a BigQuery extension rebind state that clears attached BQ catalog caches and retries binding when a stale cache causes `COLUMN_NOT_FOUND`.

Also removes noisy stdout logging from `bigquery_clear_cache` and adds a regression test for stale-column rebind behavior.