### PR TITLE
Improve BigQuery read stream parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ D SELECT * FROM bigquery_scan('my_gcp_project.quacking_dataset.duck_tbl');
 
 > `bigquery_scan` is the single table-scan interface for BigQuery reads and uses the DuckDB-internals-based Arrow scan path.
 
+BigQuery scans may read multiple Storage API streams in parallel. Set `bq_max_read_streams=1` when you need ordered reads from a single Storage API stream. Queries that require a SQL-guaranteed result order should still use an explicit `ORDER BY`.
+
 The function supports filter pushdown by accepting [row restriction filter statements](https://cloud.google.com/bigquery/docs/reference/storage/rpc/google.cloud.bigquery.storage.v1#google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions) as an optional argument. These filters are passed directly to BigQuery and restrict which rows are transfered from the source table. For example:
 
 ```sql
@@ -594,7 +596,8 @@ D CREATE TABLE bq.my_dataset.partition_tbl (i BIGINT)
 | `bq_experimental_use_info_schema`         | [EXPERIMENTAL] - Use information schema to fetch catalog info (often faster than REST API)                                                                                                         | `true`  |
 | `bq_experimental_enable_sql_parser` | [EXPERIMENTAL] - Enable BigQuery CREATE TABLE clause parsing extensions (PARTITION BY / CLUSTER BY / OPTIONS)                                                                                       | `false` |
 | `bq_curl_ca_bundle_path`                  | Path to the CA certificates used by cURL for SSL certificate verification                                                                                                                          |         |
-| `bq_max_read_streams`                     | Maximum number of read streams requested for BigQuery Storage Read. Set to 0 to match the number of DuckDB threads. Requires `SET preserve_insertion_order=FALSE` for parallelization to work, and BigQuery may return fewer streams than requested. | `0`     |
+| `bq_max_read_streams`                     | Maximum number of read streams requested for BigQuery Storage Read. Set to `0` to request the default maximum of 4 streams. Set to `1` for ordered reads from a single Storage API stream. BigQuery may return fewer streams than requested. | `4`     |
+| `bq_preferred_min_read_streams`           | Preferred minimum number of read streams requested for BigQuery Storage Read. Set to `0` to derive this from DuckDB threads. Must be less than or equal to the effective maximum stream count when set explicitly. | `0`     |
 | `bq_enable_inflight_request_windowing`    | Whether to keep multiple BigQuery Storage Write `AppendRows` requests in flight before waiting for acknowledgements. Usually faster, but slightly less memory efficient. Set to `false` to fall back to synchronous write/read lockstep. | `true`  |
 | `bq_arrow_compression`                    | Compression codec for BigQuery Storage Read API. Options: `UNSPECIFIED`, `LZ4_FRAME`, `ZSTD`                                                                                                       | `ZSTD`  |
 

--- a/src/bigquery_arrow_reader.cpp
+++ b/src/bigquery_arrow_reader.cpp
@@ -211,12 +211,11 @@ void BigqueryStreamFactory::GetSchema(ArrowArrayStream *factory_ptr, ArrowSchema
 
 BigqueryArrowReader::BigqueryArrowReader(const BigqueryTableRef table_ref,
                                          const string billing_project_id,
-                                         idx_t num_streams,
+                                         BigqueryReadSessionStreamLimits stream_limits,
                                          const google::cloud::Options &options,
                                          const vector<string> &selected_columns,
                                          const string &filter_condition)
-    : table_ref(table_ref), billing_project_id(billing_project_id), num_streams(num_streams), options(options),
-      localhost_test_env(false) {
+    : table_ref(table_ref), billing_project_id(billing_project_id), options(options), localhost_test_env(false) {
     if (options.has<google::cloud::EndpointOption>()) {
         localhost_test_env = true;
     }
@@ -250,7 +249,13 @@ BigqueryArrowReader::BigqueryArrowReader(const BigqueryTableRef table_ref,
         read_options->set_row_restriction(filter_condition);
     }
 
-    auto new_session = read_client->CreateReadSession(parent, session, num_streams);
+    auto request = google::cloud::bigquery::storage::v1::CreateReadSessionRequest();
+    request.set_parent(parent);
+    *request.mutable_read_session() = std::move(session);
+    request.set_max_stream_count(NumericCast<int32_t>(stream_limits.max_stream_count));
+    request.set_preferred_min_stream_count(NumericCast<int32_t>(stream_limits.preferred_min_stream_count));
+
+    auto new_session = read_client->CreateReadSession(request);
     if (!new_session) {
         auto status = new_session.status();
         if (status.code() == google::cloud::StatusCode::kPermissionDenied) {

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -1161,7 +1161,7 @@ void BigqueryClient::GetTableInfoForQuery(const string &query,
 }
 
 shared_ptr<BigqueryArrowReader> BigqueryClient::CreateArrowReader(const BigqueryTableRef &table_ref,
-                                                                  const idx_t num_streams,
+                                                                  BigqueryReadSessionStreamLimits stream_limits,
                                                                   const vector<string> &column_ids,
                                                                   const string &filter_cond) {
     CheckAuthentication();
@@ -1182,7 +1182,7 @@ shared_ptr<BigqueryArrowReader> BigqueryClient::CreateArrowReader(const Bigquery
 
     return make_shared_ptr<BigqueryArrowReader>(table_ref,
                                                 config.BillingProject(),
-                                                num_streams,
+                                                stream_limits,
                                                 options,
                                                 column_ids,
                                                 filter_cond);

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -160,12 +160,17 @@ static void LoadInternal(ExtensionLoader &loader) {
                               Value(bigquery::BigquerySettings::CurlCaBundlePath()),
                               bigquery::BigquerySettings::SetCurlCaBundlePath);
     config.AddExtensionOption("bq_max_read_streams",
-                              "Maximum number of read streams requested for BigQuery Storage Read. Set to 0 to match "
-                              "the number of DuckDB threads. `preserve_insertion_order` must be false for "
-                              "parallelization to work, and BigQuery may return fewer streams than requested.",
+                              "Maximum number of read streams requested for BigQuery Storage Read. Set to 0 to request "
+                              "the default maximum of 4 streams. BigQuery may return fewer streams than requested.",
                               LogicalType::BIGINT,
                               Value(bigquery::BigquerySettings::MaxReadStreams()),
                               bigquery::BigquerySettings::SetMaxReadStreams);
+    config.AddExtensionOption("bq_preferred_min_read_streams",
+                              "Preferred minimum number of read streams requested for BigQuery Storage Read. Set to 0 "
+                              "to derive this from DuckDB threads.",
+                              LogicalType::BIGINT,
+                              Value(bigquery::BigquerySettings::PreferredMinReadStreams()),
+                              bigquery::BigquerySettings::SetPreferredMinReadStreams);
     config.AddExtensionOption("bq_enable_inflight_request_windowing",
                               "Whether to allow multiple BigQuery Storage Write AppendRows requests to remain in "
                               "flight before waiting for acknowledgements. Usually faster, but slightly less memory "

--- a/src/bigquery_query.cpp
+++ b/src/bigquery_query.cpp
@@ -471,6 +471,7 @@ BigqueryQueryFunction::BigqueryQueryFunction()
     projection_pushdown = true;
     filter_pushdown = true;
     filter_prune = true;
+    order_preservation_type = OrderPreservationType::NO_ORDER;
 
     named_parameters["billing_project"] = LogicalType::VARCHAR;
     named_parameters["api_endpoint"] = LogicalType::VARCHAR;

--- a/src/bigquery_scan.cpp
+++ b/src/bigquery_scan.cpp
@@ -108,9 +108,9 @@ unique_ptr<GlobalTableFunctionState> BigqueryScanFunction::BigqueryScanInitGloba
         });
     }
 
-    idx_t max_read_streams = BigquerySettings::GetMaxReadStreams(context);
+    const auto stream_limits = BigquerySettings::GetReadSessionStreamLimits(context);
     auto bq_arrow_reader =
-        bind_data.bq_client->CreateArrowReader(bind_data.table_ref, max_read_streams, selected_fields, filter_string);
+        bind_data.bq_client->CreateArrowReader(bind_data.table_ref, stream_limits, selected_fields, filter_string);
 
     auto factory = make_shared_ptr<BigqueryStreamFactory>(bq_arrow_reader);
     auto factory_dependency = bind_data.GetFactoryDependency();
@@ -121,9 +121,9 @@ unique_ptr<GlobalTableFunctionState> BigqueryScanFunction::BigqueryScanInitGloba
     bind_data.stream_factory_ptr = reinterpret_cast<uintptr_t>(factory.get());
 
     auto gstate = make_uniq<BigqueryScanGlobalState>();
-    const idx_t requested_read_streams = MaxValue<idx_t>(1, max_read_streams);
+    const idx_t duckdb_threads = MaxValue<idx_t>(1, context.db->NumberOfThreads());
     const idx_t actual_read_streams = MaxValue<idx_t>(1, bq_arrow_reader->GetStreamCount());
-    gstate->max_threads = MinValue<idx_t>(requested_read_streams, actual_read_streams);
+    gstate->max_threads = MinValue<idx_t>(duckdb_threads, actual_read_streams);
     bind_data.estimated_row_count = bq_arrow_reader->GetEstimatedRowCount();
 
     auto arrow_schema = bq_arrow_reader->GetSchema();
@@ -457,6 +457,7 @@ BigqueryScanFunction::BigqueryScanFunction()
     projection_pushdown = true;
     filter_pushdown = true;
     filter_prune = true;
+    order_preservation_type = OrderPreservationType::NO_ORDER;
 
     to_string = BigqueryScanToString;
     cardinality = BigqueryScanCardinality;

--- a/src/include/bigquery_arrow_reader.hpp
+++ b/src/include/bigquery_arrow_reader.hpp
@@ -13,6 +13,7 @@
 #include "google/cloud/bigquery/storage/v1/bigquery_read_connection.h"
 #include "google/cloud/stream_range.h"
 
+#include "bigquery_read_session.hpp"
 #include "bigquery_utils.hpp"
 
 namespace duckdb {
@@ -41,7 +42,7 @@ struct BigqueryArrowReader {
 public:
     BigqueryArrowReader(const BigqueryTableRef table_ref,
                         const string billing_project_id,
-                        idx_t num_streams,
+                        BigqueryReadSessionStreamLimits stream_limits,
                         const google::cloud::Options &options,
                         const vector<string> &column_ids = std::vector<string>(),
                         const string &filter_cond = "");
@@ -61,7 +62,6 @@ private:
     BigqueryTableRef table_ref;
     string billing_project_id;
 
-    idx_t num_streams;
     google::cloud::Options options;
 
     std::shared_ptr<google::cloud::bigquery_storage_v1::BigQueryReadConnection> read_connection;

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -129,7 +129,7 @@ public:
         const string &page_token = "");
 
     shared_ptr<BigqueryArrowReader> CreateArrowReader(const BigqueryTableRef &table_ref,
-                                                      const idx_t num_streams,
+                                                      BigqueryReadSessionStreamLimits stream_limits,
                                                       const vector<string> &column_ids = std::vector<string>(),
                                                       const string &filter_cond = "");
 

--- a/src/include/bigquery_read_session.hpp
+++ b/src/include/bigquery_read_session.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+namespace duckdb {
+namespace bigquery {
+
+struct BigqueryReadSessionStreamLimits {
+    idx_t max_stream_count;
+    idx_t preferred_min_stream_count;
+};
+
+} // namespace bigquery
+} // namespace duckdb

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -4,6 +4,8 @@
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/main/settings.hpp"
 
+#include "bigquery_read_session.hpp"
+
 #include "google/cloud/bigquery/storage/v1/arrow.pb.h"
 
 #include <chrono>
@@ -185,7 +187,7 @@ public:
     }
 
     static int &MaxReadStreams() {
-        static int BIGQUERY_MAX_READ_STREAMS = 0; // 0 means default DuckDB thread count
+        static int BIGQUERY_MAX_READ_STREAMS = 4;
         return BIGQUERY_MAX_READ_STREAMS;
     }
 
@@ -193,29 +195,50 @@ public:
         int max_streams = GetIntSettingValue("Max read streams", parameter);
         if (max_streams < 0) {
             throw InvalidInputException("Max read streams must be non-negative (0 or greater). Use 0 to automatically "
-                                        "match the number of DuckDB threads.");
-        }
-        const bool preserve_insertion_order = Settings::Get<PreserveInsertionOrderSetting>(context);
-        if (preserve_insertion_order && max_streams > 1) {
-            std::cout << "Warning: preserve_insertion_order is set to true, but max_read_streams is set to "
-                      << max_streams << ". This will effectively limit execution to a single stream." << std::endl;
+                                        "request the default stream count.");
         }
         MaxReadStreams() = max_streams;
     }
 
-    static int GetMaxReadStreams(ClientContext &context) {
-        const bool preserve_insertion_order = Settings::Get<PreserveInsertionOrderSetting>(context);
-        if (preserve_insertion_order) {
-            // when preserve_insertion_order is true, we can only use 1 stream
-            return 1;
+    static int &PreferredMinReadStreams() {
+        static int BIGQUERY_PREFERRED_MIN_READ_STREAMS = 0; // 0 means auto
+        return BIGQUERY_PREFERRED_MIN_READ_STREAMS;
+    }
+
+    static void SetPreferredMinReadStreams(ClientContext &context, SetScope scope, Value &parameter) {
+        int min_streams = GetIntSettingValue("Preferred min read streams", parameter);
+        if (min_streams < 0) {
+            throw InvalidInputException("Preferred min read streams must be non-negative (0 or greater). Use 0 to "
+                                        "automatically derive the preferred minimum from DuckDB threads.");
         }
+        PreferredMinReadStreams() = min_streams;
+    }
+
+    static BigqueryReadSessionStreamLimits GetReadSessionStreamLimits(ClientContext &context) {
+        static constexpr idx_t BIGQUERY_AUTO_MAX_READ_STREAMS = 4;
+
+        const idx_t duckdb_threads = MaxValue<idx_t>(1, context.db->NumberOfThreads());
         const int max_read_streams = MaxReadStreams();
-        if (max_read_streams == 0) {
-            // if max_read_streams is 0, we use the maximum threads from the DuckDB config
-            const auto &config = DBConfig::GetConfig(context);
-            return static_cast<int>(config.options.maximum_threads);
+        const idx_t max_stream_count =
+            max_read_streams == 0 ? BIGQUERY_AUTO_MAX_READ_STREAMS : static_cast<idx_t>(max_read_streams);
+
+        const int preferred_min_read_streams = PreferredMinReadStreams();
+        idx_t preferred_min_stream_count;
+        if (preferred_min_read_streams == 0) {
+            const idx_t duckdb_thread_target =
+                duckdb_threads >= max_stream_count / 3 ? max_stream_count : 3 * duckdb_threads;
+            preferred_min_stream_count = MinValue<idx_t>(max_stream_count, MaxValue<idx_t>(1, duckdb_thread_target));
+        } else {
+            preferred_min_stream_count = static_cast<idx_t>(preferred_min_read_streams);
+            if (preferred_min_stream_count > max_stream_count) {
+                throw InvalidInputException(
+                    "Preferred min read streams (%llu) must be less than or equal to max read streams (%llu).",
+                    static_cast<unsigned long long>(preferred_min_stream_count),
+                    static_cast<unsigned long long>(max_stream_count));
+            }
         }
-        return max_read_streams;
+
+        return BigqueryReadSessionStreamLimits{max_stream_count, preferred_min_stream_count};
     }
 
     static bool &EnableInflightRequestWindowing() {

--- a/test/sql/functions/function_bigquery_scan_stream_settings.test
+++ b/test/sql/functions/function_bigquery_scan_stream_settings.test
@@ -1,0 +1,61 @@
+# name: test/sql/functions/function_bigquery_scan_stream_settings.test
+# description: Validate BigQuery Storage Read stream settings
+# group: [functions]
+
+require bigquery
+
+require-env BQ_TEST_PROJECT
+
+require-env BQ_TEST_DATASET
+
+query I
+SELECT current_setting('bq_max_read_streams');
+----
+4
+
+query I
+SELECT current_setting('bq_preferred_min_read_streams');
+----
+0
+
+statement error
+SET bq_preferred_min_read_streams = -1;
+----
+Invalid Input Error: Preferred min read streams must be non-negative (0 or greater). Use 0 to automatically derive the preferred minimum from DuckDB threads.
+
+statement error
+SET bq_preferred_min_read_streams = 2147483648;
+----
+Invalid Input Error: Preferred min read streams must fit in a 32-bit integer
+
+statement ok
+SET preserve_insertion_order = true;
+
+statement ok
+SET bq_max_read_streams = 8;
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', '
+    CREATE OR REPLACE TABLE `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.function_scan_stream_settings_test` AS
+    SELECT 1 AS a
+');
+
+statement ok
+SET bq_max_read_streams = 2;
+
+statement ok
+SET bq_preferred_min_read_streams = 3;
+
+statement error
+SELECT COUNT(*) FROM bigquery_scan('${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.function_scan_stream_settings_test');
+----
+Invalid Input Error: Preferred min read streams (3) must be less than or equal to max read streams (2).
+
+statement ok
+SET bq_preferred_min_read_streams = 0;
+
+statement ok
+SET bq_max_read_streams = 0;
+
+statement ok
+FROM bigquery_execute('${BQ_TEST_PROJECT}', 'DROP TABLE `${BQ_TEST_DATASET}.function_scan_stream_settings_test`');

--- a/test/sql/storage/attach_types_varchar.test
+++ b/test/sql/storage/attach_types_varchar.test
@@ -40,7 +40,7 @@ statement ok
 INSERT INTO bq.${BQ_TEST_DATASET}.table_varchars VALUES ('some BIG...query string');
 
 query I
-SELECT * FROM bq.${BQ_TEST_DATASET}.table_varchars;
+SELECT * FROM bq.${BQ_TEST_DATASET}.table_varchars ORDER BY v;
 ----
 (empty)
 some BIG...query string


### PR DESCRIPTION
The change makes BigQuery Storage Reads unordered by default, allowing DuckDB to use multiple BigQuery read streams in parallel for faster large reads. `preserve_insertion_order` no longer forces the read path down to a single stream; users who need ordered reads can set `bq_max_read_streams=1` for ordered singel stream reads. The new default for `bq_max_read_streams` is 4.

It also adds `bq_preferred_min_read_streams` and switches read session creation to an explicit `CreateReadSessionRequest`. Local DuckDB execution remains capped at `min(duckdb_threads, actual_stream_count)`, while the existing stream queue still lets each local state consume multiple BigQuery streams.