### PR TITLE
Poll long-running BQ query jobs to completion and introduce new timeout_ms param

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,12 +334,13 @@ The `bigquery_query` function supports the following named parameters:
 | `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).                                               |
 | `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
 | `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
+| `timeout_ms`      | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms` for this call.   |
 
 > **REST API vs Storage API**: By default, `bigquery_query` uses the [BigQuery Storage Read API](https://cloud.google.com/bigquery/docs/reference/storage) to fetch results. This executes the query as a job, materializes results into a temporary table, and reads them via gRPC — optimized for large result sets but adds overhead for small queries.
 >
 > With `use_rest_api=true`, the query is executed using the [jobs.query REST endpoint](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query) with [`JOB_CREATION_OPTIONAL`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#JobCreationMode) mode. For short-running queries, BigQuery can return results inline without creating a job at all, significantly reducing latency. This is ideal for interactive or exploratory queries with small result sets (under ~10MB).
 >
-> If a query job is still running when a REST wait request returns, the extension polls until it completes or `bq_query_timeout_ms` is reached. Long-running queries are therefore supported on both result paths when the timeout is configured accordingly.
+> If a query job is still running when a REST wait request returns, the extension polls until it completes or the configured timeout is reached. Set `timeout_ms` for one call or `bq_query_timeout_ms` as the session default.
 >
 > ```sql
 > D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT count(*) FROM `my_dataset.my_table`', use_rest_api=true);
@@ -347,7 +348,7 @@ The `bigquery_query` function supports the following named parameters:
 
 ### `bigquery_execute` Function
 
-The `bigquery_execute` function runs arbitrary GoogleSQL queries directly in BigQuery. These queries are executed without interpretation by DuckDB. The call waits for BigQuery job completion up to `bq_query_timeout_ms`, polling long-running jobs when required, and returns a result with details about the query execution, like the following.
+The `bigquery_execute` function runs arbitrary GoogleSQL queries directly in BigQuery. These queries are executed without interpretation by DuckDB. The call waits for BigQuery job completion up to its effective timeout, polling long-running jobs when required, and returns a result with details about the query execution, like the following.
 
 ```sql
 D ATTACH 'project=my_gcp_project' as bq (TYPE bigquery);
@@ -386,6 +387,7 @@ The `bigquery_execute` function supports the following named parameters:
 | `dry_run`       | `BOOLEAN` | When `true`, validates the query without executing it. Returns metadata: `total_bytes_processed`, `cache_hit`, and `location`. |
 | `api_endpoint`  | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
 | `grpc_endpoint` | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
+| `timeout_ms`    | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms` for this call.   |
 
 ### `bigquery_load` Function
 
@@ -451,8 +453,9 @@ The `bigquery_load` function supports the following named parameters:
 | `location`           | `VARCHAR` | BigQuery job location.                                                                 |
 | `billing_project`    | `VARCHAR` | Project ID to bill for the load job. Only supported for direct project-ID calls.       |
 | `labels`             | `MAP(VARCHAR, VARCHAR)` | BigQuery job labels to attach to the load job.                                         |
+| `timeout_ms`         | `BIGINT`  | Optional maximum time to wait for the submitted load job to finish. Timed-out jobs may continue running in BigQuery. |
 
-Exactly one of `source_file`, `source_uris`, or `source_table` must be provided. For Cloud Storage loads, the BigQuery job identity needs permission to read the objects, and the bucket location must be compatible with the destination dataset location.
+Exactly one of `source_file`, `source_uris`, or `source_table` must be provided. Without `timeout_ms`, `bigquery_load` continues waiting for the load job as before. For Cloud Storage loads, the BigQuery job identity needs permission to read the objects, and the bucket location must be compatible with the destination dataset location.
 
 ### `bigquery_jobs` Function
 

--- a/README.md
+++ b/README.md
@@ -339,13 +339,15 @@ The `bigquery_query` function supports the following named parameters:
 >
 > With `use_rest_api=true`, the query is executed using the [jobs.query REST endpoint](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query) with [`JOB_CREATION_OPTIONAL`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#JobCreationMode) mode. For short-running queries, BigQuery can return results inline without creating a job at all, significantly reducing latency. This is ideal for interactive or exploratory queries with small result sets (under ~10MB).
 >
+> If a query job is still running when a REST wait request returns, the extension polls it to completion. Long-running queries are therefore supported on both result paths.
+>
 > ```sql
 > D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT count(*) FROM `my_dataset.my_table`', use_rest_api=true);
 > ```
 
 ### `bigquery_execute` Function
 
-The `bigquery_execute` function runs arbitrary GoogleSQL queries directly in BigQuery. These queries are executed without interpretation by DuckDB. The call is synchronous and returns a result with details about the query execution, like the following.
+The `bigquery_execute` function runs arbitrary GoogleSQL queries directly in BigQuery. These queries are executed without interpretation by DuckDB. The call waits for BigQuery job completion, polling long-running jobs when required, and returns a result with details about the query execution, like the following.
 
 ```sql
 D ATTACH 'project=my_gcp_project' as bq (TYPE bigquery);
@@ -565,7 +567,7 @@ D CREATE TABLE bq.my_dataset.partition_tbl (i BIGINT)
 | Setting                                   | Description                                                                                                                                                                                        | Default |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `bq_bignumeric_as_varchar`                | Compatibility setting kept for older workflows. `BIGNUMERIC` columns are exposed as `VARCHAR` by default in current versions.                                                                        | `true`  |
-| `bq_query_timeout_ms`                     | Timeout for BigQuery queries in milliseconds. If a query exceeds this time, the operation stops waiting.                                                                                           | `90000` |
+| `bq_query_timeout_ms`                     | Maximum wait time for each `jobs.query` or `jobs.getQueryResults` REST request in milliseconds. Incomplete query jobs are polled until BigQuery completes them. A DuckDB interrupt stops local waiting but does not cancel the BigQuery job.                       | `90000` |
 | `bq_auth_timeout_s`                       | Timeout for authentication token fetches in seconds. This bounds ADC metadata and OAuth token requests without changing normal BigQuery query timeouts.                                             | `10`    |
 | `bq_debug_show_queries`                   | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                                                                                                                  | `false` |
 | `bq_experimental_filter_pushdown`         | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                                                                                                             | `true`  |

--- a/README.md
+++ b/README.md
@@ -334,13 +334,13 @@ The `bigquery_query` function supports the following named parameters:
 | `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).                                               |
 | `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
 | `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
-| `timeout_ms`      | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms` for this call.   |
+| `timeout_ms`      | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms`; `0` waits indefinitely. |
 
 > **REST API vs Storage API**: By default, `bigquery_query` uses the [BigQuery Storage Read API](https://cloud.google.com/bigquery/docs/reference/storage) to fetch results. This executes the query as a job, materializes results into a temporary table, and reads them via gRPC — optimized for large result sets but adds overhead for small queries.
 >
 > With `use_rest_api=true`, the query is executed using the [jobs.query REST endpoint](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query) with [`JOB_CREATION_OPTIONAL`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#JobCreationMode) mode. For short-running queries, BigQuery can return results inline without creating a job at all, significantly reducing latency. This is ideal for interactive or exploratory queries with small result sets (under ~10MB).
 >
-> If a query job is still running when a REST wait request returns, the extension polls until it completes or the configured timeout is reached. Set `timeout_ms` for one call or `bq_query_timeout_ms` as the session default.
+> If a query job is still running when a REST wait request returns, the extension polls until it completes or a configured positive timeout is reached. Set `timeout_ms` for one call or `bq_query_timeout_ms` as the session default; `0` waits indefinitely.
 >
 > ```sql
 > D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT count(*) FROM `my_dataset.my_table`', use_rest_api=true);
@@ -348,7 +348,7 @@ The `bigquery_query` function supports the following named parameters:
 
 ### `bigquery_execute` Function
 
-The `bigquery_execute` function runs arbitrary GoogleSQL queries directly in BigQuery. These queries are executed without interpretation by DuckDB. The call waits for BigQuery job completion up to its effective timeout, polling long-running jobs when required, and returns a result with details about the query execution, like the following.
+The `bigquery_execute` function runs arbitrary GoogleSQL queries directly in BigQuery. These queries are executed without interpretation by DuckDB. The call waits for BigQuery job completion, polling long-running jobs when required until completion or a configured positive timeout, and returns a result with details about the query execution, like the following.
 
 ```sql
 D ATTACH 'project=my_gcp_project' as bq (TYPE bigquery);
@@ -387,7 +387,7 @@ The `bigquery_execute` function supports the following named parameters:
 | `dry_run`       | `BOOLEAN` | When `true`, validates the query without executing it. Returns metadata: `total_bytes_processed`, `cache_hit`, and `location`. |
 | `api_endpoint`  | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
 | `grpc_endpoint` | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
-| `timeout_ms`    | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms` for this call.   |
+| `timeout_ms`    | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms`; `0` waits indefinitely. |
 
 ### `bigquery_load` Function
 
@@ -453,9 +453,9 @@ The `bigquery_load` function supports the following named parameters:
 | `location`           | `VARCHAR` | BigQuery job location.                                                                 |
 | `billing_project`    | `VARCHAR` | Project ID to bill for the load job. Only supported for direct project-ID calls.       |
 | `labels`             | `MAP(VARCHAR, VARCHAR)` | BigQuery job labels to attach to the load job.                                         |
-| `timeout_ms`         | `BIGINT`  | Optional maximum time to wait for the submitted load job to finish. Timed-out jobs may continue running in BigQuery. |
+| `timeout_ms`         | `BIGINT`  | Optional maximum time to wait for the submitted load job to finish. `0` waits indefinitely; timed-out jobs may continue running in BigQuery. |
 
-Exactly one of `source_file`, `source_uris`, or `source_table` must be provided. Without `timeout_ms`, `bigquery_load` continues waiting for the load job as before. For Cloud Storage loads, the BigQuery job identity needs permission to read the objects, and the bucket location must be compatible with the destination dataset location.
+Exactly one of `source_file`, `source_uris`, or `source_table` must be provided. Without `timeout_ms`, or with `timeout_ms := 0`, `bigquery_load` waits for the load job to complete. For Cloud Storage loads, the BigQuery job identity needs permission to read the objects, and the bucket location must be compatible with the destination dataset location.
 
 ### `bigquery_jobs` Function
 
@@ -570,7 +570,7 @@ D CREATE TABLE bq.my_dataset.partition_tbl (i BIGINT)
 | Setting                                   | Description                                                                                                                                                                                        | Default |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `bq_bignumeric_as_varchar`                | Compatibility setting kept for older workflows. `BIGNUMERIC` columns are exposed as `VARCHAR` by default in current versions.                                                                        | `true`  |
-| `bq_query_timeout_ms`                     | Maximum time to wait for a BigQuery query to complete, including polling. A timed-out query job may continue running in BigQuery.                                                                   | `90000` |
+| `bq_query_timeout_ms`                     | Maximum time to wait for a BigQuery query to complete, including polling. `0` waits indefinitely; a timed-out query job may continue running in BigQuery.                                         | `0`     |
 | `bq_auth_timeout_s`                       | Timeout for authentication token fetches in seconds. This bounds ADC metadata and OAuth token requests without changing normal BigQuery query timeouts.                                             | `10`    |
 | `bq_debug_show_queries`                   | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                                                                                                                  | `false` |
 | `bq_experimental_filter_pushdown`         | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                                                                                                             | `true`  |

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ The `bigquery_query` function supports the following named parameters:
 >
 > With `use_rest_api=true`, the query is executed using the [jobs.query REST endpoint](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query) with [`JOB_CREATION_OPTIONAL`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#JobCreationMode) mode. For short-running queries, BigQuery can return results inline without creating a job at all, significantly reducing latency. This is ideal for interactive or exploratory queries with small result sets (under ~10MB).
 >
-> If a query job is still running when a REST wait request returns, the extension polls it to completion. Long-running queries are therefore supported on both result paths.
+> If a query job is still running when a REST wait request returns, the extension polls until it completes or `bq_query_timeout_ms` is reached. Long-running queries are therefore supported on both result paths when the timeout is configured accordingly.
 >
 > ```sql
 > D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT count(*) FROM `my_dataset.my_table`', use_rest_api=true);
@@ -347,7 +347,7 @@ The `bigquery_query` function supports the following named parameters:
 
 ### `bigquery_execute` Function
 
-The `bigquery_execute` function runs arbitrary GoogleSQL queries directly in BigQuery. These queries are executed without interpretation by DuckDB. The call waits for BigQuery job completion, polling long-running jobs when required, and returns a result with details about the query execution, like the following.
+The `bigquery_execute` function runs arbitrary GoogleSQL queries directly in BigQuery. These queries are executed without interpretation by DuckDB. The call waits for BigQuery job completion up to `bq_query_timeout_ms`, polling long-running jobs when required, and returns a result with details about the query execution, like the following.
 
 ```sql
 D ATTACH 'project=my_gcp_project' as bq (TYPE bigquery);
@@ -567,7 +567,7 @@ D CREATE TABLE bq.my_dataset.partition_tbl (i BIGINT)
 | Setting                                   | Description                                                                                                                                                                                        | Default |
 | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
 | `bq_bignumeric_as_varchar`                | Compatibility setting kept for older workflows. `BIGNUMERIC` columns are exposed as `VARCHAR` by default in current versions.                                                                        | `true`  |
-| `bq_query_timeout_ms`                     | Maximum wait time for each `jobs.query` or `jobs.getQueryResults` REST request in milliseconds. Incomplete query jobs are polled until BigQuery completes them. A DuckDB interrupt stops local waiting but does not cancel the BigQuery job.                       | `90000` |
+| `bq_query_timeout_ms`                     | Maximum time to wait for a BigQuery query to complete, including polling. A timed-out query job may continue running in BigQuery.                                                                   | `90000` |
 | `bq_auth_timeout_s`                       | Timeout for authentication token fetches in seconds. This bounds ADC metadata and OAuth token requests without changing normal BigQuery query timeouts.                                             | `10`    |
 | `bq_debug_show_queries`                   | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                                                                                                                  | `false` |
 | `bq_experimental_filter_pushdown`         | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                                                                                                             | `true`  |

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -695,7 +695,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryT
                                                                  const string &write_disposition,
                                                                  const string &create_disposition,
                                                                  const string &location,
-                                                                 const std::map<string, string> &labels) {
+                                                                 const std::map<string, string> &labels,
+                                                                 const std::optional<int> &timeout_ms) {
     CheckAuthentication();
 
     auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
@@ -717,7 +718,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryT
                                    write_disposition,
                                    create_disposition,
                                    location,
-                                   labels);
+                                   labels,
+                                   timeout_ms);
         }
 
         throw BinderException("Load job submission failed: " + response.status().message());
@@ -726,7 +728,11 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryT
     if (!response->has_job_reference()) {
         throw BinderException("Load job submission succeeded but did not return a job reference");
     }
-    return WaitForJobCompletion(response->job_reference());
+    if (response->has_status() && response->status().state() == "DONE") {
+        ThrowOnJobStatusError(response->status(), "Load job");
+        return *response;
+    }
+    return WaitForJobCompletion(response->job_reference(), timeout_ms);
 }
 
 google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryTableRef &destination_table,
@@ -734,7 +740,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryT
                                                                  const string &write_disposition,
                                                                  const string &create_disposition,
                                                                  const string &location,
-                                                                 const std::map<string, string> &labels) {
+                                                                 const std::map<string, string> &labels,
+                                                                 const std::optional<int> &timeout_ms) {
     if (source_uris.empty()) {
         throw BinderException("At least one source URI must be provided for a BigQuery load job");
     }
@@ -768,7 +775,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryT
                                    write_disposition,
                                    create_disposition,
                                    location,
-                                   labels);
+                                   labels,
+                                   timeout_ms);
         }
 
         throw BinderException("Load job submission failed: " + response.status().message());
@@ -777,7 +785,11 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryT
     if (!response->has_job_reference()) {
         throw BinderException("Load job submission succeeded but did not return a job reference");
     }
-    return WaitForJobCompletion(response->job_reference());
+    if (response->has_status() && response->status().state() == "DONE") {
+        ThrowOnJobStatusError(response->status(), "Load job");
+        return *response;
+    }
+    return WaitForJobCompletion(response->job_reference(), timeout_ms);
 }
 
 google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &table_name,
@@ -785,7 +797,8 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &t
                                                                  const string &write_disposition,
                                                                  const string &create_disposition,
                                                                  const string &location,
-                                                                 const std::map<string, string> &labels) {
+                                                                 const std::map<string, string> &labels,
+                                                                 const std::optional<int> &timeout_ms) {
     if (!context) {
         throw InternalException("LoadDuckDBTable requires an active DuckDB client context");
     }
@@ -811,8 +824,13 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &t
             result->ThrowError("Failed to materialize DuckDB source table for bigquery_load: ");
         }
 
-        auto job =
-            LoadParquetFile(destination_table, temp_file_path, write_disposition, create_disposition, location, labels);
+        auto job = LoadParquetFile(destination_table,
+                                   temp_file_path,
+                                   write_disposition,
+                                   create_disposition,
+                                   location,
+                                   labels,
+                                   timeout_ms);
         fs.TryRemoveFile(temp_file_path);
         return job;
     } catch (...) {
@@ -1074,8 +1092,9 @@ bool BigqueryClient::TryGetTableInfo(const string &dataset_id,
 void BigqueryClient::GetTableInfoForQuery(const string &query,
                                           const vector<Value> &query_parameters,
                                           ColumnList &res_columns,
-                                          vector<unique_ptr<Constraint>> &res_constraints) {
-    auto query_response = ExecuteQuery(query, "", true, query_parameters);
+                                          vector<unique_ptr<Constraint>> &res_constraints,
+                                          const std::optional<int> &timeout_ms) {
+    auto query_response = ExecuteQuery(query, "", true, query_parameters, false, timeout_ms);
     if (!query_response.has_schema()) {
         throw BinderException("Query response does not contain a result schema.");
     }
@@ -1148,10 +1167,11 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
                                                                         const string &location,
                                                                         const bool &dry_run,
                                                                         const vector<Value> &query_parameters,
-                                                                        const bool &optional_job_creation) {
+                                                                        const bool &optional_job_creation,
+                                                                        const std::optional<int> &timeout_override_ms) {
     CheckAuthentication();
 
-    const auto timeout_ms = BigquerySettings::QueryTimeoutMs();
+    const auto timeout_ms = timeout_override_ms.value_or(BigquerySettings::QueryTimeoutMs());
     const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
     auto request_timeout_ms = timeout_ms;
 
@@ -1548,12 +1568,42 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> Bi
 }
 
 google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
-    const google::cloud::bigquery::v2::JobReference &job_ref) {
+    const google::cloud::bigquery::v2::JobReference &job_ref,
+    const std::optional<int> &timeout_ms) {
     if (job_ref.job_id().empty()) {
         throw BinderException("Load job reference did not contain a job ID");
     }
 
+    if (timeout_ms.has_value()) {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms.value());
+        while (true) {
+            if (context && context->IsInterrupted()) {
+                throw InterruptException();
+            }
+            if (RemainingQueryTimeoutMs(deadline) == 0) {
+                throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
+            }
+
+            auto job = GetLoadJobUntilDeadline(job_ref, deadline);
+            if (!job.has_status() || job.status().state() == "DONE") {
+                if (job.has_status()) {
+                    ThrowOnJobStatusError(job.status(), "Load job");
+                }
+                return job;
+            }
+
+            auto remaining_ms = RemainingQueryTimeoutMs(deadline);
+            if (remaining_ms == 0) {
+                throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(std::min(remaining_ms, 250)));
+        }
+    }
+
     while (true) {
+        if (context && context->IsInterrupted()) {
+            throw InterruptException();
+        }
         auto job = GetJobByReference(job_ref);
         if (!job.has_status() || job.status().state() == "DONE") {
             if (job.has_status()) {
@@ -1562,6 +1612,39 @@ google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
             return job;
         }
         std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
+}
+
+google::cloud::bigquery::v2::Job BigqueryClient::GetLoadJobUntilDeadline(
+    const google::cloud::bigquery::v2::JobReference &job_ref,
+    const std::chrono::steady_clock::time_point &deadline) {
+    while (true) {
+        if (context && context->IsInterrupted()) {
+            throw InterruptException();
+        }
+        if (RemainingQueryTimeoutMs(deadline) == 0) {
+            throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
+        }
+
+        CheckAuthentication();
+        auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
+            google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+        auto request = google::cloud::bigquery::v2::GetJobRequest();
+        request.set_project_id(job_ref.project_id());
+        request.set_job_id(job_ref.job_id());
+        if (job_ref.has_location()) {
+            request.set_location(job_ref.location().value());
+        }
+
+        auto response = client.GetJob(request);
+        if (response.ok()) {
+            return *response;
+        }
+
+        ThrowOnErrorStatus(response.status());
+        if (!CheckSSLError(response.status())) {
+            throw BinderException(response.status().message());
+        }
     }
 }
 

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -297,8 +297,8 @@ static idx_t CastDmlAffectedRows(int64_t affected_rows, BigqueryDmlStatementType
     return static_cast<idx_t>(affected_rows);
 }
 
-static int RemainingQueryTimeoutMs(const std::chrono::steady_clock::time_point &deadline) {
-    auto remaining = deadline - std::chrono::steady_clock::now();
+static int RemainingWaitTimeMs(const std::chrono::steady_clock::time_point &wait_until) {
+    auto remaining = wait_until - std::chrono::steady_clock::now();
     if (remaining <= std::chrono::steady_clock::duration::zero()) {
         return 0;
     }
@@ -307,6 +307,12 @@ static int RemainingQueryTimeoutMs(const std::chrono::steady_clock::time_point &
         return 1;
     }
     return static_cast<int>(std::min<int64_t>(remaining_ms, std::numeric_limits<int>::max()));
+}
+
+static constexpr int QUERY_REQUEST_WAIT_TIMEOUT_MS = 120000;
+
+static int QueryRequestTimeoutMs(const int timeout_ms) {
+    return timeout_ms > 0 ? timeout_ms : QUERY_REQUEST_WAIT_TIMEOUT_MS;
 }
 
 static string GetLoadStagingDirectory(FileSystem &fs) {
@@ -1172,8 +1178,11 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
     CheckAuthentication();
 
     const auto timeout_ms = timeout_override_ms.value_or(BigquerySettings::QueryTimeoutMs());
-    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
-    auto request_timeout_ms = timeout_ms;
+    std::optional<std::chrono::steady_clock::time_point> wait_until;
+    if (timeout_ms > 0) {
+        wait_until = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    }
+    auto request_timeout_ms = QueryRequestTimeoutMs(timeout_ms);
 
     while (true) {
         if (context && context->IsInterrupted()) {
@@ -1193,9 +1202,11 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
             ThrowOnErrorStatus(response.status());
 
             if (CheckSSLError(response.status())) {
-                request_timeout_ms = RemainingQueryTimeoutMs(deadline);
-                if (request_timeout_ms == 0) {
-                    throw BinderException("Query execution exceeded the timeout.");
+                if (wait_until.has_value()) {
+                    request_timeout_ms = RemainingWaitTimeMs(wait_until.value());
+                    if (request_timeout_ms == 0) {
+                        throw BinderException("Query execution exceeded the timeout.");
+                    }
                 }
                 continue;
             }
@@ -1212,7 +1223,7 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
 
         auto query_response = *response;
         if (!query_response.has_job_complete() || !query_response.job_complete().value()) {
-            return WaitForQueryCompletion(std::move(query_response), deadline);
+            return WaitForQueryCompletion(std::move(query_response), wait_until);
         }
 
         return query_response;
@@ -1247,7 +1258,8 @@ google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryRes
     auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
         google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
 
-    auto response = GetQueryResultsInternal(client, job_ref, page_token, BigquerySettings::QueryTimeoutMs());
+    auto response =
+        GetQueryResultsInternal(client, job_ref, page_token, QueryRequestTimeoutMs(BigquerySettings::QueryTimeoutMs()));
     if (!response) {
         ThrowOnErrorStatus(response.status());
         if (CheckSSLError(response.status())) {
@@ -1260,7 +1272,7 @@ google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryRes
 
 google::cloud::bigquery::v2::QueryResponse BigqueryClient::WaitForQueryCompletion(
     google::cloud::bigquery::v2::QueryResponse response,
-    const std::chrono::steady_clock::time_point &deadline) {
+    const std::optional<std::chrono::steady_clock::time_point> &wait_until) {
     if (!response.has_job_reference() || response.job_reference().job_id().empty()) {
         throw BinderException("BigQuery query did not complete and did not return a valid job reference.");
     }
@@ -1271,7 +1283,7 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::WaitForQueryCompletio
             throw InterruptException();
         }
 
-        auto results_response = GetQueryResultsUntilDeadline(job_ref, deadline);
+        auto results_response = GetQueryResultsForCompletion(job_ref, wait_until);
         if (results_response.has_job_complete() && results_response.job_complete().value()) {
             MergeQueryResultsResponse(response, results_response);
             auto job = GetJobByReference(job_ref);
@@ -1281,25 +1293,32 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::WaitForQueryCompletio
             return response;
         }
 
-        auto remaining_ms = RemainingQueryTimeoutMs(deadline);
-        if (remaining_ms == 0) {
-            throw BinderException("Query execution exceeded the timeout. Job ID: " + job_ref.job_id());
+        if (wait_until.has_value()) {
+            auto remaining_ms = RemainingWaitTimeMs(wait_until.value());
+            if (remaining_ms == 0) {
+                throw BinderException("Query execution exceeded the timeout. Job ID: " + job_ref.job_id());
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(std::min(remaining_ms, 250)));
+        } else {
+            std::this_thread::sleep_for(std::chrono::milliseconds(250));
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(std::min(remaining_ms, 250)));
     }
 }
 
-google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryResultsUntilDeadline(
+google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryResultsForCompletion(
     const google::cloud::bigquery::v2::JobReference &job_ref,
-    const std::chrono::steady_clock::time_point &deadline) {
+    const std::optional<std::chrono::steady_clock::time_point> &wait_until) {
     while (true) {
         if (context && context->IsInterrupted()) {
             throw InterruptException();
         }
 
-        auto timeout_ms = RemainingQueryTimeoutMs(deadline);
-        if (timeout_ms == 0) {
-            throw BinderException("Query execution exceeded the timeout. Job ID: " + job_ref.job_id());
+        auto timeout_ms = QUERY_REQUEST_WAIT_TIMEOUT_MS;
+        if (wait_until.has_value()) {
+            timeout_ms = RemainingWaitTimeMs(wait_until.value());
+            if (timeout_ms == 0) {
+                throw BinderException("Query execution exceeded the timeout. Job ID: " + job_ref.job_id());
+            }
         }
 
         auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
@@ -1574,17 +1593,17 @@ google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
         throw BinderException("Load job reference did not contain a job ID");
     }
 
-    if (timeout_ms.has_value()) {
-        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms.value());
+    if (timeout_ms.has_value() && timeout_ms.value() > 0) {
+        const auto wait_until = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms.value());
         while (true) {
             if (context && context->IsInterrupted()) {
                 throw InterruptException();
             }
-            if (RemainingQueryTimeoutMs(deadline) == 0) {
+            if (RemainingWaitTimeMs(wait_until) == 0) {
                 throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
             }
 
-            auto job = GetLoadJobUntilDeadline(job_ref, deadline);
+            auto job = GetLoadJobForCompletion(job_ref, wait_until);
             if (!job.has_status() || job.status().state() == "DONE") {
                 if (job.has_status()) {
                     ThrowOnJobStatusError(job.status(), "Load job");
@@ -1592,7 +1611,7 @@ google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
                 return job;
             }
 
-            auto remaining_ms = RemainingQueryTimeoutMs(deadline);
+            auto remaining_ms = RemainingWaitTimeMs(wait_until);
             if (remaining_ms == 0) {
                 throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
             }
@@ -1615,14 +1634,14 @@ google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
     }
 }
 
-google::cloud::bigquery::v2::Job BigqueryClient::GetLoadJobUntilDeadline(
+google::cloud::bigquery::v2::Job BigqueryClient::GetLoadJobForCompletion(
     const google::cloud::bigquery::v2::JobReference &job_ref,
-    const std::chrono::steady_clock::time_point &deadline) {
+    const std::chrono::steady_clock::time_point &wait_until) {
     while (true) {
         if (context && context->IsInterrupted()) {
             throw InterruptException();
         }
-        if (RemainingQueryTimeoutMs(deadline) == 0) {
+        if (RemainingWaitTimeMs(wait_until) == 0) {
             throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
         }
 

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -1159,16 +1159,12 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
         throw BinderException("Query execution failed: " + message);
     }
 
-    auto complete = response->job_complete().value();
-    if (!complete) {
-        if (response->has_job_reference()) {
-            auto job_id = response->job_reference().job_id();
-            throw BinderException("Query execution exceeded the timeout. Job ID: " + job_id);
-        }
-        throw BinderException("Query execution exceeded the timeout.");
+    auto query_response = *response;
+    if (!query_response.has_job_complete() || !query_response.job_complete().value()) {
+        return WaitForQueryCompletion(std::move(query_response));
     }
 
-    return *response;
+    return query_response;
 }
 
 idx_t BigqueryClient::ExecuteDmlQuery(const string &query,
@@ -1208,6 +1204,101 @@ google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryRes
         throw BinderException("GetQueryResults failed: " + response.status().message());
     }
     return *response;
+}
+
+google::cloud::bigquery::v2::QueryResponse BigqueryClient::WaitForQueryCompletion(
+    google::cloud::bigquery::v2::QueryResponse response) {
+    if (!response.has_job_reference() || response.job_reference().job_id().empty()) {
+        throw BinderException("BigQuery query did not complete and did not return a valid job reference.");
+    }
+
+    const auto job_ref = response.job_reference();
+    while (true) {
+        if (context && context->IsInterrupted()) {
+            throw InterruptException();
+        }
+
+        auto results_response = GetQueryResults(job_ref);
+        if (results_response.has_job_complete() && results_response.job_complete().value()) {
+            MergeQueryResultsResponse(response, results_response);
+            auto job = GetJobByReference(job_ref);
+            if (job.has_status()) {
+                ThrowOnQueryJobStatusError(job.status());
+            }
+            return response;
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+    }
+}
+
+void BigqueryClient::MergeQueryResultsResponse(
+    google::cloud::bigquery::v2::QueryResponse &query_response,
+    const google::cloud::bigquery::v2::GetQueryResultsResponse &results_response) {
+    if (results_response.has_schema()) {
+        *query_response.mutable_schema() = results_response.schema();
+    } else {
+        query_response.clear_schema();
+    }
+    if (results_response.has_job_reference()) {
+        *query_response.mutable_job_reference() = results_response.job_reference();
+    }
+    query_response.clear_rows();
+    query_response.mutable_rows()->CopyFrom(results_response.rows());
+    query_response.set_page_token(results_response.page_token());
+    if (results_response.has_total_rows()) {
+        *query_response.mutable_total_rows() = results_response.total_rows();
+    } else {
+        query_response.clear_total_rows();
+    }
+    if (results_response.has_total_bytes_processed()) {
+        *query_response.mutable_total_bytes_processed() = results_response.total_bytes_processed();
+    } else {
+        query_response.clear_total_bytes_processed();
+    }
+    if (results_response.has_job_complete()) {
+        *query_response.mutable_job_complete() = results_response.job_complete();
+    } else {
+        query_response.clear_job_complete();
+    }
+    if (results_response.has_cache_hit()) {
+        *query_response.mutable_cache_hit() = results_response.cache_hit();
+    } else {
+        query_response.clear_cache_hit();
+    }
+    if (results_response.has_num_dml_affected_rows()) {
+        *query_response.mutable_num_dml_affected_rows() = results_response.num_dml_affected_rows();
+    } else {
+        query_response.clear_num_dml_affected_rows();
+    }
+    query_response.clear_errors();
+    query_response.mutable_errors()->CopyFrom(results_response.errors());
+}
+
+void BigqueryClient::ThrowOnQueryJobStatusError(const google::cloud::bigquery::v2::JobStatus &status) {
+    if (!status.has_error_result()) {
+        return;
+    }
+
+    const auto &error = status.error_result();
+    if (error.reason() == "accessDenied") {
+        throw PermissionException(
+            "BigQuery query permission denied.\n"
+            "\n"
+            "The query job was created, but BigQuery rejected access while executing it.\n"
+            "\n"
+            "Check query-job permission on the project (`bigquery.jobs.create`) and read access on the "
+            "referenced tables or views (`bigquery.tables.getData`).\n"
+            "\n"
+            "Error details: %s",
+            error.message());
+    }
+    if (error.message().find("Array cannot have a null element") != string::npos) {
+        throw BinderException("Query execution failed: BigQuery does not allow query results with ARRAY values "
+                              "that contain NULL elements. Original error: " +
+                              error.message());
+    }
+    ThrowOnJobStatusError(status, "Query execution");
 }
 
 google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::GetJobInternal(
@@ -1377,6 +1468,7 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> Bi
     auto get_results_request = google::cloud::bigquery::v2::GetQueryResultsRequest();
     get_results_request.set_project_id(job_ref.project_id());
     get_results_request.set_job_id(job_ref.job_id());
+    get_results_request.mutable_timeout_ms()->set_value(BigquerySettings::QueryTimeoutMs());
     // get_results_request.mutable_max_results()->set_value(3);
 
     if (job_ref.has_location()) {
@@ -1387,12 +1479,7 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> Bi
         get_results_request.set_page_token(page_token);
     }
 
-    auto response = job_client.GetQueryResults(get_results_request);
-    if (!response.ok()) {
-        ThrowOnErrorStatus(response.status());
-        throw BinderException(response.status().message());
-    }
-    return response;
+    return job_client.GetQueryResults(get_results_request);
 }
 
 google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -52,6 +52,7 @@
 #include <chrono>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <optional>
 
 
@@ -294,6 +295,18 @@ static idx_t CastDmlAffectedRows(int64_t affected_rows, BigqueryDmlStatementType
                                 DmlStatementName(statement_type));
     }
     return static_cast<idx_t>(affected_rows);
+}
+
+static int RemainingQueryTimeoutMs(const std::chrono::steady_clock::time_point &deadline) {
+    auto remaining = deadline - std::chrono::steady_clock::now();
+    if (remaining <= std::chrono::steady_clock::duration::zero()) {
+        return 0;
+    }
+    auto remaining_ms = std::chrono::duration_cast<std::chrono::milliseconds>(remaining).count();
+    if (remaining_ms <= 0) {
+        return 1;
+    }
+    return static_cast<int>(std::min<int64_t>(remaining_ms, std::numeric_limits<int>::max()));
 }
 
 static string GetLoadStagingDirectory(FileSystem &fs) {
@@ -1138,33 +1151,52 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::ExecuteQuery(const st
                                                                         const bool &optional_job_creation) {
     CheckAuthentication();
 
-    auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
-        google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+    const auto timeout_ms = BigquerySettings::QueryTimeoutMs();
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+    auto request_timeout_ms = timeout_ms;
 
-    auto response = PostQueryJobInternal(client, query, location, dry_run, query_parameters, optional_job_creation);
-    if (!response.ok()) {
-        ThrowOnErrorStatus(response.status());
-
-        if (CheckSSLError(response.status())) {
-            return ExecuteQuery(query, location, dry_run, query_parameters, optional_job_creation);
+    while (true) {
+        if (context && context->IsInterrupted()) {
+            throw InterruptException();
         }
 
-        const auto &message = response.status().message();
-        if (message.find("Array cannot have a null element") != string::npos) {
-            throw BinderException("Query execution failed: BigQuery does not allow query results with ARRAY values "
-                                  "that contain NULL elements. Original error: " +
-                                  message);
+        auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
+            google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+        auto response = PostQueryJobInternal(client,
+                                             query,
+                                             location,
+                                             dry_run,
+                                             query_parameters,
+                                             optional_job_creation,
+                                             request_timeout_ms);
+        if (!response.ok()) {
+            ThrowOnErrorStatus(response.status());
+
+            if (CheckSSLError(response.status())) {
+                request_timeout_ms = RemainingQueryTimeoutMs(deadline);
+                if (request_timeout_ms == 0) {
+                    throw BinderException("Query execution exceeded the timeout.");
+                }
+                continue;
+            }
+
+            const auto &message = response.status().message();
+            if (message.find("Array cannot have a null element") != string::npos) {
+                throw BinderException("Query execution failed: BigQuery does not allow query results with ARRAY "
+                                      "values that contain NULL elements. Original error: " +
+                                      message);
+            }
+
+            throw BinderException("Query execution failed: " + message);
         }
 
-        throw BinderException("Query execution failed: " + message);
-    }
+        auto query_response = *response;
+        if (!query_response.has_job_complete() || !query_response.job_complete().value()) {
+            return WaitForQueryCompletion(std::move(query_response), deadline);
+        }
 
-    auto query_response = *response;
-    if (!query_response.has_job_complete() || !query_response.job_complete().value()) {
-        return WaitForQueryCompletion(std::move(query_response));
+        return query_response;
     }
-
-    return query_response;
 }
 
 idx_t BigqueryClient::ExecuteDmlQuery(const string &query,
@@ -1195,7 +1227,7 @@ google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryRes
     auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
         google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
 
-    auto response = GetQueryResultsInternal(client, job_ref, page_token);
+    auto response = GetQueryResultsInternal(client, job_ref, page_token, BigquerySettings::QueryTimeoutMs());
     if (!response) {
         ThrowOnErrorStatus(response.status());
         if (CheckSSLError(response.status())) {
@@ -1207,7 +1239,8 @@ google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryRes
 }
 
 google::cloud::bigquery::v2::QueryResponse BigqueryClient::WaitForQueryCompletion(
-    google::cloud::bigquery::v2::QueryResponse response) {
+    google::cloud::bigquery::v2::QueryResponse response,
+    const std::chrono::steady_clock::time_point &deadline) {
     if (!response.has_job_reference() || response.job_reference().job_id().empty()) {
         throw BinderException("BigQuery query did not complete and did not return a valid job reference.");
     }
@@ -1218,7 +1251,7 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::WaitForQueryCompletio
             throw InterruptException();
         }
 
-        auto results_response = GetQueryResults(job_ref);
+        auto results_response = GetQueryResultsUntilDeadline(job_ref, deadline);
         if (results_response.has_job_complete() && results_response.job_complete().value()) {
             MergeQueryResultsResponse(response, results_response);
             auto job = GetJobByReference(job_ref);
@@ -1228,7 +1261,38 @@ google::cloud::bigquery::v2::QueryResponse BigqueryClient::WaitForQueryCompletio
             return response;
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(250));
+        auto remaining_ms = RemainingQueryTimeoutMs(deadline);
+        if (remaining_ms == 0) {
+            throw BinderException("Query execution exceeded the timeout. Job ID: " + job_ref.job_id());
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(std::min(remaining_ms, 250)));
+    }
+}
+
+google::cloud::bigquery::v2::GetQueryResultsResponse BigqueryClient::GetQueryResultsUntilDeadline(
+    const google::cloud::bigquery::v2::JobReference &job_ref,
+    const std::chrono::steady_clock::time_point &deadline) {
+    while (true) {
+        if (context && context->IsInterrupted()) {
+            throw InterruptException();
+        }
+
+        auto timeout_ms = RemainingQueryTimeoutMs(deadline);
+        if (timeout_ms == 0) {
+            throw BinderException("Query execution exceeded the timeout. Job ID: " + job_ref.job_id());
+        }
+
+        auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
+            google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+        auto response = GetQueryResultsInternal(client, job_ref, "", timeout_ms);
+        if (response.ok()) {
+            return *response;
+        }
+
+        ThrowOnErrorStatus(response.status());
+        if (!CheckSSLError(response.status())) {
+            throw BinderException("GetQueryResults failed: " + response.status().message());
+        }
     }
 }
 
@@ -1336,7 +1400,8 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::QueryResponse> BigqueryClie
     const string &location,
     const bool &dry_run,
     const vector<Value> &query_parameters,
-    const bool &optional_job_creation) {
+    const bool &optional_job_creation,
+    const int timeout_ms) {
 
     if (!dry_run && BigquerySettings::DebugQueryPrint()) {
         std::cout << "query: " << query << std::endl;
@@ -1362,7 +1427,6 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::QueryResponse> BigqueryClie
         query_request.set_job_creation_mode(google::cloud::bigquery::v2::QueryRequest::JOB_CREATION_OPTIONAL);
     }
 
-    int timeout_ms = BigquerySettings::QueryTimeoutMs();
     query_request.mutable_timeout_ms()->set_value(timeout_ms);
 
     if (!location.empty()) {
@@ -1463,12 +1527,13 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::Insert
 google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> BigqueryClient::GetQueryResultsInternal(
     google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
     const google::cloud::bigquery::v2::JobReference &job_ref,
-    const string &page_token) {
+    const string &page_token,
+    const int timeout_ms) {
 
     auto get_results_request = google::cloud::bigquery::v2::GetQueryResultsRequest();
     get_results_request.set_project_id(job_ref.project_id());
     get_results_request.set_job_id(job_ref.job_id());
-    get_results_request.mutable_timeout_ms()->set_value(BigquerySettings::QueryTimeoutMs());
+    get_results_request.mutable_timeout_ms()->set_value(timeout_ms);
     // get_results_request.mutable_max_results()->set_value(3);
 
     if (job_ref.has_location()) {

--- a/src/bigquery_execute.cpp
+++ b/src/bigquery_execute.cpp
@@ -7,6 +7,8 @@
 #include "storage/bigquery_catalog.hpp"
 #include "storage/bigquery_transaction.hpp"
 
+#include <optional>
+
 namespace duckdb {
 namespace bigquery {
 
@@ -15,6 +17,7 @@ struct BigQueryExecuteBindData : public TableFunctionData {
     shared_ptr<BigqueryClient> bq_client;
     string query;
     bool dry_run = false;
+    std::optional<int> timeout_ms;
     bool finished = false;
 };
 
@@ -31,6 +34,7 @@ static duckdb::unique_ptr<FunctionData> BigQueryExecuteBind(ClientContext &conte
     auto result = make_uniq<BigQueryExecuteBindData>();
     result->query = query_string;
     result->dry_run = params.dry_run;
+    result->timeout_ms = params.timeout_ms;
 
     auto &database_manager = DatabaseManager::Get(context);
     auto database = database_manager.GetDatabase(context, dbname_or_project_id);
@@ -92,7 +96,7 @@ static void BigQueryExecuteFunc(ClientContext &context, TableFunctionInput &data
     if (data.finished) {
         return;
     }
-    auto response = data.bq_client->ExecuteQuery(data.query, "", data.dry_run);
+    auto response = data.bq_client->ExecuteQuery(data.query, "", data.dry_run, {}, false, data.timeout_ms);
     data.finished = true;
 
     if (!data.dry_run) {
@@ -120,6 +124,7 @@ BigQueryExecuteFunction::BigQueryExecuteFunction()
     named_parameters["api_endpoint"] = LogicalType::VARCHAR;
     named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
     named_parameters["dry_run"] = LogicalType::BOOLEAN;
+    named_parameters["timeout_ms"] = LogicalType::BIGINT;
 }
 
 } // namespace bigquery

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -122,11 +122,12 @@ static void LoadInternal(ExtensionLoader &loader) {
                               LogicalType::VARCHAR,
                               Value(bigquery::BigquerySettings::DefaultLocation()),
                               bigquery::BigquerySettings::SetDefaultLocation);
-    config.AddExtensionOption("bq_query_timeout_ms",
-                              "Maximum time to wait for BigQuery query completion in milliseconds",
-                              LogicalType::BIGINT,
-                              Value(bigquery::BigquerySettings::QueryTimeoutMs()),
-                              bigquery::BigquerySettings::SetQueryTimeoutMs);
+    config.AddExtensionOption(
+        "bq_query_timeout_ms",
+        "Maximum time to wait for BigQuery query completion in milliseconds; 0 waits until completion",
+        LogicalType::BIGINT,
+        Value(bigquery::BigquerySettings::QueryTimeoutMs()),
+        bigquery::BigquerySettings::SetQueryTimeoutMs);
     config.AddExtensionOption("bq_auth_timeout_s",
                               "Timeout for BigQuery authentication token fetches in seconds",
                               LogicalType::BIGINT,

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -123,7 +123,7 @@ static void LoadInternal(ExtensionLoader &loader) {
                               Value(bigquery::BigquerySettings::DefaultLocation()),
                               bigquery::BigquerySettings::SetDefaultLocation);
     config.AddExtensionOption("bq_query_timeout_ms",
-                              "Timeout for BigQuery queries in milliseconds",
+                              "Maximum wait time for each BigQuery query REST request in milliseconds",
                               LogicalType::BIGINT,
                               Value(bigquery::BigquerySettings::QueryTimeoutMs()),
                               bigquery::BigquerySettings::SetQueryTimeoutMs);

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -123,7 +123,7 @@ static void LoadInternal(ExtensionLoader &loader) {
                               Value(bigquery::BigquerySettings::DefaultLocation()),
                               bigquery::BigquerySettings::SetDefaultLocation);
     config.AddExtensionOption("bq_query_timeout_ms",
-                              "Maximum wait time for each BigQuery query REST request in milliseconds",
+                              "Maximum time to wait for BigQuery query completion in milliseconds",
                               LogicalType::BIGINT,
                               Value(bigquery::BigquerySettings::QueryTimeoutMs()),
                               bigquery::BigquerySettings::SetQueryTimeoutMs);

--- a/src/bigquery_load.cpp
+++ b/src/bigquery_load.cpp
@@ -41,6 +41,7 @@ struct BigQueryLoadBindData : public TableFunctionData {
     string create_disposition;
     string location;
     std::map<string, string> labels;
+    std::optional<int> timeout_ms;
     bool remove_staged_source_file = false;
     bool finished = false;
 
@@ -61,6 +62,7 @@ struct BigQueryLoadParameters {
     string billing_project;
     string api_endpoint;
     std::map<string, string> labels;
+    std::optional<int> timeout_ms;
 };
 
 static string NormalizeEnumValue(const string &value) {
@@ -185,6 +187,7 @@ static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &n
     auto api_endpoint = ParseOptionalStringParameter(named_parameters, "api_endpoint");
     params.api_endpoint = api_endpoint ? *api_endpoint : string();
     params.labels = ParseOptionalLabelsParameter(named_parameters);
+    params.timeout_ms = BigqueryUtils::ParseTimeoutMsParameter(named_parameters);
     params.write_disposition = ParseEnumParameter(named_parameters,
                                                   "write_disposition",
                                                   "WRITE_TRUNCATE",
@@ -349,6 +352,7 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
     bind_data->source_table = params.source_table;
     bind_data->location = params.location ? *params.location : BigquerySettings::DefaultLocation();
     bind_data->labels = params.labels;
+    bind_data->timeout_ms = params.timeout_ms;
 
     auto destination_table = BigqueryUtils::ParseDatasetTableString(destination_table_string);
 
@@ -416,14 +420,16 @@ static void BigQueryLoadFunc(ClientContext &context, TableFunctionInput &data_p,
                                               data.write_disposition,
                                               data.create_disposition,
                                               data.location,
-                                              data.labels);
+                                              data.labels,
+                                              data.timeout_ms);
     } else if (!data.source_uris.empty()) {
         job = data.bq_client->LoadParquetUris(data.destination_table,
                                               data.source_uris,
                                               data.write_disposition,
                                               data.create_disposition,
                                               data.location,
-                                              data.labels);
+                                              data.labels,
+                                              data.timeout_ms);
     } else {
         throw InternalException("bigquery_load has no source to load");
     }
@@ -467,6 +473,7 @@ BigQueryLoadFunction::BigQueryLoadFunction()
     named_parameters["billing_project"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["api_endpoint"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["labels"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
+    named_parameters["timeout_ms"] = LogicalType::BIGINT;
 }
 
 } // namespace bigquery

--- a/src/bigquery_query.cpp
+++ b/src/bigquery_query.cpp
@@ -213,7 +213,8 @@ static unique_ptr<GlobalTableFunctionState> BigqueryQueryInitGlobal(ClientContex
                                                                 /*optional_job_creation=*/true);
 
         if (!query_response.has_job_complete() || !query_response.job_complete().value()) {
-            throw BinderException("Query did not complete within the timeout.");
+            throw InternalException(
+                "BigQuery query execution returned an incomplete response after completion polling.");
         }
 
         auto gstate = make_uniq<BigqueryQueryInlineGlobalState>();

--- a/src/bigquery_query.cpp
+++ b/src/bigquery_query.cpp
@@ -44,6 +44,7 @@ static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
         auto result = make_uniq<BigqueryQueryDryRunBindData>();
         result->query = query_string;
         result->query_parameters = query_parameters;
+        result->timeout_ms = params.timeout_ms;
 
         if (database) {
             auto &catalog = database->GetCatalog();
@@ -76,6 +77,7 @@ static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
         auto bind_data = make_uniq<BigqueryQueryRestBindData>();
         bind_data->query = query_string;
         bind_data->query_parameters = query_parameters;
+        bind_data->timeout_ms = params.timeout_ms;
 
         if (database) {
             auto &catalog = database->GetCatalog();
@@ -104,7 +106,11 @@ static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
 
         ColumnList columns;
         vector<unique_ptr<Constraint>> constraints;
-        bind_data->bq_client->GetTableInfoForQuery(query_string, bind_data->query_parameters, columns, constraints);
+        bind_data->bq_client->GetTableInfoForQuery(query_string,
+                                                   bind_data->query_parameters,
+                                                   columns,
+                                                   constraints,
+                                                   bind_data->timeout_ms);
 
         for (auto &column : columns.Logical()) {
             names.push_back(column.GetName());
@@ -122,6 +128,7 @@ static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
     auto bind_data = make_uniq<BigqueryScanBindData>();
     bind_data->query = query_string;
     bind_data->query_parameters = query_parameters;
+    bind_data->query_timeout_ms = params.timeout_ms;
     bind_data->estimated_row_count = 1;
 
     if (database) {
@@ -151,7 +158,11 @@ static unique_ptr<FunctionData> BigqueryQueryBind(ClientContext &context,
 
     ColumnList columns;
     vector<unique_ptr<Constraint>> constraints;
-    bind_data->bq_client->GetTableInfoForQuery(query_string, bind_data->query_parameters, columns, constraints);
+    bind_data->bq_client->GetTableInfoForQuery(query_string,
+                                               bind_data->query_parameters,
+                                               columns,
+                                               constraints,
+                                               bind_data->query_timeout_ms);
 
     auto arrow_schema_ptr = BigqueryUtils::BuildArrowSchema(columns);
     auto status = arrow::ExportSchema(*std::move(arrow_schema_ptr), &bind_data->schema_root.arrow_schema);
@@ -210,7 +221,8 @@ static unique_ptr<GlobalTableFunctionState> BigqueryQueryInitGlobal(ClientContex
                                                                 "",
                                                                 false,
                                                                 bind_data.query_parameters,
-                                                                /*optional_job_creation=*/true);
+                                                                /*optional_job_creation=*/true,
+                                                                bind_data.timeout_ms);
 
         if (!query_response.has_job_complete() || !query_response.job_complete().value()) {
             throw InternalException(
@@ -240,7 +252,8 @@ static unique_ptr<GlobalTableFunctionState> BigqueryQueryInitGlobal(ClientContex
                                                             "",
                                                             false,
                                                             bind_data.query_parameters,
-                                                            /*optional_job_creation=*/false);
+                                                            /*optional_job_creation=*/false,
+                                                            bind_data.query_timeout_ms);
     auto job = bind_data.bq_client->GetJobByReference(query_response.job_reference());
 
     if (job.status().has_error_result()) {
@@ -292,7 +305,12 @@ static void BigqueryQueryExecute(ClientContext &context, TableFunctionInput &dat
             return;
         }
 
-        auto response = bind_data.bq_client->ExecuteQuery(bind_data.query, "", true, bind_data.query_parameters);
+        auto response = bind_data.bq_client->ExecuteQuery(bind_data.query,
+                                                          "",
+                                                          true,
+                                                          bind_data.query_parameters,
+                                                          false,
+                                                          bind_data.timeout_ms);
         bind_data.finished = true;
 
         output.SetValue(0, 0, Value::BIGINT(response.total_bytes_processed().value()));
@@ -459,6 +477,7 @@ BigqueryQueryFunction::BigqueryQueryFunction()
     named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
     named_parameters["use_rest_api"] = LogicalType::BOOLEAN;
     named_parameters["dry_run"] = LogicalType::BOOLEAN;
+    named_parameters["timeout_ms"] = LogicalType::BIGINT;
     varargs = LogicalType::ANY;
 }
 

--- a/src/bigquery_utils.cpp
+++ b/src/bigquery_utils.cpp
@@ -1,5 +1,6 @@
 #include <arrow/api.h>
 #include <iostream>
+#include <limits>
 #include <regex>
 
 #include <google/protobuf/descriptor.h>
@@ -1079,6 +1080,7 @@ BigQueryCommonParameters BigQueryCommonParameters::ParseFromNamedParameters(
     const named_parameter_map_t &named_parameters) {
 
     BigQueryCommonParameters params;
+    params.timeout_ms = BigqueryUtils::ParseTimeoutMsParameter(named_parameters);
     for (auto &kv : named_parameters) {
         auto loption = StringUtil::Lower(kv.first);
 
@@ -1098,6 +1100,22 @@ BigQueryCommonParameters BigQueryCommonParameters::ParseFromNamedParameters(
         // otherwise, ignore
     }
     return params;
+}
+
+std::optional<int> BigqueryUtils::ParseTimeoutMsParameter(const named_parameter_map_t &named_parameters) {
+    auto entry = named_parameters.find("timeout_ms");
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return std::nullopt;
+    }
+
+    auto value = entry->second.GetValue<int64_t>();
+    if (value < 0) {
+        throw InvalidInputException("Timeout must be non-negative");
+    }
+    if (value > std::numeric_limits<int>::max()) {
+        throw InvalidInputException("Timeout must fit in a 32-bit integer");
+    }
+    return static_cast<int>(value);
 }
 
 

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <iostream>
 #include <map>
 #include <string>
@@ -136,17 +137,23 @@ private:
     google::cloud::StatusOr<google::cloud::bigquery::v2::QueryResponse> PostQueryJobInternal(
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const string &query,
-        const string &location = "",
-        const bool &dry_run = false,
-        const vector<Value> &query_parameters = {},
-        const bool &optional_job_creation = false);
+        const string &location,
+        const bool &dry_run,
+        const vector<Value> &query_parameters,
+        const bool &optional_job_creation,
+        const int timeout_ms);
 
     google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> GetQueryResultsInternal(
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const google::cloud::bigquery::v2::JobReference &job_ref,
-        const string &page_token = "");
+        const string &page_token,
+        const int timeout_ms);
     google::cloud::bigquery::v2::QueryResponse WaitForQueryCompletion(
-        google::cloud::bigquery::v2::QueryResponse response);
+        google::cloud::bigquery::v2::QueryResponse response,
+        const std::chrono::steady_clock::time_point &deadline);
+    google::cloud::bigquery::v2::GetQueryResultsResponse GetQueryResultsUntilDeadline(
+        const google::cloud::bigquery::v2::JobReference &job_ref,
+        const std::chrono::steady_clock::time_point &deadline);
     void MergeQueryResultsResponse(google::cloud::bigquery::v2::QueryResponse &query_response,
                                    const google::cloud::bigquery::v2::GetQueryResultsResponse &results_response);
     void ThrowOnQueryJobStatusError(const google::cloud::bigquery::v2::JobStatus &status);

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -145,6 +145,11 @@ private:
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const google::cloud::bigquery::v2::JobReference &job_ref,
         const string &page_token = "");
+    google::cloud::bigquery::v2::QueryResponse WaitForQueryCompletion(
+        google::cloud::bigquery::v2::QueryResponse response);
+    void MergeQueryResultsResponse(google::cloud::bigquery::v2::QueryResponse &query_response,
+                                   const google::cloud::bigquery::v2::GetQueryResultsResponse &results_response);
+    void ThrowOnQueryJobStatusError(const google::cloud::bigquery::v2::JobStatus &status);
     google::cloud::bigquery::v2::InsertJobRequest BuildLoadJobRequest(const BigqueryTableRef &destination_table,
                                                                       const string &write_disposition,
                                                                       const string &create_disposition,

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -156,10 +156,10 @@ private:
         const int timeout_ms);
     google::cloud::bigquery::v2::QueryResponse WaitForQueryCompletion(
         google::cloud::bigquery::v2::QueryResponse response,
-        const std::chrono::steady_clock::time_point &deadline);
-    google::cloud::bigquery::v2::GetQueryResultsResponse GetQueryResultsUntilDeadline(
+        const std::optional<std::chrono::steady_clock::time_point> &wait_until);
+    google::cloud::bigquery::v2::GetQueryResultsResponse GetQueryResultsForCompletion(
         const google::cloud::bigquery::v2::JobReference &job_ref,
-        const std::chrono::steady_clock::time_point &deadline);
+        const std::optional<std::chrono::steady_clock::time_point> &wait_until);
     void MergeQueryResultsResponse(google::cloud::bigquery::v2::QueryResponse &query_response,
                                    const google::cloud::bigquery::v2::GetQueryResultsResponse &results_response);
     void ThrowOnQueryJobStatusError(const google::cloud::bigquery::v2::JobStatus &status);
@@ -186,8 +186,8 @@ private:
         const std::map<string, string> &labels);
     google::cloud::bigquery::v2::Job WaitForJobCompletion(const google::cloud::bigquery::v2::JobReference &job_ref,
                                                           const std::optional<int> &timeout_ms = std::nullopt);
-    google::cloud::bigquery::v2::Job GetLoadJobUntilDeadline(const google::cloud::bigquery::v2::JobReference &job_ref,
-                                                             const std::chrono::steady_clock::time_point &deadline);
+    google::cloud::bigquery::v2::Job GetLoadJobForCompletion(const google::cloud::bigquery::v2::JobReference &job_ref,
+                                                             const std::chrono::steady_clock::time_point &wait_until);
     void ThrowOnJobStatusError(const google::cloud::bigquery::v2::JobStatus &status, const string &operation_name);
 
     void MapTableSchema(const google::cloud::bigquery::v2::TableSchema &schema,

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -78,7 +79,8 @@ public:
     void GetTableInfoForQuery(const string &query,
                               const vector<Value> &query_parameters,
                               ColumnList &res_columns,
-                              vector<unique_ptr<Constraint>> &res_constraints);
+                              vector<unique_ptr<Constraint>> &res_constraints,
+                              const std::optional<int> &timeout_ms = std::nullopt);
 
     vector<google::cloud::bigquery::v2::ListFormatJob> ListJobs(const ListJobsParams &params);
     google::cloud::bigquery::v2::Job GetJob(const string &job_id, const string &location = "");
@@ -88,25 +90,29 @@ public:
                                                      const string &write_disposition = "WRITE_TRUNCATE",
                                                      const string &create_disposition = "CREATE_IF_NEEDED",
                                                      const string &location = "",
-                                                     const std::map<string, string> &labels = {});
+                                                     const std::map<string, string> &labels = {},
+                                                     const std::optional<int> &timeout_ms = std::nullopt);
     google::cloud::bigquery::v2::Job LoadParquetUris(const BigqueryTableRef &destination_table,
                                                      const vector<string> &source_uris,
                                                      const string &write_disposition = "WRITE_TRUNCATE",
                                                      const string &create_disposition = "CREATE_IF_NEEDED",
                                                      const string &location = "",
-                                                     const std::map<string, string> &labels = {});
+                                                     const std::map<string, string> &labels = {},
+                                                     const std::optional<int> &timeout_ms = std::nullopt);
     google::cloud::bigquery::v2::Job LoadDuckDBTable(const string &table_name,
                                                      const BigqueryTableRef &destination_table,
                                                      const string &write_disposition = "WRITE_TRUNCATE",
                                                      const string &create_disposition = "CREATE_IF_NEEDED",
                                                      const string &location = "",
-                                                     const std::map<string, string> &labels = {});
+                                                     const std::map<string, string> &labels = {},
+                                                     const std::optional<int> &timeout_ms = std::nullopt);
 
     google::cloud::bigquery::v2::QueryResponse ExecuteQuery(const string &query,
                                                             const string &location = "",
                                                             const bool &dry_run = false,
                                                             const vector<Value> &query_parameters = {},
-                                                            const bool &optional_job_creation = false);
+                                                            const bool &optional_job_creation = false,
+                                                            const std::optional<int> &timeout_ms = std::nullopt);
     idx_t ExecuteDmlQuery(const string &query, BigqueryDmlStatementType statement_type, const string &location = "");
     google::cloud::bigquery::v2::GetQueryResultsResponse GetQueryResults(
         const google::cloud::bigquery::v2::JobReference &job_ref,
@@ -178,7 +184,10 @@ private:
         const string &create_disposition,
         const string &location,
         const std::map<string, string> &labels);
-    google::cloud::bigquery::v2::Job WaitForJobCompletion(const google::cloud::bigquery::v2::JobReference &job_ref);
+    google::cloud::bigquery::v2::Job WaitForJobCompletion(const google::cloud::bigquery::v2::JobReference &job_ref,
+                                                          const std::optional<int> &timeout_ms = std::nullopt);
+    google::cloud::bigquery::v2::Job GetLoadJobUntilDeadline(const google::cloud::bigquery::v2::JobReference &job_ref,
+                                                             const std::chrono::steady_clock::time_point &deadline);
     void ThrowOnJobStatusError(const google::cloud::bigquery::v2::JobStatus &status, const string &operation_name);
 
     void MapTableSchema(const google::cloud::bigquery::v2::TableSchema &schema,

--- a/src/include/bigquery_query.hpp
+++ b/src/include/bigquery_query.hpp
@@ -5,6 +5,8 @@
 #include "bigquery_client.hpp"
 #include "bigquery_utils.hpp"
 
+#include <optional>
+
 namespace duckdb {
 namespace bigquery {
 
@@ -13,6 +15,7 @@ struct BigqueryQueryDryRunBindData : public TableFunctionData {
     shared_ptr<BigqueryClient> bq_client;
     string query;
     vector<Value> query_parameters;
+    std::optional<int> timeout_ms;
     bool finished = false;
 };
 
@@ -22,6 +25,7 @@ struct BigqueryQueryRestBindData : public TableFunctionData {
     shared_ptr<BigqueryClient> bq_client;
     string query;
     vector<Value> query_parameters;
+    std::optional<int> timeout_ms;
 
     vector<string> names;
     vector<LogicalType> types;

--- a/src/include/bigquery_scan.hpp
+++ b/src/include/bigquery_scan.hpp
@@ -10,6 +10,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 
 namespace duckdb {
 namespace bigquery {
@@ -32,6 +33,7 @@ struct BigqueryScanBindData : public ArrowScanFunctionData {
     BigqueryTableRef table_ref;
     string query;
     vector<Value> query_parameters;
+    std::optional<int> query_timeout_ms;
     string filter_condition;
 
     BigqueryConfig bq_config;

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -138,7 +138,7 @@ public:
     }
 
     static int &QueryTimeoutMs() {
-        static int BIGQUERY_QUERY_TIMEOUT_MS = 90000;
+        static int BIGQUERY_QUERY_TIMEOUT_MS = 0;
         return BIGQUERY_QUERY_TIMEOUT_MS;
     }
 

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -154,12 +154,6 @@ public:
         int timeout = GetIntSettingValue("Query timeout", parameter);
         if (timeout < 0) {
             throw InvalidInputException("Query timeout must be non-negative");
-        } else if (timeout > 200000) {
-            std::cout << "Warning: Query timeout is set to a very high value. The BigQuery documentation states that "
-                         "the call is not guaranteed to wait for the specified timeout and returns typically after "
-                         "around 200 seconds even if the query is not complete (see "
-                         "https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#QueryRequest)"
-                      << std::endl;
         }
         QueryTimeoutMs() = timeout;
     }

--- a/src/include/bigquery_utils.hpp
+++ b/src/include/bigquery_utils.hpp
@@ -12,6 +12,7 @@
 
 #include <arrow/api.h>
 #include <chrono>
+#include <optional>
 #include <regex>
 #include <thread>
 
@@ -223,6 +224,8 @@ public:
                                       const vector<LogicalType> &types,
                                       DataChunk &output);
 
+    static std::optional<int> ParseTimeoutMsParameter(const named_parameter_map_t &named_parameters);
+
 private:
     static vector<string> SplitStructFields(const string &struct_field_str);
     static string StructRemoveWhitespaces(const string &struct_str);
@@ -236,6 +239,7 @@ struct BigQueryCommonParameters {
     string filter;
     bool dry_run = false;
     bool use_rest_api = false;
+    std::optional<int> timeout_ms;
 
     //! Parse common parameters from named_parameters map
     static BigQueryCommonParameters ParseFromNamedParameters(const named_parameter_map_t &named_parameters);

--- a/test/sql/functions/function_bigquery_execute.test
+++ b/test/sql/functions/function_bigquery_execute.test
@@ -11,16 +11,10 @@ require-env BQ_TEST_DATASET
 statement ok
 SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`')
 
-statement ok
-SET bq_query_timeout_ms = 0;
-
 query IIIIIII
 SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table` (x INT64)')
 ----
 1	<REGEX>:job_.+	<REGEX>:.+	<REGEX>:.+	0	0	0
-
-statement ok
-SET bq_query_timeout_ms = 90000;
 
 query III
 FROM bigquery_execute('${BQ_TEST_PROJECT}', 'FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`', dry_run=true)

--- a/test/sql/functions/function_bigquery_execute.test
+++ b/test/sql/functions/function_bigquery_execute.test
@@ -11,10 +11,16 @@ require-env BQ_TEST_DATASET
 statement ok
 SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`')
 
+statement ok
+SET bq_query_timeout_ms = 0;
+
 query IIIIIII
 SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table` (x INT64)')
 ----
 1	<REGEX>:job_.+	<REGEX>:.+	<REGEX>:.+	0	0	0
+
+statement ok
+SET bq_query_timeout_ms = 90000;
 
 query III
 FROM bigquery_execute('${BQ_TEST_PROJECT}', 'FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`', dry_run=true)

--- a/test/sql/functions/function_bigquery_execute.test
+++ b/test/sql/functions/function_bigquery_execute.test
@@ -11,8 +11,11 @@ require-env BQ_TEST_DATASET
 statement ok
 SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`')
 
+statement ok
+SET bq_query_timeout_ms = 90000;
+
 query IIIIIII
-SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table` (x INT64)', timeout_ms := 90000)
+SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table` (x INT64)', timeout_ms := 0)
 ----
 1	<REGEX>:job_.+	<REGEX>:.+	<REGEX>:.+	0	0	0
 

--- a/test/sql/functions/function_bigquery_execute.test
+++ b/test/sql/functions/function_bigquery_execute.test
@@ -12,12 +12,12 @@ statement ok
 SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`')
 
 query IIIIIII
-SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table` (x INT64)')
+SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table` (x INT64)', timeout_ms := 90000)
 ----
 1	<REGEX>:job_.+	<REGEX>:.+	<REGEX>:.+	0	0	0
 
 query III
-FROM bigquery_execute('${BQ_TEST_PROJECT}', 'FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`', dry_run=true)
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table`', dry_run=true, timeout_ms := 90000)
 ----
 0	false	<REGEX>:.+
 
@@ -30,7 +30,7 @@ SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'exec_table';
 1
 
 statement ok
-CALL bigquery_execute('bq', 'DROP TABLE ${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table;')
+CALL bigquery_execute('bq', 'DROP TABLE ${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table;', timeout_ms := 90000)
 
 statement ok
 CALL bigquery_clear_cache();

--- a/test/sql/functions/function_bigquery_load.test
+++ b/test/sql/functions/function_bigquery_load.test
@@ -34,6 +34,26 @@ CALL bigquery_load(
 ----
 Binder Error: Null label values are not allowed in parameter 'labels'
 
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/multiple_row_groups.parquet',
+	timeout_ms := -1
+);
+----
+Invalid Input Error: Timeout must be non-negative
+
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/multiple_row_groups.parquet',
+	timeout_ms := 2147483648
+);
+----
+Invalid Input Error: Timeout must fit in a 32-bit integer
+
 statement ok
 CREATE OR REPLACE TEMP TABLE load_file_job AS
 SELECT *
@@ -42,6 +62,7 @@ FROM bigquery_load(
 	'${BQ_TEST_DATASET}.load_file_table',
 	source_file := 'test/data/multiple_row_groups.parquet',
 	location := 'europe-west3',
+	timeout_ms := 90000,
 	labels := MAP {'duckdb_label_env': 'test', 'duckdb_load_label': 'load_job'}
 );
 

--- a/test/sql/functions/function_bigquery_load.test
+++ b/test/sql/functions/function_bigquery_load.test
@@ -95,7 +95,8 @@ CALL bigquery_load(
 	'bq',
 	'${BQ_TEST_DATASET}.load_file_table',
 	source_table := 'local_load_source',
-	location='europe-west3'
+	location='europe-west3',
+	timeout_ms := 0
 );
 
 sleep 5 seconds

--- a/test/sql/functions/function_bigquery_query.test
+++ b/test/sql/functions/function_bigquery_query.test
@@ -55,6 +55,17 @@ SELECT count(*) FROM bigquery_query('bq', 'SELECT * FROM ${BQ_TEST_DATASET}.test
 ----
 14
 
+statement ok
+SET bq_query_timeout_ms = 0;
+
+query I
+SELECT count(*) FROM bigquery_query('bq', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view', timeout_ms := 90000);
+----
+14
+
+statement ok
+SET bq_query_timeout_ms = 90000;
+
 query I
 SELECT name FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view ORDER BY name ASC LIMIT 1');
 ----
@@ -83,6 +94,16 @@ statement error
 SELECT * FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT ? AS x', [1,2,3]);
 ----
 <REGEX>:Binder Error: Unsupported DuckDB type for BigQuery query parameter .+: .+
+
+statement error
+SELECT * FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 1 AS x', timeout_ms := -1);
+----
+Invalid Input Error: Timeout must be non-negative
+
+statement error
+SELECT * FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 1 AS x', timeout_ms := 2147483648);
+----
+Invalid Input Error: Timeout must fit in a 32-bit integer
 
 statement ok
 CALL bigquery_execute('bq', 'DROP VIEW ${BQ_TEST_DATASET}.test_cities_view;');

--- a/test/sql/functions/function_bigquery_query.test
+++ b/test/sql/functions/function_bigquery_query.test
@@ -59,7 +59,7 @@ statement ok
 SET bq_query_timeout_ms = 0;
 
 query I
-SELECT count(*) FROM bigquery_query('bq', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view', timeout_ms := 90000);
+SELECT count(*) FROM bigquery_query('bq', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view');
 ----
 14
 
@@ -67,7 +67,12 @@ statement ok
 SET bq_query_timeout_ms = 90000;
 
 query I
-SELECT name FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view ORDER BY name ASC LIMIT 1');
+SELECT count(*) FROM bigquery_query('bq', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view', timeout_ms := 0);
+----
+14
+
+query I
+SELECT name FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT * FROM ${BQ_TEST_DATASET}.test_cities_view ORDER BY name ASC LIMIT 1', timeout_ms := 90000);
 ----
 Amsterdam
 

--- a/test/sql/functions/function_bigquery_query.test
+++ b/test/sql/functions/function_bigquery_query.test
@@ -65,6 +65,18 @@ SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT ? AS x', 42);
 ----
 42
 
+# Best-effort coverage for jobs.query returning before job completion.
+statement ok
+SET bq_query_timeout_ms = 0;
+
+query I
+SELECT x FROM bigquery_query('bq', 'SELECT 7 AS x');
+----
+7
+
+statement ok
+SET bq_query_timeout_ms = 90000;
+
 statement error
 SELECT * FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT ? AS x');
 ----

--- a/test/sql/functions/function_bigquery_query.test
+++ b/test/sql/functions/function_bigquery_query.test
@@ -65,18 +65,6 @@ SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT ? AS x', 42);
 ----
 42
 
-# Best-effort coverage for jobs.query returning before job completion.
-statement ok
-SET bq_query_timeout_ms = 0;
-
-query I
-SELECT x FROM bigquery_query('bq', 'SELECT 7 AS x');
-----
-7
-
-statement ok
-SET bq_query_timeout_ms = 90000;
-
 statement error
 SELECT * FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT ? AS x');
 ----

--- a/test/sql/functions/function_bigquery_query_rest.test
+++ b/test/sql/functions/function_bigquery_query_rest.test
@@ -21,6 +21,20 @@ SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 42 AS x', use_rest_ap
 ----
 42
 
+# Best-effort coverage for the REST result path after an incomplete wait response.
+statement ok
+SET bq_query_timeout_ms = 0;
+
+query I
+SELECT total FROM bigquery_query('${BQ_TEST_PROJECT}', '
+    SELECT SUM(i) AS total FROM UNNEST(GENERATE_ARRAY(1, 1000000)) AS i
+', use_rest_api=true);
+----
+500000500000
+
+statement ok
+SET bq_query_timeout_ms = 90000;
+
 # Query parameters
 query I
 SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT ? AS x', 42, use_rest_api=true);

--- a/test/sql/functions/function_bigquery_query_rest.test
+++ b/test/sql/functions/function_bigquery_query_rest.test
@@ -21,20 +21,6 @@ SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 42 AS x', use_rest_ap
 ----
 42
 
-# Best-effort coverage for the REST result path after an incomplete wait response.
-statement ok
-SET bq_query_timeout_ms = 0;
-
-query I
-SELECT total FROM bigquery_query('${BQ_TEST_PROJECT}', '
-    SELECT SUM(i) AS total FROM UNNEST(GENERATE_ARRAY(1, 1000000)) AS i
-', use_rest_api=true);
-----
-500000500000
-
-statement ok
-SET bq_query_timeout_ms = 90000;
-
 # Query parameters
 query I
 SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT ? AS x', 42, use_rest_api=true);

--- a/test/sql/functions/function_bigquery_query_rest.test
+++ b/test/sql/functions/function_bigquery_query_rest.test
@@ -17,7 +17,7 @@ SELECT count(*) FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 1 AS x UNION A
 
 # Simple value
 query I
-SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 42 AS x', use_rest_api=true);
+SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 42 AS x', use_rest_api=true, timeout_ms := 90000);
 ----
 42
 

--- a/test/sql/functions/function_bigquery_query_rest.test
+++ b/test/sql/functions/function_bigquery_query_rest.test
@@ -17,7 +17,7 @@ SELECT count(*) FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 1 AS x UNION A
 
 # Simple value
 query I
-SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 42 AS x', use_rest_api=true, timeout_ms := 90000);
+SELECT x FROM bigquery_query('${BQ_TEST_PROJECT}', 'SELECT 42 AS x', use_rest_api=true, timeout_ms := 0);
 ----
 42
 

--- a/test/sql/storage/attach_dml_statements.test
+++ b/test/sql/storage/attach_dml_statements.test
@@ -36,10 +36,16 @@ INSERT INTO bq.${BQ_TEST_DATASET}.dml_struct_filters VALUES
     (2, 0, {'name': 'Bob Johnson', 'address': {'city': 'Los Angeles', 'zip_code': '90001'}}),
     (3, 0, {'name': 'Alice Smith', 'address': {'city': 'New York', 'zip_code': '10001'}});
 
+statement ok
+SET bq_query_timeout_ms = 0;
+
 query I
 UPDATE bq.${BQ_TEST_DATASET}.dml_statements SET i=10 WHERE 1=1;
 ----
 5
+
+statement ok
+SET bq_query_timeout_ms = 90000;
 
 query I
 SELECT * FROM bq.${BQ_TEST_DATASET}.dml_statements;

--- a/test/sql/storage/attach_dml_statements.test
+++ b/test/sql/storage/attach_dml_statements.test
@@ -36,16 +36,10 @@ INSERT INTO bq.${BQ_TEST_DATASET}.dml_struct_filters VALUES
     (2, 0, {'name': 'Bob Johnson', 'address': {'city': 'Los Angeles', 'zip_code': '90001'}}),
     (3, 0, {'name': 'Alice Smith', 'address': {'city': 'New York', 'zip_code': '10001'}});
 
-statement ok
-SET bq_query_timeout_ms = 0;
-
 query I
 UPDATE bq.${BQ_TEST_DATASET}.dml_statements SET i=10 WHERE 1=1;
 ----
 5
-
-statement ok
-SET bq_query_timeout_ms = 90000;
 
 query I
 SELECT * FROM bq.${BQ_TEST_DATASET}.dml_statements;


### PR DESCRIPTION
This fixes long-running BQ queries that previously failed when the initial `jobs.query` request returned before the job had completed, typically after around 200 seconds (max). The extension now keeps polling the BQ job until it finishes, so queries that take several minutes can complete through DuckDB as well.

Queries now wait for completion by default. `bq_query_timeout_ms` defaults to 0, which means unlimited waiting. A positive value can still be configured when a local wait limit is required:

```sql
SET bq_query_timeout_ms = 500000;

SELECT * FROM bigquery_query('bq', 'SELECT ...');
```

`bigquery_query` and `bigquery_execute` also accept `timeout_ms` for individual calls. This overrides the session setting, and `timeout_ms := 0` explicitly waits indefinitely:

```sql
SELECT * FROM bigquery_query(
    'bq',
    'SELECT ...',
    timeout_ms := 550000
);
```

A local timeout or DuckDB interrupt stops waiting in DuckDB but does not automatically cancel an already running BigQuery query or load job. The change also preserves final query error handling and DML/result metadata after a job completes through polling.

Closes #194 