### PR TITLE
Unify BQ filter rendering

### DIFF
--- a/src/bigquery_scan.cpp
+++ b/src/bigquery_scan.cpp
@@ -99,18 +99,13 @@ unique_ptr<GlobalTableFunctionState> BigqueryScanFunction::BigqueryScanInitGloba
     string filter_string = bind_data.filter_condition;
     if (BigquerySettings::ExperimentalFilterPushdown() && filter_string.empty() && input.filters &&
         !input.filters->filters.empty()) {
-        for (auto &filter : input.filters->filters) {
-            column_t logical_col = input.column_ids[filter.first];
+        filter_string = BigquerySQL::TransformFilters(*input.filters, [&](idx_t filter_idx) -> string {
+            column_t logical_col = input.column_ids[filter_idx];
             if (logical_col == COLUMN_IDENTIFIER_ROW_ID || logical_col < 0) {
                 throw InvalidInputException("ROWID cannot be referenced in a WHERE clause for BigQuery tables");
             }
-
-            if (!filter_string.empty()) {
-                filter_string += " AND ";
-            }
-            const string &column_name = bind_data.names[logical_col];
-            filter_string += BigquerySQL::TransformFilter(column_name, *filter.second);
-        }
+            return bind_data.names[logical_col];
+        });
     }
 
     idx_t max_read_streams = BigquerySettings::GetMaxReadStreams(context);

--- a/src/bigquery_sql.cpp
+++ b/src/bigquery_sql.cpp
@@ -21,6 +21,97 @@
 
 namespace duckdb {
 namespace bigquery {
+namespace {
+
+static string QuoteFilterColumnPath(const vector<string> &column_path) {
+    vector<string> quoted_path;
+    quoted_path.reserve(column_path.size());
+    for (auto &entry : column_path) {
+        quoted_path.push_back(BigqueryUtils::WriteQuotedIdentifier(entry));
+    }
+    return StringUtil::Join(quoted_path, ".");
+}
+
+static string TransformFilterPath(const vector<string> &column_path, const TableFilter &filter);
+
+static string CreateFilterExpression(const vector<string> &column_path,
+                                     const vector<unique_ptr<TableFilter>> &filters,
+                                     const string &op) {
+    vector<string> filter_entries;
+    for (auto &filter : filters) {
+        filter_entries.push_back(TransformFilterPath(column_path, *filter));
+    }
+    return "(" + StringUtil::Join(filter_entries, " " + op + " ") + ")";
+}
+
+static string TransformFilterPath(const vector<string> &column_path, const TableFilter &filter) {
+    switch (filter.filter_type) {
+    case TableFilterType::CONSTANT_COMPARISON: {
+        auto &constant_filter = filter.Cast<ConstantFilter>();
+
+        string constant_string;
+        if (BigqueryUtils::IsValueQuotable(constant_filter.constant)) {
+            constant_string = KeywordHelper::WriteQuoted(constant_filter.constant.ToString());
+        } else {
+            constant_string = constant_filter.constant.ToString();
+        }
+
+        auto column_ref = QuoteFilterColumnPath(column_path);
+        switch (constant_filter.comparison_type) {
+        case ExpressionType::COMPARE_EQUAL:
+            return column_ref + " = " + constant_string;
+        case ExpressionType::COMPARE_GREATERTHAN:
+            return column_ref + " > " + constant_string;
+        case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
+            return column_ref + " >= " + constant_string;
+        case ExpressionType::COMPARE_LESSTHAN:
+            return column_ref + " < " + constant_string;
+        case ExpressionType::COMPARE_LESSTHANOREQUALTO:
+            return column_ref + " <= " + constant_string;
+        case ExpressionType::COMPARE_NOTEQUAL:
+            return column_ref + " != " + constant_string;
+        default:
+            throw NotImplementedException("Unsupported comparison type");
+        }
+    }
+    case TableFilterType::IS_NULL:
+        return QuoteFilterColumnPath(column_path) + " IS NULL";
+    case TableFilterType::IS_NOT_NULL:
+        return QuoteFilterColumnPath(column_path) + " IS NOT NULL";
+    case TableFilterType::CONJUNCTION_AND:
+    case TableFilterType::CONJUNCTION_OR: {
+        auto &conjunction_filter = dynamic_cast<const ConjunctionFilter &>(filter);
+        string op = filter.filter_type == TableFilterType::CONJUNCTION_AND ? "AND" : "OR";
+        return CreateFilterExpression(column_path, conjunction_filter.child_filters, op);
+    }
+    case TableFilterType::STRUCT_EXTRACT: {
+        auto &struct_filter = filter.Cast<StructFilter>();
+        auto child_path = column_path;
+        child_path.push_back(struct_filter.child_name);
+        return TransformFilterPath(child_path, *struct_filter.child_filter);
+    }
+    case TableFilterType::OPTIONAL_FILTER: {
+        auto &optional_filter = filter.Cast<OptionalFilter>();
+        return TransformFilterPath(column_path, *optional_filter.child_filter);
+    }
+    case TableFilterType::IN_FILTER: {
+        auto &in_filter = filter.Cast<InFilter>();
+        vector<string> in_values;
+        for (auto &value : in_filter.values) {
+            if (BigqueryUtils::IsValueQuotable(value)) {
+                in_values.push_back(KeywordHelper::WriteQuoted(value.ToString()));
+            } else {
+                in_values.push_back(value.ToString());
+            }
+        }
+        return QuoteFilterColumnPath(column_path) + " IN (" + StringUtil::Join(in_values, ", ") + ")";
+    }
+    default:
+        throw InternalException("Unsupported filter type");
+    }
+}
+
+} // namespace
 
 std::string BigquerySQL::ExtractFilters(LogicalOperator &child) {
     switch (child.type) {
@@ -48,17 +139,8 @@ std::string BigquerySQL::ExtractFilters(LogicalOperator &child) {
         if (get.table_filters.filters.empty()) {
             return string();
         }
-        auto &column_ids = get.GetColumnIds();
-        string table_filters_exp;
-        for (auto &filter : get.table_filters.filters) {
-            if (!table_filters_exp.empty()) {
-                table_filters_exp += " AND ";
-            }
-            auto column_id = column_ids[filter.first];
-            auto &column_name = get.names[column_id.GetPrimaryIndex()];
-            table_filters_exp += TransformFilter(column_name, *filter.second);
-        }
-        return table_filters_exp;
+        return TransformFilters(get.table_filters,
+                                [&](idx_t filter_idx) -> string { return get.GetColumnName(ColumnIndex(filter_idx)); });
     }
     case LogicalOperatorType::LOGICAL_EMPTY_RESULT:
         return "false";
@@ -68,79 +150,23 @@ std::string BigquerySQL::ExtractFilters(LogicalOperator &child) {
 }
 
 string BigquerySQL::CreateExpression(const string &column_name,
-                                     vector<unique_ptr<TableFilter>> &filters,
+                                     const vector<unique_ptr<TableFilter>> &filters,
                                      const string &op) {
-    vector<string> filter_entries;
-    for (auto &filter : filters) {
-        filter_entries.push_back(TransformFilter(column_name, *filter));
-    }
-    return "(" + StringUtil::Join(filter_entries, " " + op + " ") + ")";
+    return CreateFilterExpression(vector<string>{column_name}, filters, op);
 }
 
-string BigquerySQL::TransformFilter(const string &column_name, TableFilter &filter) {
-    switch (filter.filter_type) {
-    case TableFilterType::CONSTANT_COMPARISON: {
-        auto &constant_filter = dynamic_cast<ConstantFilter &>(filter);
+string BigquerySQL::TransformFilters(const TableFilterSet &filters,
+                                     const std::function<string(idx_t)> &column_name_resolver) {
+    vector<string> filter_entries;
+    filter_entries.reserve(filters.filters.size());
+    for (auto &filter : filters.filters) {
+        filter_entries.push_back(TransformFilter(column_name_resolver(filter.first), *filter.second));
+    }
+    return StringUtil::Join(filter_entries, " AND ");
+}
 
-        string constant_string;
-        if (BigqueryUtils::IsValueQuotable(constant_filter.constant)) {
-            constant_string = KeywordHelper::WriteQuoted(constant_filter.constant.ToString());
-        } else {
-            constant_string = constant_filter.constant.ToString();
-        }
-
-        switch (constant_filter.comparison_type) {
-        case ExpressionType::COMPARE_EQUAL:
-            return "`" + column_name + "` = " + constant_string;
-        case ExpressionType::COMPARE_GREATERTHAN:
-            return "`" + column_name + "` > " + constant_string;
-        case ExpressionType::COMPARE_GREATERTHANOREQUALTO:
-            return "`" + column_name + "` >= " + constant_string;
-        case ExpressionType::COMPARE_LESSTHAN:
-            return "`" + column_name + "` < " + constant_string;
-        case ExpressionType::COMPARE_LESSTHANOREQUALTO:
-            return "`" + column_name + "` <= " + constant_string;
-        case ExpressionType::COMPARE_NOTEQUAL:
-            return "`" + column_name + "` != " + constant_string;
-        default:
-            throw NotImplementedException("Unsupported comparison type");
-        }
-    }
-    case TableFilterType::IS_NULL:
-        return "`" + column_name + "` IS NULL";
-    case TableFilterType::IS_NOT_NULL:
-        return "`" + column_name + "` IS NOT NULL";
-    case TableFilterType::CONJUNCTION_AND:
-    case TableFilterType::CONJUNCTION_OR: {
-        auto &conjunction_filter = dynamic_cast<ConjunctionAndFilter &>(filter);
-        string op = filter.filter_type == TableFilterType::CONJUNCTION_AND ? "AND" : "OR";
-        return CreateExpression(column_name, conjunction_filter.child_filters, op);
-    }
-    case TableFilterType::STRUCT_EXTRACT: {
-        auto &struct_filter = dynamic_cast<StructFilter &>(filter);
-        auto child_name = KeywordHelper::WriteQuoted(struct_filter.child_name, '`');
-        auto new_column_name = "`" + column_name + "`." + child_name;
-        return TransformFilter(new_column_name, *struct_filter.child_filter);
-    }
-    case TableFilterType::OPTIONAL_FILTER: {
-        auto &optional_filter = filter.Cast<OptionalFilter>();
-        return TransformFilter(column_name, *optional_filter.child_filter);
-    }
-    case TableFilterType::IN_FILTER: {
-        auto &in_filter = dynamic_cast<InFilter &>(filter);
-        vector<string> in_values;
-        for (auto &value : in_filter.values) {
-            if (BigqueryUtils::IsValueQuotable(value)) {
-                in_values.push_back(KeywordHelper::WriteQuoted(value.ToString()));
-            } else {
-                in_values.push_back(value.ToString());
-            }
-        }
-        return "`" + column_name + "` IN (" + StringUtil::Join(in_values, ", ") + ")";
-    }
-    default:
-        throw InternalException("Unsupported filter type");
-    }
+string BigquerySQL::TransformFilter(const string &column_name, const TableFilter &filter) {
+    return TransformFilterPath(vector<string>{column_name}, filter);
 }
 
 string BigquerySQL::AlterTableInfoToSQL(const string &project_id, const AlterTableInfo &info) {

--- a/src/include/bigquery_sql.hpp
+++ b/src/include/bigquery_sql.hpp
@@ -9,8 +9,11 @@
 #include "duckdb/planner/logical_operator.hpp"
 #include "duckdb/planner/operator/logical_delete.hpp"
 #include "duckdb/planner/operator/logical_update.hpp"
+#include "duckdb/planner/table_filter.hpp"
 
 #include "bigquery_utils.hpp"
+
+#include <functional>
 
 namespace duckdb {
 namespace bigquery {
@@ -18,9 +21,11 @@ namespace bigquery {
 struct BigquerySQL {
 public:
     static string ExtractFilters(LogicalOperator &child);
-    static string TransformFilter(const string &column_name, TableFilter &filter);
+    static string TransformFilters(const TableFilterSet &filters,
+                                   const std::function<string(idx_t)> &column_name_resolver);
+    static string TransformFilter(const string &column_name, const TableFilter &filter);
     static string CreateExpression(const string &column_name,
-                                   vector<unique_ptr<TableFilter>> &filters,
+                                   const vector<unique_ptr<TableFilter>> &filters,
                                    const string &op);
 
     static string AlterTableInfoToSQL(const string &project_id, const AlterTableInfo &info);

--- a/test/sql/storage/attach_dml_statements.test
+++ b/test/sql/storage/attach_dml_statements.test
@@ -9,16 +9,32 @@ require-env BQ_TEST_PROJECT
 require-env BQ_TEST_DATASET
 
 statement ok
-SET bq_debug_show_queries=true
-
-statement ok
 ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigquery);
 
 statement ok
 CREATE OR REPLACE TABLE bq.${BQ_TEST_DATASET}.dml_statements (i INTEGER);
 
 statement ok
+CREATE OR REPLACE TABLE bq.${BQ_TEST_DATASET}.dml_struct_filters (
+    id INTEGER,
+    marker INTEGER,
+    customer_info STRUCT(
+        name VARCHAR,
+        address STRUCT(
+            city VARCHAR,
+            zip_code VARCHAR
+        )
+    )
+);
+
+statement ok
 INSERT INTO bq.${BQ_TEST_DATASET}.dml_statements FROM range(5);
+
+statement ok
+INSERT INTO bq.${BQ_TEST_DATASET}.dml_struct_filters VALUES
+    (1, 0, {'name': 'Alice Smith', 'address': {'city': 'New York', 'zip_code': '10001'}}),
+    (2, 0, {'name': 'Bob Johnson', 'address': {'city': 'Los Angeles', 'zip_code': '90001'}}),
+    (3, 0, {'name': 'Alice Smith', 'address': {'city': 'New York', 'zip_code': '10001'}});
 
 query I
 UPDATE bq.${BQ_TEST_DATASET}.dml_statements SET i=10 WHERE 1=1;
@@ -42,6 +58,32 @@ DELETE FROM bq.${BQ_TEST_DATASET}.dml_statements WHERE 1=1;
 query I
 SELECT * FROM bq.${BQ_TEST_DATASET}.dml_statements;
 ----
+
+query I
+UPDATE bq.${BQ_TEST_DATASET}.dml_struct_filters SET marker=9 WHERE customer_info.address.city='New York';
+----
+2
+
+query II
+SELECT id, marker FROM bq.${BQ_TEST_DATASET}.dml_struct_filters ORDER BY id;
+----
+1	9
+2	0
+3	9
+
+query I
+DELETE FROM bq.${BQ_TEST_DATASET}.dml_struct_filters WHERE customer_info.name='Bob Johnson';
+----
+1
+
+query I
+SELECT id FROM bq.${BQ_TEST_DATASET}.dml_struct_filters ORDER BY id;
+----
+1
+3
+
+statement ok
+DROP TABLE bq.${BQ_TEST_DATASET}.dml_struct_filters;
 
 statement ok
 DROP TABLE bq.${BQ_TEST_DATASET}.dml_statements;

--- a/test/sql/storage/attach_filter_pushdown.test
+++ b/test/sql/storage/attach_filter_pushdown.test
@@ -15,6 +15,9 @@ statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.filter_pushdown;
 
 statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.filter_pushdown_struct;
+
+statement ok
 CREATE TABLE bq.${BQ_TEST_DATASET}.filter_pushdown(i INTEGER);
 
 statement ok
@@ -45,6 +48,38 @@ SELECT * FROM bq.${BQ_TEST_DATASET}.filter_pushdown WHERE i IN (2222, 3333, 4444
 3333
 4444
 5555
+
+statement ok
+CREATE TABLE bq.${BQ_TEST_DATASET}.filter_pushdown_struct(
+    id INTEGER,
+    customer_info STRUCT(
+        name VARCHAR,
+        address STRUCT(
+            city VARCHAR,
+            zip_code VARCHAR
+        )
+    )
+);
+
+statement ok
+INSERT INTO bq.${BQ_TEST_DATASET}.filter_pushdown_struct VALUES
+    (1, {'name': 'Alice Smith', 'address': {'city': 'New York', 'zip_code': '10001'}}),
+    (2, {'name': 'Bob Johnson', 'address': {'city': 'Los Angeles', 'zip_code': '90001'}}),
+    (3, {'name': 'Alice Smith', 'address': {'city': 'Seattle', 'zip_code': '98101'}});
+
+query I
+SELECT id FROM bq.${BQ_TEST_DATASET}.filter_pushdown_struct WHERE customer_info.name = 'Alice Smith' ORDER BY id;
+----
+1
+3
+
+query I
+SELECT id FROM bq.${BQ_TEST_DATASET}.filter_pushdown_struct WHERE customer_info.address.city = 'Los Angeles';
+----
+2
+
+statement ok
+DROP TABLE bq.${BQ_TEST_DATASET}.filter_pushdown_struct;
 
 statement ok
 DROP TABLE bq.${BQ_TEST_DATASET}.filter_pushdown;


### PR DESCRIPTION
Unifies the filter rendering between scan pushdown and DML planning, so both paths produce the same BQ-compatible SQL for pushed-down `TableFilters`. It also fixes nested `STRUCT` field quoting by rendering each path segment separately. For example:

```sql
UPDATE bq.test_dataset.orders
SET marker = 1
WHERE customer_info.address.city = 'New York';
```

now correctly renders the filter in bq syntax as:

```sql
`customer_info`.`address`.`city` = 'New York'
```

The change also avoids incorrect column index mapping in DML filters and adds coverage for nested `STRUCT` filters in both scan pushdown and `UPDATE`/`DELETE` tests.