### PR TITLE
Use attached BigQuery dataset as the default schema

### DIFF
--- a/src/include/storage/bigquery_catalog.hpp
+++ b/src/include/storage/bigquery_catalog.hpp
@@ -65,6 +65,7 @@ public:
 
     bool InMemory() override;
     string GetDBPath() override;
+    string GetDefaultSchema() const override;
 
     const string GetProjectID() {
         return config.project_id;

--- a/src/storage/bigquery_catalog.cpp
+++ b/src/storage/bigquery_catalog.cpp
@@ -145,6 +145,13 @@ string BigqueryCatalog::GetDBPath() {
     return config.project_id;
 };
 
+string BigqueryCatalog::GetDefaultSchema() const {
+    if (config.HasDatasetId()) {
+        return config.dataset_id;
+    }
+    return Catalog::GetDefaultSchema();
+}
+
 void BigqueryCatalog::ClearCache() {
     schemas.ClearEntries();
     {

--- a/test/sql/storage/attach_use_logic.test
+++ b/test/sql/storage/attach_use_logic.test
@@ -14,13 +14,15 @@ ATTACH 'project=${BQ_TEST_PROJECT} dataset=${BQ_TEST_DATASET}' AS bq (TYPE bigqu
 statement ok
 USE bq;
 
+query I
+SELECT current_schema() = '${BQ_TEST_DATASET}';
+----
+true
+
 statement error
 SET schema='some_schema'
 ----
 Catalog Error: SET schema: No catalog + schema named "some_schema" found.
-
-statement ok
-SET schema='${BQ_TEST_DATASET}'
 
 statement ok
 DROP TABLE IF EXISTS use_logic_table;


### PR DESCRIPTION
This updates the BigQuery catalog to return the attached dataset as its default schema when `ATTACH` includes `dataset=...`, while preserving DuckDB’s default schema behavior for project-wide attaches. As a result, `USE bq` now sets the current schema to the attached dataset and unqualified table operations resolve consistently there.

The attach use-logic test now verifies the current schema after `USE bq` and removes the previously required explicit `SET schema` step before unqualified DDL.