### PR TITLE
feat(bigquery_execute): add destination_table for query-to-table jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,6 +393,18 @@ The `bigquery_execute` function supports the following named parameters:
 | `api_endpoint`  | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
 | `grpc_endpoint` | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
 | `timeout_ms`    | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms`; `0` waits indefinitely. |
+| `destination_table` | `VARCHAR` | Materialise the query result into this table (`dataset.table` or `project.dataset.table`). Runs the query as a `jobs.insert` job writing to the table — something the default `jobs.query` path cannot do. Cannot be combined with `dry_run`. |
+| `write_disposition` | `VARCHAR` | How to write into an existing `destination_table`: `WRITE_TRUNCATE` (default), `WRITE_APPEND`, or `WRITE_EMPTY`. Ignored without `destination_table`. |
+| `create_disposition` | `VARCHAR` | Whether to create `destination_table` if it does not exist: `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`. Ignored without `destination_table`. |
+
+When `destination_table` is set, the query runs as a query job that writes its result into the table, and the returned `total_rows` / `total_bytes_processed` reflect that job (`num_dml_affected_rows` is `NULL` for non-DML queries):
+
+```sql
+D CALL bigquery_execute('my_gcp_project',
+    'SELECT id, name FROM `my_gcp_project.quacking_dataset.ducks` WHERE active',
+    destination_table := 'quacking_dataset.active_ducks',
+    write_disposition := 'WRITE_TRUNCATE');
+```
 
 ### `bigquery_load` Function
 

--- a/README.md
+++ b/README.md
@@ -367,9 +367,9 @@ D CALL bigquery_execute('bq', '
 ');
 ┌─────────┬──────────────────────────────────┬─────────────────┬──────────┬────────────┬───────────────────────┬───────────────────────┐
 │ success │             job_id               │    project_id   │ location │ total_rows │ total_bytes_processed │ num_dml_affected_rows │
-│ boolean │             varchar              │     varchar     │ varchar  │   uint64   │         int64         │        varchar        │
+│ boolean │             varchar              │     varchar     │ varchar  │   uint64   │         int64         │         int64         │
 ├─────────┼──────────────────────────────────┼─────────────────┼──────────┼────────────┼───────────────────────┼───────────────────────┤
-│ true    │ job_-Xu_D2wxe2Xjh-ArZNwZ6gut5ggi │ my_gcp_project  │ US       │          0 │                     0 │ 0                     │
+│ true    │ job_-Xu_D2wxe2Xjh-ArZNwZ6gut5ggi │ my_gcp_project  │ US       │          0 │                     0 │                     0 │
 └─────────┴──────────────────────────────────┴─────────────────┴──────────┴────────────┴───────────────────────┴───────────────────────┘
 ```
 

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -798,6 +798,53 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryT
     return WaitForJobCompletion(response->job_reference(), timeout_ms);
 }
 
+google::cloud::bigquery::v2::Job BigqueryClient::ExecuteQueryToTable(const string &query,
+                                                                    const BigqueryTableRef &destination_table,
+                                                                    const string &write_disposition,
+                                                                    const string &create_disposition,
+                                                                    const string &location,
+                                                                    const std::map<string, string> &labels,
+                                                                    const std::optional<int> &timeout_ms) {
+    if (query.empty()) {
+        throw BinderException("ExecuteQueryToTable requires a non-empty query");
+    }
+    if (destination_table.dataset_id.empty() || destination_table.table_id.empty()) {
+        throw BinderException("ExecuteQueryToTable requires a destination table with a dataset and table id");
+    }
+
+    CheckAuthentication();
+
+    auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
+        google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+
+    auto request = BuildQueryJobRequest(query, destination_table, write_disposition, create_disposition, location, labels);
+    auto response = client.InsertJob(request);
+    if (!response.ok()) {
+        ThrowOnErrorStatus(response.status());
+
+        if (CheckSSLError(response.status())) {
+            return ExecuteQueryToTable(query,
+                                       destination_table,
+                                       write_disposition,
+                                       create_disposition,
+                                       location,
+                                       labels,
+                                       timeout_ms);
+        }
+
+        throw BinderException("Query job submission failed: " + response.status().message());
+    }
+
+    if (!response->has_job_reference()) {
+        throw BinderException("Query job submission succeeded but did not return a job reference");
+    }
+    if (response->has_status() && response->status().state() == "DONE") {
+        ThrowOnJobStatusError(response->status(), "Query job");
+        return *response;
+    }
+    return WaitForJobCompletion(response->job_reference(), timeout_ms);
+}
+
 google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &table_name,
                                                                  const BigqueryTableRef &destination_table,
                                                                  const string &write_disposition,
@@ -1513,6 +1560,45 @@ google::cloud::bigquery::v2::InsertJobRequest BigqueryClient::BuildLoadJobReques
     load_config->set_create_disposition(create_disposition);
     load_config->set_write_disposition(write_disposition);
     auto *destination = load_config->mutable_destination_table();
+    destination->set_project_id(destination_table.project_id);
+    destination->set_dataset_id(destination_table.dataset_id);
+    destination->set_table_id(destination_table.table_id);
+
+    google::cloud::bigquery::v2::InsertJobRequest request;
+    request.set_project_id(config.BillingProject());
+    *request.mutable_job() = job;
+    return request;
+}
+
+google::cloud::bigquery::v2::InsertJobRequest BigqueryClient::BuildQueryJobRequest(
+    const string &query,
+    const BigqueryTableRef &destination_table,
+    const string &write_disposition,
+    const string &create_disposition,
+    const string &location,
+    const std::map<string, string> &labels) {
+    google::cloud::bigquery::v2::Job job;
+    auto *job_reference = job.mutable_job_reference();
+    job_reference->set_project_id(config.BillingProject());
+    job_reference->set_job_id(GenerateJobId("query"));
+    if (!location.empty()) {
+        job_reference->mutable_location()->set_value(location);
+    }
+
+    auto *job_config = job.mutable_configuration();
+    if (!labels.empty()) {
+        auto *job_labels = job_config->mutable_labels();
+        for (const auto &label : labels) {
+            (*job_labels)[label.first] = label.second;
+        }
+    }
+
+    auto *query_config = job_config->mutable_query();
+    query_config->set_query(query);
+    query_config->mutable_use_legacy_sql()->set_value(false);
+    query_config->set_create_disposition(create_disposition);
+    query_config->set_write_disposition(write_disposition);
+    auto *destination = query_config->mutable_destination_table();
     destination->set_project_id(destination_table.project_id);
     destination->set_dataset_id(destination_table.dataset_id);
     destination->set_table_id(destination_table.table_id);

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -842,7 +842,11 @@ google::cloud::bigquery::v2::Job BigqueryClient::ExecuteQueryToTable(const strin
         ThrowOnJobStatusError(response->status(), "Query job");
         return *response;
     }
-    return WaitForJobCompletion(response->job_reference(), timeout_ms);
+    // Mirror ExecuteQuery: when the caller didn't pass an explicit per-call timeout,
+    // fall back to the session-level bq_query_timeout_ms instead of waiting forever.
+    const auto effective_timeout_ms =
+        timeout_ms.has_value() ? timeout_ms : std::optional<int>(BigquerySettings::QueryTimeoutMs());
+    return WaitForJobCompletion(response->job_reference(), effective_timeout_ms, "Query job");
 }
 
 google::cloud::bigquery::v2::Job BigqueryClient::LoadDuckDBTable(const string &table_name,
@@ -1674,9 +1678,10 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::GetQueryResultsResponse> Bi
 
 google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
     const google::cloud::bigquery::v2::JobReference &job_ref,
-    const std::optional<int> &timeout_ms) {
+    const std::optional<int> &timeout_ms,
+    const string &job_kind) {
     if (job_ref.job_id().empty()) {
-        throw BinderException("Load job reference did not contain a job ID");
+        throw BinderException(job_kind + " reference did not contain a job ID");
     }
 
     if (timeout_ms.has_value() && timeout_ms.value() > 0) {
@@ -1686,20 +1691,20 @@ google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
                 throw InterruptException();
             }
             if (RemainingWaitTimeMs(wait_until) == 0) {
-                throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
+                throw BinderException(job_kind + " execution exceeded the timeout. Job ID: " + job_ref.job_id());
             }
 
-            auto job = GetLoadJobForCompletion(job_ref, wait_until);
+            auto job = GetLoadJobForCompletion(job_ref, wait_until, job_kind);
             if (!job.has_status() || job.status().state() == "DONE") {
                 if (job.has_status()) {
-                    ThrowOnJobStatusError(job.status(), "Load job");
+                    ThrowOnJobStatusError(job.status(), job_kind);
                 }
                 return job;
             }
 
             auto remaining_ms = RemainingWaitTimeMs(wait_until);
             if (remaining_ms == 0) {
-                throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
+                throw BinderException(job_kind + " execution exceeded the timeout. Job ID: " + job_ref.job_id());
             }
             std::this_thread::sleep_for(std::chrono::milliseconds(std::min(remaining_ms, 250)));
         }
@@ -1712,7 +1717,7 @@ google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
         auto job = GetJobByReference(job_ref);
         if (!job.has_status() || job.status().state() == "DONE") {
             if (job.has_status()) {
-                ThrowOnJobStatusError(job.status(), "Load job");
+                ThrowOnJobStatusError(job.status(), job_kind);
             }
             return job;
         }
@@ -1722,13 +1727,14 @@ google::cloud::bigquery::v2::Job BigqueryClient::WaitForJobCompletion(
 
 google::cloud::bigquery::v2::Job BigqueryClient::GetLoadJobForCompletion(
     const google::cloud::bigquery::v2::JobReference &job_ref,
-    const std::chrono::steady_clock::time_point &wait_until) {
+    const std::chrono::steady_clock::time_point &wait_until,
+    const string &job_kind) {
     while (true) {
         if (context && context->IsInterrupted()) {
             throw InterruptException();
         }
         if (RemainingWaitTimeMs(wait_until) == 0) {
-            throw BinderException("Load job execution exceeded the timeout. Job ID: " + job_ref.job_id());
+            throw BinderException(job_kind + " execution exceeded the timeout. Job ID: " + job_ref.job_id());
         }
 
         CheckAuthentication();

--- a/src/bigquery_execute.cpp
+++ b/src/bigquery_execute.cpp
@@ -152,7 +152,7 @@ static duckdb::unique_ptr<FunctionData> BigQueryExecuteBind(ClientContext &conte
         names.emplace_back("total_rows");
         return_types.emplace_back(LogicalTypeId::BIGINT);
         names.emplace_back("total_bytes_processed");
-        return_types.emplace_back(LogicalTypeId::VARCHAR);
+        return_types.emplace_back(LogicalTypeId::BIGINT);
         names.emplace_back("num_dml_affected_rows");
     } else {
         return_types.emplace_back(LogicalTypeId::BIGINT);
@@ -201,7 +201,7 @@ static void BigQueryExecuteFunc(ClientContext &context, TableFunctionInput &data
                                   : Value(LogicalType::BIGINT));
         output.SetValue(6, 0, query_stats.has_num_dml_affected_rows()
                                   ? Value::BIGINT(query_stats.num_dml_affected_rows().value())
-                                  : Value(LogicalType::VARCHAR));
+                                  : Value(LogicalType::BIGINT));
         output.SetCardinality(1);
         return;
     }

--- a/src/bigquery_execute.cpp
+++ b/src/bigquery_execute.cpp
@@ -4,6 +4,7 @@
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
 #include "bigquery_execute.hpp"
+#include "bigquery_utils.hpp"
 #include "storage/bigquery_catalog.hpp"
 #include "storage/bigquery_transaction.hpp"
 
@@ -19,7 +20,63 @@ struct BigQueryExecuteBindData : public TableFunctionData {
     bool dry_run = false;
     std::optional<int> timeout_ms;
     bool finished = false;
+    //! When set, the query result is materialised into `destination_table`
+    //! (jobs.insert + JobConfigurationQuery) instead of being run via jobs.query.
+    bool has_destination = false;
+    BigqueryTableRef destination_table;
+    string write_disposition = "WRITE_TRUNCATE";
+    string create_disposition = "CREATE_IF_NEEDED";
 };
+
+//! Parse a VARCHAR named parameter, returning the default when absent or NULL.
+static string GetStringParam(const named_parameter_map_t &named_parameters,
+                             const string &name,
+                             const string &default_value) {
+    auto entry = named_parameters.find(name);
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return default_value;
+    }
+    return entry->second.GetValue<string>();
+}
+
+static string ParseDispositionParam(const named_parameter_map_t &named_parameters,
+                                    const string &name,
+                                    const string &default_value,
+                                    const vector<string> &allowed_values) {
+    auto value = GetStringParam(named_parameters, name, default_value);
+    auto normalized = StringUtil::Upper(value);
+    for (const auto &allowed : allowed_values) {
+        if (normalized == allowed) {
+            return normalized;
+        }
+    }
+    throw BinderException("Invalid value for parameter '%s': %s", name, value);
+}
+
+//! Parse `project.dataset.table` or `dataset.table` (backticks tolerated) into a
+//! BigqueryTableRef. The project falls back to `default_project` when omitted.
+static BigqueryTableRef ParseDestinationTable(const string &table_string, const string &default_project) {
+    auto cleaned = StringUtil::Replace(table_string, "`", "");
+    auto parts = StringUtil::Split(cleaned, '.');
+    BigqueryTableRef ref;
+    if (parts.size() == 3) {
+        ref.project_id = parts[0];
+        ref.dataset_id = parts[1];
+        ref.table_id = parts[2];
+    } else if (parts.size() == 2) {
+        ref.project_id = default_project;
+        ref.dataset_id = parts[0];
+        ref.table_id = parts[1];
+    } else {
+        throw BinderException("Invalid destination_table '%s' — expected 'dataset.table' or "
+                              "'project.dataset.table'",
+                              table_string);
+    }
+    if (ref.dataset_id.empty() || ref.table_id.empty()) {
+        throw BinderException("Invalid destination_table '%s' — dataset and table must be non-empty", table_string);
+    }
+    return ref;
+}
 
 static duckdb::unique_ptr<FunctionData> BigQueryExecuteBind(ClientContext &context,
                                                             TableFunctionBindInput &input,
@@ -64,6 +121,24 @@ static duckdb::unique_ptr<FunctionData> BigQueryExecuteBind(ClientContext &conte
         result->bq_client = make_shared_ptr<BigqueryClient>(context, result->config);
     }
 
+    auto destination_entry = input.named_parameters.find("destination_table");
+    if (destination_entry != input.named_parameters.end() && !destination_entry->second.IsNull()) {
+        if (params.dry_run) {
+            throw BinderException("'destination_table' cannot be combined with 'dry_run'");
+        }
+        result->has_destination = true;
+        result->destination_table =
+            ParseDestinationTable(destination_entry->second.GetValue<string>(), result->config.project_id);
+        result->write_disposition = ParseDispositionParam(input.named_parameters,
+                                                          "write_disposition",
+                                                          "WRITE_TRUNCATE",
+                                                          {"WRITE_TRUNCATE", "WRITE_APPEND", "WRITE_EMPTY"});
+        result->create_disposition = ParseDispositionParam(input.named_parameters,
+                                                           "create_disposition",
+                                                           "CREATE_IF_NEEDED",
+                                                           {"CREATE_IF_NEEDED", "CREATE_NEVER"});
+    }
+
     if (!params.dry_run) {
         return_types.emplace_back(LogicalTypeId::BOOLEAN);
         names.emplace_back("success");
@@ -96,6 +171,31 @@ static void BigQueryExecuteFunc(ClientContext &context, TableFunctionInput &data
     if (data.finished) {
         return;
     }
+
+    if (data.has_destination) {
+        // jobs.insert + JobConfigurationQuery: materialise the query result into the
+        // destination table (jobs.query, used below, cannot write to a table).
+        auto job = data.bq_client->ExecuteQueryToTable(data.query,
+                                                       data.destination_table,
+                                                       data.write_disposition,
+                                                       data.create_disposition,
+                                                       "",
+                                                       {},
+                                                       data.timeout_ms);
+        data.finished = true;
+
+        const auto &job_ref = job.job_reference();
+        output.SetValue(0, 0, true);
+        output.SetValue(1, 0, Value(job_ref.job_id()));
+        output.SetValue(2, 0, Value(job_ref.project_id()));
+        output.SetValue(3, 0, job_ref.has_location() ? Value(job_ref.location().value()) : Value(LogicalType::VARCHAR));
+        output.SetValue(4, 0, Value::UBIGINT(0));
+        output.SetValue(5, 0, Value::BIGINT(0));
+        output.SetValue(6, 0, Value(LogicalType::VARCHAR));
+        output.SetCardinality(1);
+        return;
+    }
+
     auto response = data.bq_client->ExecuteQuery(data.query, "", data.dry_run, {}, false, data.timeout_ms);
     data.finished = true;
 
@@ -125,6 +225,9 @@ BigQueryExecuteFunction::BigQueryExecuteFunction()
     named_parameters["grpc_endpoint"] = LogicalType::VARCHAR;
     named_parameters["dry_run"] = LogicalType::BOOLEAN;
     named_parameters["timeout_ms"] = LogicalType::BIGINT;
+    named_parameters["destination_table"] = LogicalType::VARCHAR;
+    named_parameters["write_disposition"] = LogicalType::VARCHAR;
+    named_parameters["create_disposition"] = LogicalType::VARCHAR;
 }
 
 } // namespace bigquery

--- a/src/bigquery_execute.cpp
+++ b/src/bigquery_execute.cpp
@@ -185,13 +185,23 @@ static void BigQueryExecuteFunc(ClientContext &context, TableFunctionInput &data
         data.finished = true;
 
         const auto &job_ref = job.job_reference();
+        const auto &query_stats = job.statistics().query();
         output.SetValue(0, 0, true);
         output.SetValue(1, 0, Value(job_ref.job_id()));
         output.SetValue(2, 0, Value(job_ref.project_id()));
         output.SetValue(3, 0, job_ref.has_location() ? Value(job_ref.location().value()) : Value(LogicalType::VARCHAR));
-        output.SetValue(4, 0, Value::UBIGINT(0));
-        output.SetValue(5, 0, Value::BIGINT(0));
-        output.SetValue(6, 0, Value(LogicalType::VARCHAR));
+        // The query job statistics carry bytes processed and DML-affected rows, but not the
+        // result row count. Fetch total_rows via the job's query results, matching the source
+        // used by the inline jobs.query path. Anything BigQuery doesn't report stays NULL.
+        auto results = data.bq_client->GetQueryResults(job_ref);
+        output.SetValue(4, 0, results.has_total_rows() ? Value::UBIGINT(results.total_rows().value())
+                                                       : Value(LogicalType::UBIGINT));
+        output.SetValue(5, 0, query_stats.has_total_bytes_processed()
+                                  ? Value::BIGINT(query_stats.total_bytes_processed().value())
+                                  : Value(LogicalType::BIGINT));
+        output.SetValue(6, 0, query_stats.has_num_dml_affected_rows()
+                                  ? Value::BIGINT(query_stats.num_dml_affected_rows().value())
+                                  : Value(LogicalType::VARCHAR));
         output.SetCardinality(1);
         return;
     }

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -203,9 +203,11 @@ private:
         const string &location,
         const std::map<string, string> &labels);
     google::cloud::bigquery::v2::Job WaitForJobCompletion(const google::cloud::bigquery::v2::JobReference &job_ref,
-                                                          const std::optional<int> &timeout_ms = std::nullopt);
+                                                          const std::optional<int> &timeout_ms = std::nullopt,
+                                                          const string &job_kind = "Load job");
     google::cloud::bigquery::v2::Job GetLoadJobForCompletion(const google::cloud::bigquery::v2::JobReference &job_ref,
-                                                             const std::chrono::steady_clock::time_point &wait_until);
+                                                             const std::chrono::steady_clock::time_point &wait_until,
+                                                             const string &job_kind = "Load job");
     void ThrowOnJobStatusError(const google::cloud::bigquery::v2::JobStatus &status, const string &operation_name);
 
     void MapTableSchema(const google::cloud::bigquery::v2::TableSchema &schema,

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -114,6 +114,16 @@ public:
                                                             const bool &optional_job_creation = false,
                                                             const std::optional<int> &timeout_ms = std::nullopt);
     idx_t ExecuteDmlQuery(const string &query, BigqueryDmlStatementType statement_type, const string &location = "");
+    //! Run a query whose result is materialised into `destination_table` (jobs.insert +
+    //! JobConfigurationQuery, polled via WaitForJobCompletion). Unlike ExecuteQuery (jobs.query),
+    //! this can write the result of a SELECT into a table with a write/create disposition.
+    google::cloud::bigquery::v2::Job ExecuteQueryToTable(const string &query,
+                                                         const BigqueryTableRef &destination_table,
+                                                         const string &write_disposition = "WRITE_TRUNCATE",
+                                                         const string &create_disposition = "CREATE_IF_NEEDED",
+                                                         const string &location = "",
+                                                         const std::map<string, string> &labels = {},
+                                                         const std::optional<int> &timeout_ms = std::nullopt);
     google::cloud::bigquery::v2::GetQueryResultsResponse GetQueryResults(
         const google::cloud::bigquery::v2::JobReference &job_ref,
         const string &page_token = "");
@@ -165,6 +175,12 @@ private:
     void MergeQueryResultsResponse(google::cloud::bigquery::v2::QueryResponse &query_response,
                                    const google::cloud::bigquery::v2::GetQueryResultsResponse &results_response);
     void ThrowOnQueryJobStatusError(const google::cloud::bigquery::v2::JobStatus &status);
+    google::cloud::bigquery::v2::InsertJobRequest BuildQueryJobRequest(const string &query,
+                                                                       const BigqueryTableRef &destination_table,
+                                                                       const string &write_disposition,
+                                                                       const string &create_disposition,
+                                                                       const string &location,
+                                                                       const std::map<string, string> &labels);
     google::cloud::bigquery::v2::InsertJobRequest BuildLoadJobRequest(const BigqueryTableRef &destination_table,
                                                                       const string &write_disposition,
                                                                       const string &create_disposition,

--- a/test/sql/functions/function_bigquery_execute.test
+++ b/test/sql/functions/function_bigquery_execute.test
@@ -32,6 +32,59 @@ SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'exec_table';
 ----
 1
 
+# --- destination_table: materialise a SELECT result into a table ---
+
+# Write two rows into a fresh destination table. total_rows reflects the query
+# result and total_bytes_processed comes from the job statistics; a plain SELECT
+# is not DML, so num_dml_affected_rows stays NULL.
+query IIIIIII
+SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}',
+    'SELECT 1 AS id UNION ALL SELECT 2 AS id',
+    destination_table := '${BQ_TEST_DATASET}.exec_dest_table',
+    write_disposition := 'WRITE_TRUNCATE',
+    timeout_ms := 90000)
+----
+1	<REGEX>:job_.+	<REGEX>:.+	<REGEX>:.+	2	<REGEX>:\d+	NULL
+
+query I
+SELECT COUNT(*) FROM bq.${BQ_TEST_DATASET}.exec_dest_table;
+----
+2
+
+# WRITE_TRUNCATE replaces the contents in place rather than appending.
+statement ok
+SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}',
+    'SELECT 42 AS id',
+    destination_table := '${BQ_TEST_DATASET}.exec_dest_table',
+    write_disposition := 'WRITE_TRUNCATE',
+    timeout_ms := 90000)
+
+query I
+SELECT id FROM bq.${BQ_TEST_DATASET}.exec_dest_table;
+----
+42
+
+# An invalid disposition is rejected at bind time.
+statement error
+SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'SELECT 1 AS id',
+    destination_table := '${BQ_TEST_DATASET}.exec_dest_table',
+    write_disposition := 'NOPE',
+    timeout_ms := 90000)
+----
+Invalid value for parameter 'write_disposition'
+
+# destination_table cannot be combined with dry_run.
+statement error
+SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'SELECT 1 AS id',
+    destination_table := '${BQ_TEST_DATASET}.exec_dest_table',
+    dry_run := true,
+    timeout_ms := 90000)
+----
+'destination_table' cannot be combined with 'dry_run'
+
+statement ok
+SELECT * FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE IF EXISTS `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_dest_table`', timeout_ms := 90000)
+
 statement ok
 CALL bigquery_execute('bq', 'DROP TABLE ${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.exec_table;', timeout_ms := 90000)
 


### PR DESCRIPTION
## What

Adds optional `destination_table`, `write_disposition`, and `create_disposition` named parameters to `bigquery_execute`. When `destination_table` is set, the query result is materialised into that table.

```sql
SELECT * FROM bigquery_execute(
  'my-project',
  'SELECT id, ST_GEOGFROMTEXT(wkt) AS geom FROM staging',
  destination_table := 'dataset.table',
  write_disposition := 'WRITE_TRUNCATE'   -- default; also WRITE_APPEND / WRITE_EMPTY
);
```

## Why

`bigquery_execute` runs everything through the `jobs.query` REST endpoint, which **cannot write to a destination table** — there's no way to express "run this SELECT and land the result in `dataset.table`".

A concrete need: converting a staged WKT column into a native `GEOGRAPHY` with `SELECT ... ST_GEOGFROMTEXT(...)` that writes into the destination using `WRITE_TRUNCATE`. `WRITE_TRUNCATE` preserves the table's partitioning/clustering spec on re-runs, which `CREATE OR REPLACE TABLE AS SELECT` drops — and which `jobs.query` can't do regardless.

## How

When `destination_table` is present, the query is submitted as a **`jobs.insert`** job carrying a `JobConfigurationQuery` (destination table + write/create disposition), then polled to completion via `WaitForJobCompletion`. This mirrors the existing `bigquery_load` `JobConfigurationLoad` path almost exactly (`BuildQueryJobRequest` is the analogue of `BuildLoadJobRequest`), and reuses the `timeout_ms` plumbing from #195 (nullopt waits to completion).

- New `BigqueryClient::ExecuteQueryToTable(...)` + private `BuildQueryJobRequest(...)`.
- `bigquery_execute` parses the three new params; absent `destination_table`, behaviour is unchanged (still `jobs.query`).
- `destination_table` accepts `dataset.table` or `project.dataset.table` (backticks tolerated); project falls back to the connection's project.
- `destination_table` + `dry_run` is rejected.

Rebased onto `main` after #195 — that PR's query-job polling and per-call `timeout_ms` are complementary (they fixed inline-wait timeouts for `jobs.query`); this PR adds the orthogonal *destination-table* capability and plugs into the same `timeout_ms` parameter.

## Verified

Built locally (DuckDB v1.5.3, arm64-osx, ADC) and run end-to-end against BigQuery:
- `destination_table` write + `ST_GEOGFROMTEXT` GEOGRAPHY round-trip ✅
- idempotent `WRITE_TRUNCATE` re-run (table + its spec preserved) ✅
- heavy 2B-row aggregation materialised into a table, polled to completion (`2000000000` landed) ✅