### PR TITLE
Validate bq credentials during attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ LOAD 'bigquery';
 
 After loading the extension, you can connect to your BigQuery project using the `ATTACH` statement. Replace `my_gcp_project` with the name of your actual Google Cloud Project. Here is an example:
 
+`ATTACH` immediately checks that configured credentials can provide an authentication token. It does not load catalog
+metadata or verify BigQuery permissions for datasets, tables, jobs, or Storage APIs; those checks occur when the
+corresponding objects or operations are used. When `ACCESS_TOKEN` is configured directly, BigQuery may only reject an
+invalid token on the first API request.
+
 ```sql
 -- Attach to your BigQuery Project
 D ATTACH 'project=my_gcp_project' as bq (TYPE bigquery, READ_ONLY);

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -1499,6 +1499,10 @@ void BigqueryClient::MapInformationSchemaRows(
     }
 }
 
+void BigqueryClient::ValidateAuthentication() {
+    CheckAuthentication();
+}
+
 void BigqueryClient::CheckAuthentication() {
     if (authentication_checked) {
         return;

--- a/src/bigquery_storage.cpp
+++ b/src/bigquery_storage.cpp
@@ -6,6 +6,7 @@
 #include "duckdb/parser/parsed_data/attach_info.hpp"
 #include "duckdb/transaction/transaction_manager.hpp"
 
+#include "bigquery_client.hpp"
 #include "bigquery_storage.hpp"
 #include "storage/bigquery_catalog.hpp"
 #include "storage/bigquery_options.hpp"
@@ -29,7 +30,10 @@ static unique_ptr<Catalog> BigqueryAttach(optional_ptr<StorageExtensionInfo> sto
 
     BigqueryOptions options;
     options.access_mode = attach_options.access_mode;
-    return duckdb::make_uniq<BigqueryCatalog>(db, info.path, options);
+    auto catalog = duckdb::make_uniq<BigqueryCatalog>(db, info.path, options);
+    BigqueryClient client(context, catalog->config);
+    client.ValidateAuthentication();
+    return catalog;
 }
 
 

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -118,6 +118,8 @@ public:
 
     shared_ptr<BigqueryProtoWriter> CreateProtoWriter(BigqueryTableEntry *entry);
 
+    void ValidateAuthentication();
+
     string GetProjectID() const {
         return config.project_id;
     }

--- a/test/sql/secrets/secrets_validation.test
+++ b/test/sql/secrets/secrets_validation.test
@@ -29,6 +29,11 @@ CREATE SECRET bq_auth_preflight_secret (
 );
 
 statement error
+ATTACH 'project=auth-preflight-project' AS bq_auth_preflight (TYPE bigquery);
+----
+<REGEX>:.*BigQuery Authentication Failed.*
+
+statement error
 SELECT * FROM bigquery_query('auth-preflight-project', 'SELECT 1 AS x', use_rest_api=true);
 ----
 <REGEX>:.*BigQuery Authentication Failed.*


### PR DESCRIPTION
This PR adds an authentication preflight to `ATTACH`, so invalid or unavailable credentials fail immediately instead of on the first catalog interaction. Catalog metadata loading remains lazy and `ATTACH` does not perform dataset or table permission checks.

