### PR TITLE
Add additional bigquery_load format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,12 +280,12 @@ While `bigquery_scan` offers high-speed data retrieval, it does not support read
 
 The `bigquery_scan` function supports the following named parameters:
 
-| Parameter         | Type      | Description                                                                      |
-| ----------------- | --------- | -------------------------------------------------------------------------------- |
-| `filter`          | `VARCHAR` | Row restriction filter statements passed directly to BigQuery Storage Read API.  |
-| `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).             |
-| `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                                |
-| `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                       |
+| Parameter         | Type      | Description                                                                     |
+| ----------------- | --------- | ------------------------------------------------------------------------------- |
+| `filter`          | `VARCHAR` | Row restriction filter statements passed directly to BigQuery Storage Read API. |
+| `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).            |
+| `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                               |
+| `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                      |
 
 ### `bigquery_query` Function
 
@@ -333,14 +333,14 @@ D SELECT * FROM bigquery_query('my_gcp_project', 'SELECT * FROM `my_gcp_project.
 
 The `bigquery_query` function supports the following named parameters:
 
-| Parameter         | Type      | Description                                                                                                        |
-| ----------------- | --------- | ------------------------------------------------------------------------------------------------------------------ |
+| Parameter         | Type      | Description                                                                                                                                                                                                                                                                            |
+| ----------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `use_rest_api`    | `BOOLEAN` | When `true`, uses the BigQuery REST API with optional job creation instead of the Storage API. This provides lower latency for small result sets (under ~10MB) by returning results inline, avoiding the overhead of creating a job and reading via the Storage API. Default: `false`. |
-| `dry_run`         | `BOOLEAN` | When `true`, validates the query without executing it. Returns metadata: `total_bytes_processed`, `cache_hit`, and `location`. |
-| `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).                                               |
-| `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
-| `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
-| `timeout_ms`      | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms`; `0` waits indefinitely. |
+| `dry_run`         | `BOOLEAN` | When `true`, validates the query without executing it. Returns metadata: `total_bytes_processed`, `cache_hit`, and `location`.                                                                                                                                                         |
+| `billing_project` | `VARCHAR` | Project ID to bill for query execution (useful for public datasets).                                                                                                                                                                                                                   |
+| `api_endpoint`    | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                                                                                                                                                                                      |
+| `grpc_endpoint`   | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                                                                                                                                                                                             |
+| `timeout_ms`      | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms`; `0` waits indefinitely.                                                                                                                                                              |
 
 > **REST API vs Storage API**: By default, `bigquery_query` uses the [BigQuery Storage Read API](https://cloud.google.com/bigquery/docs/reference/storage) to fetch results. This executes the query as a job, materializes results into a temporary table, and reads them via gRPC — optimized for large result sets but adds overhead for small queries.
 >
@@ -388,15 +388,15 @@ D CALL bigquery_execute('my_gcp_project', 'SELECT * FROM `my_gcp_project.quackin
 
 The `bigquery_execute` function supports the following named parameters:
 
-| Parameter       | Type      | Description                                                                                                        |
-| --------------- | --------- | ------------------------------------------------------------------------------------------------------------------ |
-| `dry_run`       | `BOOLEAN` | When `true`, validates the query without executing it. Returns metadata: `total_bytes_processed`, `cache_hit`, and `location`. |
-| `api_endpoint`  | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                  |
-| `grpc_endpoint` | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                         |
-| `timeout_ms`    | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms`; `0` waits indefinitely. |
-| `destination_table` | `VARCHAR` | Materialise the query result into this table (`dataset.table` or `project.dataset.table`). Runs the query as a `jobs.insert` job writing to the table — something the default `jobs.query` path cannot do. Cannot be combined with `dry_run`. |
-| `write_disposition` | `VARCHAR` | How to write into an existing `destination_table`: `WRITE_TRUNCATE` (default), `WRITE_APPEND`, or `WRITE_EMPTY`. Ignored without `destination_table`. |
-| `create_disposition` | `VARCHAR` | Whether to create `destination_table` if it does not exist: `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`. Ignored without `destination_table`. |
+| Parameter            | Type      | Description                                                                                                                                                                                                                                   |
+| -------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dry_run`            | `BOOLEAN` | When `true`, validates the query without executing it. Returns metadata: `total_bytes_processed`, `cache_hit`, and `location`.                                                                                                                |
+| `api_endpoint`       | `VARCHAR` | Custom BigQuery API endpoint URL.                                                                                                                                                                                                             |
+| `grpc_endpoint`      | `VARCHAR` | Custom BigQuery Storage gRPC endpoint URL.                                                                                                                                                                                                    |
+| `timeout_ms`         | `BIGINT`  | Maximum wait time for this query to complete, including polling. Overrides `bq_query_timeout_ms`; `0` waits indefinitely.                                                                                                                     |
+| `destination_table`  | `VARCHAR` | Materialise the query result into this table (`dataset.table` or `project.dataset.table`). Runs the query as a `jobs.insert` job writing to the table — something the default `jobs.query` path cannot do. Cannot be combined with `dry_run`. |
+| `write_disposition`  | `VARCHAR` | How to write into an existing `destination_table`: `WRITE_TRUNCATE` (default), `WRITE_APPEND`, or `WRITE_EMPTY`. Ignored without `destination_table`.                                                                                         |
+| `create_disposition` | `VARCHAR` | Whether to create `destination_table` if it does not exist: `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`. Ignored without `destination_table`.                                                                                              |
 
 When `destination_table` is set, the query runs as a query job that writes its result into the table, and the returned `total_rows` / `total_bytes_processed` reflect that job (`num_dml_affected_rows` is `NULL` for non-DML queries):
 
@@ -409,13 +409,16 @@ D CALL bigquery_execute('my_gcp_project',
 
 ### `bigquery_load` Function
 
-The `bigquery_load` function submits a BigQuery load job that writes data into a destination BigQuery table. The source can be a local Parquet file (`source_file`), one or more Cloud Storage Parquet URIs (`source_uris`), or a DuckDB table/view (`source_table`).
+The `bigquery_load` function submits a BigQuery load job that writes data into a destination BigQuery table. The source can be a local file (`source_file`), one or more Cloud Storage URIs (`source_uris`), or a DuckDB table/view (`source_table`). File and URI loads support `PARQUET`, `CSV`, `NEWLINE_DELIMITED_JSON`, `AVRO`, and `ORC`; `source_table` is always staged through a temporary Parquet file.
 
 ```sql
 D SELECT * FROM bigquery_load(
     'my_gcp_project',
     'my_dataset.target_table',
-    source_file := '/path/to/data.parquet',
+    source_file := '/path/to/data.csv',
+    source_format := 'CSV',
+    autodetect := true,
+    csv_skip_leading_rows := 1,
     location := 'EU'
 );
 ┌─────────┬──────────────────────────────┬────────────────┬──────────┬──────────────────────────────────────────────┬─────────────┬──────────────────┐
@@ -443,6 +446,7 @@ D CALL bigquery_load(
     'my_storage_project',
     'my_dataset.target_table',
     source_uris := ['gs://my_bucket/path/part-1.parquet', 'gs://my_bucket/path/part-2.parquet'],
+    source_format := 'PARQUET',
     write_disposition := 'WRITE_APPEND',
     location := 'EU',
     labels := MAP {'pipeline': 'daily_load', 'env': 'prod'},
@@ -455,23 +459,40 @@ Use `source_uris` to load one or more Cloud Storage objects directly. To attach 
 Compared to `CREATE TABLE ... AS` or `INSERT INTO ...`, `bigquery_load` uses a different write path:
 
 - `CREATE TABLE ... AS` and `INSERT INTO bq...` use the BigQuery Storage Write API and stream rows with `AppendRows`.
-- `bigquery_load` uses a BigQuery load job. With a local `source_file` it uploads a Parquet file directly; with `source_uris` it passes Cloud Storage URIs directly to BigQuery; with `source_table` it first stages the DuckDB relation as a temporary Parquet file and then submits the load job.
+- `bigquery_load` uses a BigQuery load job. With a local `source_file` it uploads the file directly; with `source_uris` it passes Cloud Storage URIs directly to BigQuery; with `source_table` it first stages the DuckDB relation as a temporary Parquet file and then submits the load job.
 
-Use `CREATE TABLE ... AS` when you want the normal streaming write path from a DuckDB query result. Use `bigquery_load` when you already have Parquet files or when you explicitly want load-job semantics such as `write_disposition` and `create_disposition`.
+Use `CREATE TABLE ... AS` when you want the normal streaming write path from a DuckDB query result. Use `bigquery_load` when you already have load-job inputs or when you explicitly want load-job semantics such as `write_disposition`, `create_disposition`, schema update options, source-format parsing options, or Hive partitioning.
 
 The `bigquery_load` function supports the following named parameters:
 
-| Parameter            | Type      | Description                                                                            |
-| -------------------- | --------- | -------------------------------------------------------------------------------------- |
-| `source_file`        | `VARCHAR` | Path to a local Parquet file to upload, or a single `gs://` Parquet URI to load directly from Cloud Storage. |
-| `source_uris`        | `VARCHAR` or `LIST<VARCHAR>` | One or more `gs://` Parquet URIs to load directly from Cloud Storage. Each URI can contain one `*` wildcard after the bucket name. |
-| `source_table`       | `VARCHAR` | Name of a DuckDB table or view to load.                                                |
-| `write_disposition`  | `VARCHAR` | BigQuery write behavior: `WRITE_TRUNCATE` (default), `WRITE_APPEND`, or `WRITE_EMPTY`. |
-| `create_disposition` | `VARCHAR` | BigQuery create behavior: `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`.              |
-| `location`           | `VARCHAR` | BigQuery job location.                                                                 |
-| `billing_project`    | `VARCHAR` | Project ID to bill for the load job. Only supported for direct project-ID calls.       |
-| `labels`             | `MAP(VARCHAR, VARCHAR)` | BigQuery job labels to attach to the load job.                                         |
-| `timeout_ms`         | `BIGINT`  | Optional maximum time to wait for the submitted load job to finish. `0` waits indefinitely; timed-out jobs may continue running in BigQuery. |
+| Parameter               | Type                         | Description                                                                                                                                                   |
+| ----------------------- | ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source_file`           | `VARCHAR`                    | Local file path to upload, or a single `gs://` URI. Legacy alias: `file`.                                                                                     |
+| `source_uris`           | `VARCHAR` or `LIST<VARCHAR>` | One or more `gs://` URIs to load directly from Cloud Storage.                                                                                                 |
+| `source_table`          | `VARCHAR`                    | DuckDB table or view to stage as Parquet. Legacy alias: `table`.                                                                                              |
+| `source_format`         | `VARCHAR`                    | `PARQUET`, `CSV`, `NEWLINE_DELIMITED_JSON`, `AVRO`, or `ORC`. If omitted for files/URIs, inferred from common extensions and otherwise defaults to `PARQUET`. |
+| `autodetect`            | `BOOLEAN`                    | Forwarded to BigQuery schema autodetection.                                                                                                                   |
+| `schema_update_options` | `VARCHAR` or `LIST<VARCHAR>` | `ALLOW_FIELD_ADDITION` and/or `ALLOW_FIELD_RELAXATION`.                                                                                                       |
+| `max_bad_records`       | `BIGINT`                     | Maximum number of bad records accepted by BigQuery.                                                                                                           |
+| `ignore_unknown_values` | `BOOLEAN`                    | Whether to ignore values not represented in the table schema.                                                                                                 |
+| `write_disposition`     | `VARCHAR`                    | `WRITE_TRUNCATE` (default), `WRITE_APPEND`, or `WRITE_EMPTY`.                                                                                                 |
+| `create_disposition`    | `VARCHAR`                    | `CREATE_IF_NEEDED` (default) or `CREATE_NEVER`.                                                                                                               |
+| `location`              | `VARCHAR`                    | BigQuery job location.                                                                                                                                        |
+| `billing_project`       | `VARCHAR`                    | Project ID to bill for the load job. Only supported for direct project-ID calls.                                                                              |
+| `labels`                | `MAP(VARCHAR, VARCHAR)`      | BigQuery job labels to attach to the load job.                                                                                                                |
+| `timeout_ms`            | `BIGINT`                     | Optional maximum time to wait for the submitted load job to finish. `0` waits indefinitely; timed-out jobs may continue running in BigQuery.                  |
+
+Format-specific load options are validated before the job is submitted:
+
+| Parameter Group               | Parameters                                                                                                                                                                                                        |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| CSV only                      | `csv_field_delimiter`, `csv_skip_leading_rows`, `csv_quote`, `csv_allow_quoted_newlines`, `csv_allow_jagged_rows`, `csv_encoding`, `csv_null_marker`, `csv_null_markers`, `csv_preserve_ascii_control_characters` |
+| CSV and JSON temporal parsing | `date_format`, `datetime_format`, `time_format`, `timestamp_format`, `time_zone`                                                                                                                                  |
+| JSON only                     | `json_extension`                                                                                                                                                                                                  |
+| Avro only                     | `avro_use_logical_types`                                                                                                                                                                                          |
+| Parquet only                  | `parquet_enable_list_inference`, `parquet_enum_as_string`                                                                                                                                                         |
+| Avro, Parquet, and ORC        | `reference_file_schema_uri`, `decimal_target_types`                                                                                                                                                               |
+| Cloud Storage URI loads only  | `hive_partitioning_mode`, `hive_partitioning_source_uri_prefix`                                                                                                                                                   |
 
 Exactly one of `source_file`, `source_uris`, or `source_table` must be provided. Without `timeout_ms`, or with `timeout_ms := 0`, `bigquery_load` waits for the load job to complete. For Cloud Storage loads, the BigQuery job identity needs permission to read the objects, and the bucket location must be compatible with the destination dataset location.
 
@@ -498,20 +519,20 @@ Use `destination_uris` for a single Cloud Storage URI or a `LIST<VARCHAR>`. Dest
 
 The `bigquery_extract` function supports the following named parameters:
 
-| Parameter                 | Type      | Description                                                                 |
-| ------------------------- | --------- | --------------------------------------------------------------------------- |
-| `source_table`            | `VARCHAR` | BigQuery table to export. Accepts `dataset.table`, `project.dataset.table`, `project:dataset.table`, or `projects/.../datasets/.../tables/...`. |
-| `destination_uris`        | `VARCHAR` or `LIST<VARCHAR>` | One or more `gs://` destination URIs.                         |
-| `format`                  | `VARCHAR` | Optional export format: `CSV`, `JSON`, `AVRO`, or `PARQUET`. `JSON` maps to BigQuery's newline-delimited JSON extract format. |
-| `compression`             | `VARCHAR` | Optional BigQuery export compression. Supported values depend on `format`: CSV/JSON support `NONE` and `GZIP`; AVRO supports `NONE`, `DEFLATE`, and `SNAPPY`; PARQUET supports `NONE`, `GZIP`, `SNAPPY`, and `ZSTD`. |
-| `csv_print_header`        | `BOOLEAN` | CSV only: whether to include a header row.                                  |
-| `csv_field_delimiter`     | `VARCHAR` | CSV only: field delimiter.                                                  |
-| `avro_use_logical_types`  | `BOOLEAN` | AVRO only: whether to use Avro logical types.                               |
-| `location`                | `VARCHAR` | BigQuery job location.                                                      |
-| `billing_project`         | `VARCHAR` | Project ID to bill for the extract job. Only supported for direct project-ID calls. |
-| `api_endpoint`            | `VARCHAR` | Custom BigQuery API endpoint URL. Only supported for direct project-ID calls. |
-| `labels`                  | `MAP(VARCHAR, VARCHAR)` | BigQuery job labels to attach to the extract job.                          |
-| `timeout_ms`              | `BIGINT`  | Optional maximum time to wait for the extract job to finish. `0` waits indefinitely; timed-out jobs may continue running in BigQuery. |
+| Parameter                | Type                         | Description                                                                                                                                                                                                          |
+| ------------------------ | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `source_table`           | `VARCHAR`                    | BigQuery table to export. Accepts `dataset.table`, `project.dataset.table`, `project:dataset.table`, or `projects/.../datasets/.../tables/...`.                                                                      |
+| `destination_uris`       | `VARCHAR` or `LIST<VARCHAR>` | One or more `gs://` destination URIs.                                                                                                                                                                                |
+| `format`                 | `VARCHAR`                    | Optional export format: `CSV`, `JSON`, `AVRO`, or `PARQUET`. `JSON` maps to BigQuery's newline-delimited JSON extract format.                                                                                        |
+| `compression`            | `VARCHAR`                    | Optional BigQuery export compression. Supported values depend on `format`: CSV/JSON support `NONE` and `GZIP`; AVRO supports `NONE`, `DEFLATE`, and `SNAPPY`; PARQUET supports `NONE`, `GZIP`, `SNAPPY`, and `ZSTD`. |
+| `csv_print_header`       | `BOOLEAN`                    | CSV only: whether to include a header row.                                                                                                                                                                           |
+| `csv_field_delimiter`    | `VARCHAR`                    | CSV only: field delimiter.                                                                                                                                                                                           |
+| `avro_use_logical_types` | `BOOLEAN`                    | AVRO only: whether to use Avro logical types.                                                                                                                                                                        |
+| `location`               | `VARCHAR`                    | BigQuery job location.                                                                                                                                                                                               |
+| `billing_project`        | `VARCHAR`                    | Project ID to bill for the extract job. Only supported for direct project-ID calls.                                                                                                                                  |
+| `api_endpoint`           | `VARCHAR`                    | Custom BigQuery API endpoint URL. Only supported for direct project-ID calls.                                                                                                                                        |
+| `labels`                 | `MAP(VARCHAR, VARCHAR)`      | BigQuery job labels to attach to the extract job.                                                                                                                                                                    |
+| `timeout_ms`             | `BIGINT`                     | Optional maximum time to wait for the extract job to finish. `0` waits indefinitely; timed-out jobs may continue running in BigQuery.                                                                                |
 
 `destination_uris` must be provided. This extract-job based function writes to Cloud Storage through BigQuery's extract-job API; use an empty or unique destination path for each extract.
 
@@ -625,19 +646,19 @@ D CREATE TABLE bq.my_dataset.partition_tbl (i BIGINT)
 
 ### Additional Extension Settings
 
-| Setting                                   | Description                                                                                                                                                                                        | Default |
-| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `bq_bignumeric_as_varchar`                | Compatibility setting kept for older workflows. `BIGNUMERIC` columns are exposed as `VARCHAR` by default in current versions.                                                                        | `true`  |
-| `bq_query_timeout_ms`                     | Maximum time to wait for a BigQuery query to complete, including polling. `0` waits indefinitely; a timed-out query job may continue running in BigQuery.                                         | `0`     |
-| `bq_auth_timeout_s`                       | Timeout for authentication token fetches in seconds. This bounds ADC metadata and OAuth token requests without changing normal BigQuery query timeouts.                                             | `10`    |
-| `bq_debug_show_queries`                   | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                                                                                                                  | `false` |
-| `bq_experimental_filter_pushdown`         | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                                                                                                             | `true`  |
-| `bq_experimental_use_info_schema`         | [EXPERIMENTAL] - Use information schema to fetch catalog info (often faster than REST API)                                                                                                         | `true`  |
-| `bq_experimental_enable_sql_parser` | [EXPERIMENTAL] - Enable BigQuery CREATE TABLE clause parsing extensions (PARTITION BY / CLUSTER BY / OPTIONS)                                                                                       | `false` |
-| `bq_curl_ca_bundle_path`                  | Path to the CA certificates used by cURL for SSL certificate verification                                                                                                                          |         |
-| `bq_max_read_streams`                     | Maximum number of read streams requested for BigQuery Storage Read. Set to 0 to match the number of DuckDB threads. Requires `SET preserve_insertion_order=FALSE` for parallelization to work, and BigQuery may return fewer streams than requested. | `0`     |
-| `bq_enable_inflight_request_windowing`    | Whether to keep multiple BigQuery Storage Write `AppendRows` requests in flight before waiting for acknowledgements. Usually faster, but slightly less memory efficient. Set to `false` to fall back to synchronous write/read lockstep. | `true`  |
-| `bq_arrow_compression`                    | Compression codec for BigQuery Storage Read API. Options: `UNSPECIFIED`, `LZ4_FRAME`, `ZSTD`                                                                                                       | `ZSTD`  |
+| Setting                                | Description                                                                                                                                                                                                                                          | Default |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `bq_bignumeric_as_varchar`             | Compatibility setting kept for older workflows. `BIGNUMERIC` columns are exposed as `VARCHAR` by default in current versions.                                                                                                                        | `true`  |
+| `bq_query_timeout_ms`                  | Maximum time to wait for a BigQuery query to complete, including polling. `0` waits indefinitely; a timed-out query job may continue running in BigQuery.                                                                                            | `0`     |
+| `bq_auth_timeout_s`                    | Timeout for authentication token fetches in seconds. This bounds ADC metadata and OAuth token requests without changing normal BigQuery query timeouts.                                                                                              | `10`    |
+| `bq_debug_show_queries`                | [DEBUG] - whether to print all queries sent to BigQuery to stdout                                                                                                                                                                                    | `false` |
+| `bq_experimental_filter_pushdown`      | [EXPERIMENTAL] - Whether or not to use filter pushdown                                                                                                                                                                                               | `true`  |
+| `bq_experimental_use_info_schema`      | [EXPERIMENTAL] - Use information schema to fetch catalog info (often faster than REST API)                                                                                                                                                           | `true`  |
+| `bq_experimental_enable_sql_parser`    | [EXPERIMENTAL] - Enable BigQuery CREATE TABLE clause parsing extensions (PARTITION BY / CLUSTER BY / OPTIONS)                                                                                                                                        | `false` |
+| `bq_curl_ca_bundle_path`               | Path to the CA certificates used by cURL for SSL certificate verification                                                                                                                                                                            |         |
+| `bq_max_read_streams`                  | Maximum number of read streams requested for BigQuery Storage Read. Set to 0 to match the number of DuckDB threads. Requires `SET preserve_insertion_order=FALSE` for parallelization to work, and BigQuery may return fewer streams than requested. | `0`     |
+| `bq_enable_inflight_request_windowing` | Whether to keep multiple BigQuery Storage Write `AppendRows` requests in flight before waiting for acknowledgements. Usually faster, but slightly less memory efficient. Set to `false` to fall back to synchronous write/read lockstep.             | `true`  |
+| `bq_arrow_compression`                 | Compression codec for BigQuery Storage Read API. Options: `UNSPECIFIED`, `LZ4_FRAME`, `ZSTD`                                                                                                                                                         | `ZSTD`  |
 
 ## Limitations
 

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -329,6 +329,19 @@ static string GetLoadStagingDirectory(FileSystem &fs) {
     return fs.ExpandPath(temp_dir);
 }
 
+static google::cloud::bigquery::v2::DecimalTargetType MapDecimalTargetType(const string &target_type) {
+    if (target_type == "NUMERIC") {
+        return google::cloud::bigquery::v2::NUMERIC;
+    }
+    if (target_type == "BIGNUMERIC") {
+        return google::cloud::bigquery::v2::BIGNUMERIC;
+    }
+    if (target_type == "STRING") {
+        return google::cloud::bigquery::v2::STRING;
+    }
+    throw BinderException("Invalid decimal target type: %s", target_type);
+}
+
 } // namespace
 
 class CustomReadIdempotencyPolicy : public google::cloud::bigquery_storage_v1::BigQueryReadConnectionIdempotencyPolicy {
@@ -696,36 +709,20 @@ google::cloud::bigquery::v2::Job BigqueryClient::GetJob(const string &job_id, co
     return job;
 }
 
-google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryTableRef &destination_table,
-                                                                 const string &file_path,
-                                                                 const string &write_disposition,
-                                                                 const string &create_disposition,
-                                                                 const string &location,
-                                                                 const std::map<string, string> &labels,
-                                                                 const std::optional<int> &timeout_ms) {
+google::cloud::bigquery::v2::Job BigqueryClient::LoadFile(const BigqueryTableRef &destination_table,
+                                                          const string &file_path,
+                                                          const BigQueryLoadOptions &options) {
     CheckAuthentication();
 
     auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
         google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
 
-    auto response = InsertLoadJobInternal(client,
-                                          destination_table,
-                                          file_path,
-                                          write_disposition,
-                                          create_disposition,
-                                          location,
-                                          labels);
+    auto response = InsertLoadJobInternal(client, destination_table, file_path, options);
     if (!response.ok()) {
         ThrowOnErrorStatus(response.status());
 
         if (CheckSSLError(response.status())) {
-            return LoadParquetFile(destination_table,
-                                   file_path,
-                                   write_disposition,
-                                   create_disposition,
-                                   location,
-                                   labels,
-                                   timeout_ms);
+            return LoadFile(destination_table, file_path, options);
         }
 
         throw BinderException("Load job submission failed: " + response.status().message());
@@ -738,7 +735,65 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryT
         ThrowOnJobStatusError(response->status(), "Load job");
         return *response;
     }
-    return WaitForJobCompletion(response->job_reference(), timeout_ms);
+    return WaitForJobCompletion(response->job_reference(), options.timeout_ms);
+}
+
+google::cloud::bigquery::v2::Job BigqueryClient::LoadUris(const BigqueryTableRef &destination_table,
+                                                          const vector<string> &source_uris,
+                                                          const BigQueryLoadOptions &options) {
+    if (source_uris.empty()) {
+        throw BinderException("At least one source URI must be provided for a BigQuery load job");
+    }
+    for (const auto &source_uri : source_uris) {
+        if (source_uri.empty()) {
+            throw BinderException("BigQuery load source URIs cannot be empty");
+        }
+        if (!StringUtil::CIStartsWith(source_uri, "gs://")) {
+            throw BinderException("BigQuery load source URI must use the gs:// scheme: %s", source_uri);
+        }
+    }
+
+    CheckAuthentication();
+
+    auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
+        google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
+
+    auto response = InsertLoadJobFromUrisInternal(client, destination_table, source_uris, options);
+    if (!response.ok()) {
+        ThrowOnErrorStatus(response.status());
+
+        if (CheckSSLError(response.status())) {
+            return LoadUris(destination_table, source_uris, options);
+        }
+
+        throw BinderException("Load job submission failed: " + response.status().message());
+    }
+
+    if (!response->has_job_reference()) {
+        throw BinderException("Load job submission succeeded but did not return a job reference");
+    }
+    if (response->has_status() && response->status().state() == "DONE") {
+        ThrowOnJobStatusError(response->status(), "Load job");
+        return *response;
+    }
+    return WaitForJobCompletion(response->job_reference(), options.timeout_ms);
+}
+
+google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetFile(const BigqueryTableRef &destination_table,
+                                                                 const string &file_path,
+                                                                 const string &write_disposition,
+                                                                 const string &create_disposition,
+                                                                 const string &location,
+                                                                 const std::map<string, string> &labels,
+                                                                 const std::optional<int> &timeout_ms) {
+    BigQueryLoadOptions options;
+    options.source_format = "PARQUET";
+    options.write_disposition = write_disposition;
+    options.create_disposition = create_disposition;
+    options.location = location;
+    options.labels = labels;
+    options.timeout_ms = timeout_ms;
+    return LoadFile(destination_table, file_path, options);
 }
 
 google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryTableRef &destination_table,
@@ -748,54 +803,14 @@ google::cloud::bigquery::v2::Job BigqueryClient::LoadParquetUris(const BigqueryT
                                                                  const string &location,
                                                                  const std::map<string, string> &labels,
                                                                  const std::optional<int> &timeout_ms) {
-    if (source_uris.empty()) {
-        throw BinderException("At least one source URI must be provided for a BigQuery load job");
-    }
-    for (const auto &source_uri : source_uris) {
-        if (source_uri.empty()) {
-            throw BinderException("BigQuery load source URIs cannot be empty");
-        }
-        if (!StringUtil::CIStartsWith(source_uri, "gs://")) {
-            throw BinderException("BigQuery Parquet load source URI must use the gs:// scheme: %s", source_uri);
-        }
-    }
-
-    CheckAuthentication();
-
-    auto client = google::cloud::bigquerycontrol_v2::JobServiceClient(
-        google::cloud::bigquerycontrol_v2::MakeJobServiceConnectionRest(OptionsAPI()));
-
-    auto response = InsertLoadJobFromUrisInternal(client,
-                                                  destination_table,
-                                                  source_uris,
-                                                  write_disposition,
-                                                  create_disposition,
-                                                  location,
-                                                  labels);
-    if (!response.ok()) {
-        ThrowOnErrorStatus(response.status());
-
-        if (CheckSSLError(response.status())) {
-            return LoadParquetUris(destination_table,
-                                   source_uris,
-                                   write_disposition,
-                                   create_disposition,
-                                   location,
-                                   labels,
-                                   timeout_ms);
-        }
-
-        throw BinderException("Load job submission failed: " + response.status().message());
-    }
-
-    if (!response->has_job_reference()) {
-        throw BinderException("Load job submission succeeded but did not return a job reference");
-    }
-    if (response->has_status() && response->status().state() == "DONE") {
-        ThrowOnJobStatusError(response->status(), "Load job");
-        return *response;
-    }
-    return WaitForJobCompletion(response->job_reference(), timeout_ms);
+    BigQueryLoadOptions options;
+    options.source_format = "PARQUET";
+    options.write_disposition = write_disposition;
+    options.create_disposition = create_disposition;
+    options.location = location;
+    options.labels = labels;
+    options.timeout_ms = timeout_ms;
+    return LoadUris(destination_table, source_uris, options);
 }
 
 google::cloud::bigquery::v2::Job BigqueryClient::ExecuteQueryToTable(const string &query,
@@ -1609,34 +1624,126 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::QueryResponse> BigqueryClie
 
 google::cloud::bigquery::v2::InsertJobRequest BigqueryClient::BuildLoadJobRequest(
     const BigqueryTableRef &destination_table,
-    const string &write_disposition,
-    const string &create_disposition,
-    const string &location,
-    const std::map<string, string> &labels) {
+    const BigQueryLoadOptions &options) {
     google::cloud::bigquery::v2::Job job;
     auto *job_reference = job.mutable_job_reference();
     job_reference->set_project_id(config.BillingProject());
     job_reference->set_job_id(GenerateJobId("load"));
-    if (!location.empty()) {
-        job_reference->mutable_location()->set_value(location);
+    if (!options.location.empty()) {
+        job_reference->mutable_location()->set_value(options.location);
     }
 
     auto *job_config = job.mutable_configuration();
-    if (!labels.empty()) {
+    if (!options.labels.empty()) {
         auto *job_labels = job_config->mutable_labels();
-        for (const auto &label : labels) {
+        for (const auto &label : options.labels) {
             (*job_labels)[label.first] = label.second;
         }
     }
 
     auto *load_config = job_config->mutable_load();
-    load_config->set_source_format("PARQUET");
-    load_config->set_create_disposition(create_disposition);
-    load_config->set_write_disposition(write_disposition);
+    load_config->set_source_format(options.source_format);
+    load_config->set_create_disposition(options.create_disposition);
+    load_config->set_write_disposition(options.write_disposition);
     auto *destination = load_config->mutable_destination_table();
     destination->set_project_id(destination_table.project_id);
     destination->set_dataset_id(destination_table.dataset_id);
     destination->set_table_id(destination_table.table_id);
+
+    if (options.autodetect.has_value()) {
+        load_config->mutable_autodetect()->set_value(options.autodetect.value());
+    }
+    for (const auto &schema_update_option : options.schema_update_options) {
+        load_config->add_schema_update_options(schema_update_option);
+    }
+    if (options.max_bad_records.has_value()) {
+        load_config->mutable_max_bad_records()->set_value(options.max_bad_records.value());
+    }
+    if (options.ignore_unknown_values.has_value()) {
+        load_config->mutable_ignore_unknown_values()->set_value(options.ignore_unknown_values.value());
+    }
+
+    if (!options.csv_field_delimiter.empty()) {
+        load_config->set_field_delimiter(options.csv_field_delimiter);
+    }
+    if (options.csv_skip_leading_rows.has_value()) {
+        load_config->mutable_skip_leading_rows()->set_value(options.csv_skip_leading_rows.value());
+    }
+    if (options.csv_quote.has_value()) {
+        load_config->mutable_quote()->set_value(options.csv_quote.value());
+    }
+    if (options.csv_allow_quoted_newlines.has_value()) {
+        load_config->mutable_allow_quoted_newlines()->set_value(options.csv_allow_quoted_newlines.value());
+    }
+    if (options.csv_allow_jagged_rows.has_value()) {
+        load_config->mutable_allow_jagged_rows()->set_value(options.csv_allow_jagged_rows.value());
+    }
+    if (!options.csv_encoding.empty()) {
+        load_config->set_encoding(options.csv_encoding);
+    }
+    if (options.csv_null_marker.has_value()) {
+        load_config->mutable_null_marker()->set_value(options.csv_null_marker.value());
+    }
+    for (const auto &null_marker : options.csv_null_markers) {
+        load_config->add_null_markers(null_marker);
+    }
+    if (options.csv_preserve_ascii_control_characters.has_value()) {
+        load_config->mutable_preserve_ascii_control_characters()->set_value(
+            options.csv_preserve_ascii_control_characters.value());
+    }
+
+    if (!options.date_format.empty()) {
+        load_config->set_date_format(options.date_format);
+    }
+    if (!options.datetime_format.empty()) {
+        load_config->set_datetime_format(options.datetime_format);
+    }
+    if (!options.time_format.empty()) {
+        load_config->set_time_format(options.time_format);
+    }
+    if (!options.timestamp_format.empty()) {
+        load_config->set_timestamp_format(options.timestamp_format);
+    }
+    if (!options.time_zone.empty()) {
+        load_config->mutable_time_zone()->set_value(options.time_zone);
+    }
+
+    if (!options.json_extension.empty()) {
+        if (options.json_extension == "GEOJSON") {
+            load_config->set_json_extension(google::cloud::bigquery::v2::GEOJSON);
+        } else {
+            throw BinderException("Invalid JSON extension: %s", options.json_extension);
+        }
+    }
+    if (options.avro_use_logical_types.has_value()) {
+        load_config->mutable_use_avro_logical_types()->set_value(options.avro_use_logical_types.value());
+    }
+    if (!options.reference_file_schema_uri.empty()) {
+        load_config->mutable_reference_file_schema_uri()->set_value(options.reference_file_schema_uri);
+    }
+    for (const auto &target_type : options.decimal_target_types) {
+        load_config->add_decimal_target_types(MapDecimalTargetType(target_type));
+    }
+
+    if (options.parquet_enable_list_inference.has_value() || options.parquet_enum_as_string.has_value()) {
+        auto *parquet_options = load_config->mutable_parquet_options();
+        if (options.parquet_enable_list_inference.has_value()) {
+            parquet_options->mutable_enable_list_inference()->set_value(options.parquet_enable_list_inference.value());
+        }
+        if (options.parquet_enum_as_string.has_value()) {
+            parquet_options->mutable_enum_as_string()->set_value(options.parquet_enum_as_string.value());
+        }
+    }
+
+    if (!options.hive_partitioning_mode.empty() || !options.hive_partitioning_source_uri_prefix.empty()) {
+        auto *hive_options = load_config->mutable_hive_partitioning_options();
+        if (!options.hive_partitioning_mode.empty()) {
+            hive_options->set_mode(options.hive_partitioning_mode);
+        }
+        if (!options.hive_partitioning_source_uri_prefix.empty()) {
+            hive_options->set_source_uri_prefix(options.hive_partitioning_source_uri_prefix);
+        }
+    }
 
     google::cloud::bigquery::v2::InsertJobRequest request;
     request.set_project_id(config.BillingProject());
@@ -1742,10 +1849,7 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::Insert
     google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
     const BigqueryTableRef &destination_table,
     const string &file_path,
-    const string &write_disposition,
-    const string &create_disposition,
-    const string &location,
-    const std::map<string, string> &labels) {
+    const BigQueryLoadOptions &options) {
     if (!context) {
         throw InternalException("InsertLoadJobInternal requires an active DuckDB client context");
     }
@@ -1753,10 +1857,10 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::Insert
     auto &fs = FileSystem::GetFileSystem(*context);
     auto absolute_file_path = fs.ExpandPath(file_path);
     if (!fs.FileExists(absolute_file_path)) {
-        throw IOException("Parquet file not found: %s", absolute_file_path);
+        throw IOException("BigQuery load source file not found: %s", absolute_file_path);
     }
 
-    auto request = BuildLoadJobRequest(destination_table, write_disposition, create_disposition, location, labels);
+    auto request = BuildLoadJobRequest(destination_table, options);
 
     return job_client.InsertJobUpload(request, absolute_file_path);
 }
@@ -1765,11 +1869,8 @@ google::cloud::StatusOr<google::cloud::bigquery::v2::Job> BigqueryClient::Insert
     google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
     const BigqueryTableRef &destination_table,
     const vector<string> &source_uris,
-    const string &write_disposition,
-    const string &create_disposition,
-    const string &location,
-    const std::map<string, string> &labels) {
-    auto request = BuildLoadJobRequest(destination_table, write_disposition, create_disposition, location, labels);
+    const BigQueryLoadOptions &options) {
+    auto request = BuildLoadJobRequest(destination_table, options);
     auto *load_config = request.mutable_job()->mutable_configuration()->mutable_load();
     for (const auto &source_uri : source_uris) {
         load_config->add_source_uris(source_uri);

--- a/src/bigquery_load.cpp
+++ b/src/bigquery_load.cpp
@@ -24,6 +24,8 @@
 #include "storage/bigquery_transaction.hpp"
 
 #include <cstdio>
+#include <initializer_list>
+#include <limits>
 #include <map>
 #include <optional>
 
@@ -37,11 +39,7 @@ struct BigQueryLoadBindData : public TableFunctionData {
     std::optional<string> source_file;
     vector<string> source_uris;
     std::optional<string> source_table;
-    string write_disposition;
-    string create_disposition;
-    string location;
-    std::map<string, string> labels;
-    std::optional<int> timeout_ms;
+    BigQueryLoadOptions options;
     bool remove_staged_source_file = false;
     bool finished = false;
 
@@ -56,13 +54,9 @@ struct BigQueryLoadParameters {
     std::optional<string> source_file;
     vector<string> source_uris;
     std::optional<string> source_table;
-    string write_disposition = "WRITE_TRUNCATE";
-    string create_disposition = "CREATE_IF_NEEDED";
-    std::optional<string> location;
     string billing_project;
-    string api_endpoint;
-    std::map<string, string> labels;
-    std::optional<int> timeout_ms;
+    bool source_format_explicit = false;
+    BigQueryLoadOptions options;
 };
 
 static string NormalizeEnumValue(const string &value) {
@@ -137,6 +131,200 @@ static std::optional<string> ParseOptionalAliasedStringParameter(const named_par
     return value ? value : legacy_value;
 }
 
+static std::optional<bool> ParseOptionalBoolParameter(const named_parameter_map_t &named_parameters,
+                                                      const string &parameter_name) {
+    auto entry = named_parameters.find(parameter_name);
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return std::nullopt;
+    }
+    return entry->second.GetValue<bool>();
+}
+
+static std::optional<int> ParseOptionalNonNegativeInt32Parameter(const named_parameter_map_t &named_parameters,
+                                                                 const string &parameter_name) {
+    auto entry = named_parameters.find(parameter_name);
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return std::nullopt;
+    }
+
+    auto value = entry->second.GetValue<int64_t>();
+    if (value < 0) {
+        throw InvalidInputException("Parameter '%s' must be non-negative", parameter_name);
+    }
+    if (value > std::numeric_limits<int>::max()) {
+        throw InvalidInputException("Parameter '%s' must fit in a 32-bit integer", parameter_name);
+    }
+    return static_cast<int>(value);
+}
+
+static vector<string> ParseOptionalStringListParameter(const named_parameter_map_t &named_parameters,
+                                                       const string &parameter_name,
+                                                       const bool normalize_upper = false) {
+    auto entry = named_parameters.find(parameter_name);
+    if (entry == named_parameters.end() || entry->second.IsNull()) {
+        return {};
+    }
+
+    vector<string> result;
+    if (entry->second.type().id() == LogicalTypeId::VARCHAR) {
+        auto value = entry->second.GetValue<string>();
+        result.push_back(normalize_upper ? NormalizeEnumValue(value) : value);
+        return result;
+    }
+    if (entry->second.type().id() != LogicalTypeId::LIST) {
+        throw BinderException("Parameter '%s' must be a VARCHAR or LIST<VARCHAR>", parameter_name);
+    }
+
+    for (const auto &child : ListValue::GetChildren(entry->second)) {
+        if (child.IsNull()) {
+            throw BinderException("Null entries are not allowed in parameter '%s'", parameter_name);
+        }
+        if (child.type().id() != LogicalTypeId::VARCHAR) {
+            throw BinderException("Parameter '%s' must contain only VARCHAR entries", parameter_name);
+        }
+        auto value = child.GetValue<string>();
+        result.push_back(normalize_upper ? NormalizeEnumValue(value) : value);
+    }
+    return result;
+}
+
+static bool HasAnyOption(const BigQueryLoadOptions &options, const std::initializer_list<bool> option_presence) {
+    for (auto present : option_presence) {
+        if (present) {
+            return true;
+        }
+    }
+    return false;
+}
+
+static bool HasCsvOptions(const BigQueryLoadOptions &options) {
+    return HasAnyOption(options,
+                        {!options.csv_field_delimiter.empty(),
+                         options.csv_skip_leading_rows.has_value(),
+                         options.csv_quote.has_value(),
+                         options.csv_allow_quoted_newlines.has_value(),
+                         options.csv_allow_jagged_rows.has_value(),
+                         !options.csv_encoding.empty(),
+                         options.csv_null_marker.has_value(),
+                         !options.csv_null_markers.empty(),
+                         options.csv_preserve_ascii_control_characters.has_value()});
+}
+
+static bool HasTemporalOptions(const BigQueryLoadOptions &options) {
+    return HasAnyOption(options,
+                        {!options.date_format.empty(),
+                         !options.datetime_format.empty(),
+                         !options.time_format.empty(),
+                         !options.timestamp_format.empty(),
+                         !options.time_zone.empty()});
+}
+
+static string InferSourceFormatFromPath(const string &source) {
+    auto lower = StringUtil::Lower(source);
+    auto query_pos = lower.find('?');
+    if (query_pos != string::npos) {
+        lower = lower.substr(0, query_pos);
+    }
+
+    const vector<string> compression_suffixes = {".gz", ".gzip", ".bz2", ".zst", ".zstd", ".snappy", ".deflate"};
+    for (const auto &suffix : compression_suffixes) {
+        if (lower.size() > suffix.size() && lower.rfind(suffix) == lower.size() - suffix.size()) {
+            lower = lower.substr(0, lower.size() - suffix.size());
+            break;
+        }
+    }
+
+    if (lower.size() >= 4 && lower.rfind(".csv") == lower.size() - 4) {
+        return "CSV";
+    }
+    if (lower.size() >= 5 && lower.rfind(".json") == lower.size() - 5) {
+        return "NEWLINE_DELIMITED_JSON";
+    }
+    if (lower.size() >= 7 && lower.rfind(".ndjson") == lower.size() - 7) {
+        return "NEWLINE_DELIMITED_JSON";
+    }
+    if (lower.size() >= 5 && lower.rfind(".avro") == lower.size() - 5) {
+        return "AVRO";
+    }
+    if (lower.size() >= 4 && lower.rfind(".orc") == lower.size() - 4) {
+        return "ORC";
+    }
+    if (lower.size() >= 8 && lower.rfind(".parquet") == lower.size() - 8) {
+        return "PARQUET";
+    }
+    if (lower.size() >= 5 && lower.rfind(".parq") == lower.size() - 5) {
+        return "PARQUET";
+    }
+    return "";
+}
+
+static string InferSourceFormatFromSources(const vector<string> &sources) {
+    string inferred_format;
+    for (const auto &source : sources) {
+        auto source_format = InferSourceFormatFromPath(source);
+        if (source_format.empty()) {
+            return "";
+        }
+        if (inferred_format.empty()) {
+            inferred_format = source_format;
+        } else if (inferred_format != source_format) {
+            return "";
+        }
+    }
+    return inferred_format;
+}
+
+static void ValidateEnumList(const vector<string> &values,
+                             const string &parameter_name,
+                             const vector<string> &allowed_values) {
+    for (const auto &value : values) {
+        bool found = false;
+        for (const auto &allowed_value : allowed_values) {
+            if (value == allowed_value) {
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            throw BinderException("Invalid value for parameter '%s': %s", parameter_name, value);
+        }
+    }
+}
+
+static void ValidateLoadOptionCombinations(const BigQueryLoadOptions &options, const bool source_is_uris) {
+    const auto &format = options.source_format;
+    if (HasCsvOptions(options) && format != "CSV") {
+        throw BinderException("CSV-specific bigquery_load options require source_format='CSV'");
+    }
+    if (!options.json_extension.empty() && format != "NEWLINE_DELIMITED_JSON") {
+        throw BinderException("json_extension requires source_format='NEWLINE_DELIMITED_JSON'");
+    }
+    if (options.avro_use_logical_types.has_value() && format != "AVRO") {
+        throw BinderException("avro_use_logical_types requires source_format='AVRO'");
+    }
+    if ((options.parquet_enable_list_inference.has_value() || options.parquet_enum_as_string.has_value()) &&
+        format != "PARQUET") {
+        throw BinderException("Parquet-specific bigquery_load options require source_format='PARQUET'");
+    }
+    if (HasTemporalOptions(options) && format != "CSV" && format != "NEWLINE_DELIMITED_JSON") {
+        throw BinderException("Temporal parsing options require source_format='CSV' or "
+                              "source_format='NEWLINE_DELIMITED_JSON'");
+    }
+    if (!options.reference_file_schema_uri.empty() && format != "AVRO" && format != "PARQUET" && format != "ORC") {
+        throw BinderException("reference_file_schema_uri requires source_format='AVRO', 'PARQUET', or 'ORC'");
+    }
+    if (!options.decimal_target_types.empty() && format != "AVRO" && format != "PARQUET" && format != "ORC") {
+        throw BinderException("decimal_target_types requires source_format='AVRO', 'PARQUET', or 'ORC'");
+    }
+    if ((!options.hive_partitioning_mode.empty() || !options.hive_partitioning_source_uri_prefix.empty()) &&
+        !source_is_uris) {
+        throw BinderException("Hive partitioning options require source_uris");
+    }
+    if (options.csv_null_marker.has_value() && !options.csv_null_markers.empty()) {
+        throw BinderException("Cannot specify both csv_null_marker and csv_null_markers");
+    }
+}
+
 static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &named_parameters) {
     BigQueryLoadParameters params;
     params.source_file = ParseOptionalAliasedStringParameter(named_parameters, "source_file", "file");
@@ -148,21 +336,91 @@ static BigQueryLoadParameters ParseLoadParameters(const named_parameter_map_t &n
     if (source_uris && source_uris->empty()) {
         throw BinderException("Parameter 'source_uris' must contain at least one URI");
     }
-    params.location = ParseOptionalStringParameter(named_parameters, "location");
+    auto source_format = ParseOptionalStringParameter(named_parameters, "source_format");
+    if (source_format.has_value()) {
+        params.source_format_explicit = true;
+        params.options.source_format = NormalizeEnumValue(*source_format);
+        ValidateEnumList({params.options.source_format},
+                         "source_format",
+                         {"PARQUET", "CSV", "NEWLINE_DELIMITED_JSON", "AVRO", "ORC"});
+    }
+
+    auto location = ParseOptionalStringParameter(named_parameters, "location");
+    params.options.location = location ? *location : string();
     auto billing_project = ParseOptionalStringParameter(named_parameters, "billing_project");
     params.billing_project = billing_project ? *billing_project : string();
-    auto api_endpoint = ParseOptionalStringParameter(named_parameters, "api_endpoint");
-    params.api_endpoint = api_endpoint ? *api_endpoint : string();
-    params.labels = BigqueryUtils::ParseOptionalLabelsParameter(named_parameters);
-    params.timeout_ms = BigqueryUtils::ParseTimeoutMsParameter(named_parameters);
-    params.write_disposition = ParseEnumParameter(named_parameters,
-                                                  "write_disposition",
-                                                  "WRITE_TRUNCATE",
-                                                  {"WRITE_TRUNCATE", "WRITE_APPEND", "WRITE_EMPTY"});
-    params.create_disposition = ParseEnumParameter(named_parameters,
-                                                   "create_disposition",
-                                                   "CREATE_IF_NEEDED",
-                                                   {"CREATE_IF_NEEDED", "CREATE_NEVER"});
+    params.options.labels = BigqueryUtils::ParseOptionalLabelsParameter(named_parameters);
+    params.options.timeout_ms = BigqueryUtils::ParseTimeoutMsParameter(named_parameters);
+    params.options.write_disposition = ParseEnumParameter(named_parameters,
+                                                          "write_disposition",
+                                                          "WRITE_TRUNCATE",
+                                                          {"WRITE_TRUNCATE", "WRITE_APPEND", "WRITE_EMPTY"});
+    params.options.create_disposition = ParseEnumParameter(named_parameters,
+                                                           "create_disposition",
+                                                           "CREATE_IF_NEEDED",
+                                                           {"CREATE_IF_NEEDED", "CREATE_NEVER"});
+    params.options.autodetect = ParseOptionalBoolParameter(named_parameters, "autodetect");
+    params.options.schema_update_options =
+        ParseOptionalStringListParameter(named_parameters, "schema_update_options", true);
+    ValidateEnumList(params.options.schema_update_options,
+                     "schema_update_options",
+                     {"ALLOW_FIELD_ADDITION", "ALLOW_FIELD_RELAXATION"});
+    params.options.max_bad_records = ParseOptionalNonNegativeInt32Parameter(named_parameters, "max_bad_records");
+    params.options.ignore_unknown_values = ParseOptionalBoolParameter(named_parameters, "ignore_unknown_values");
+
+    auto csv_field_delimiter = ParseOptionalStringParameter(named_parameters, "csv_field_delimiter");
+    params.options.csv_field_delimiter = csv_field_delimiter ? *csv_field_delimiter : string();
+    params.options.csv_skip_leading_rows =
+        ParseOptionalNonNegativeInt32Parameter(named_parameters, "csv_skip_leading_rows");
+    params.options.csv_quote = ParseOptionalStringParameter(named_parameters, "csv_quote");
+    params.options.csv_allow_quoted_newlines =
+        ParseOptionalBoolParameter(named_parameters, "csv_allow_quoted_newlines");
+    params.options.csv_allow_jagged_rows = ParseOptionalBoolParameter(named_parameters, "csv_allow_jagged_rows");
+    auto csv_encoding = ParseOptionalStringParameter(named_parameters, "csv_encoding");
+    params.options.csv_encoding = csv_encoding ? NormalizeEnumValue(*csv_encoding) : string();
+    params.options.csv_null_marker = ParseOptionalStringParameter(named_parameters, "csv_null_marker");
+    params.options.csv_null_markers = ParseOptionalStringListParameter(named_parameters, "csv_null_markers");
+    params.options.csv_preserve_ascii_control_characters =
+        ParseOptionalBoolParameter(named_parameters, "csv_preserve_ascii_control_characters");
+
+    auto date_format = ParseOptionalStringParameter(named_parameters, "date_format");
+    params.options.date_format = date_format ? *date_format : string();
+    auto datetime_format = ParseOptionalStringParameter(named_parameters, "datetime_format");
+    params.options.datetime_format = datetime_format ? *datetime_format : string();
+    auto time_format = ParseOptionalStringParameter(named_parameters, "time_format");
+    params.options.time_format = time_format ? *time_format : string();
+    auto timestamp_format = ParseOptionalStringParameter(named_parameters, "timestamp_format");
+    params.options.timestamp_format = timestamp_format ? *timestamp_format : string();
+    auto time_zone = ParseOptionalStringParameter(named_parameters, "time_zone");
+    params.options.time_zone = time_zone ? *time_zone : string();
+
+    auto json_extension = ParseOptionalStringParameter(named_parameters, "json_extension");
+    params.options.json_extension = json_extension ? NormalizeEnumValue(*json_extension) : string();
+    if (!params.options.json_extension.empty()) {
+        ValidateEnumList({params.options.json_extension}, "json_extension", {"GEOJSON"});
+    }
+    params.options.avro_use_logical_types = ParseOptionalBoolParameter(named_parameters, "avro_use_logical_types");
+    params.options.parquet_enable_list_inference =
+        ParseOptionalBoolParameter(named_parameters, "parquet_enable_list_inference");
+    params.options.parquet_enum_as_string = ParseOptionalBoolParameter(named_parameters, "parquet_enum_as_string");
+    auto reference_file_schema_uri = ParseOptionalStringParameter(named_parameters, "reference_file_schema_uri");
+    params.options.reference_file_schema_uri = reference_file_schema_uri ? *reference_file_schema_uri : string();
+    params.options.decimal_target_types =
+        ParseOptionalStringListParameter(named_parameters, "decimal_target_types", true);
+    ValidateEnumList(params.options.decimal_target_types, "decimal_target_types", {"NUMERIC", "BIGNUMERIC", "STRING"});
+
+    auto hive_partitioning_mode = ParseOptionalStringParameter(named_parameters, "hive_partitioning_mode");
+    params.options.hive_partitioning_mode =
+        hive_partitioning_mode ? NormalizeEnumValue(*hive_partitioning_mode) : string();
+    if (!params.options.hive_partitioning_mode.empty()) {
+        ValidateEnumList({params.options.hive_partitioning_mode},
+                         "hive_partitioning_mode",
+                         {"AUTO", "STRINGS", "CUSTOM"});
+    }
+    auto hive_partitioning_source_uri_prefix =
+        ParseOptionalStringParameter(named_parameters, "hive_partitioning_source_uri_prefix");
+    params.options.hive_partitioning_source_uri_prefix =
+        hive_partitioning_source_uri_prefix ? *hive_partitioning_source_uri_prefix : string();
 
     const auto source_count = static_cast<int>(params.source_file.has_value()) +
                               static_cast<int>(params.source_table.has_value()) +
@@ -185,7 +443,7 @@ static void ValidateGcsSourceUris(const vector<string> &source_uris) {
             throw BinderException("BigQuery load source URIs cannot be empty");
         }
         if (!IsGcsUri(source_uri)) {
-            throw BinderException("BigQuery Parquet load source URI must use the gs:// scheme: %s", source_uri);
+            throw BinderException("BigQuery load source URI must use the gs:// scheme: %s", source_uri);
         }
     }
 }
@@ -312,14 +570,13 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
     auto params = ParseLoadParameters(input.named_parameters);
 
     auto bind_data = make_uniq<BigQueryLoadBindData>();
-    bind_data->write_disposition = params.write_disposition;
-    bind_data->create_disposition = params.create_disposition;
     bind_data->source_file = params.source_file;
     bind_data->source_uris = params.source_uris;
     bind_data->source_table = params.source_table;
-    bind_data->location = params.location ? *params.location : BigquerySettings::DefaultLocation();
-    bind_data->labels = params.labels;
-    bind_data->timeout_ms = params.timeout_ms;
+    bind_data->options = params.options;
+    if (bind_data->options.location.empty()) {
+        bind_data->options.location = BigquerySettings::DefaultLocation();
+    }
 
     auto destination_table = BigqueryUtils::ParseDatasetTableString(destination_table_string);
 
@@ -334,9 +591,6 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
             throw BinderException("'billing_project' named parameter is not supported for attached databases; "
                                   "set billing_project in ATTACH instead");
         }
-        if (!params.api_endpoint.empty()) {
-            throw BinderException("'api_endpoint' named parameter is not supported for attached databases");
-        }
 
         auto &bigquery_catalog = catalog.Cast<BigqueryCatalog>();
         auto &transaction = BigqueryTransaction::Get(context, bigquery_catalog);
@@ -347,9 +601,7 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
         bind_data->config = bigquery_catalog.config;
         bind_data->bq_client = transaction.GetBigqueryClient();
     } else {
-        bind_data->config = BigqueryConfig(dbname_or_project_id)
-                                .SetBillingProjectId(params.billing_project)
-                                .SetApiEndpoint(params.api_endpoint);
+        bind_data->config = BigqueryConfig(dbname_or_project_id).SetBillingProjectId(params.billing_project);
         bind_data->bq_client = make_shared_ptr<BigqueryClient>(context, bind_data->config);
     }
 
@@ -363,6 +615,23 @@ static unique_ptr<FunctionData> BigQueryLoadBind(ClientContext &context,
     if (!bind_data->source_uris.empty()) {
         ValidateGcsSourceUris(bind_data->source_uris);
     }
+
+    if (!params.source_format_explicit) {
+        string inferred_format;
+        if (bind_data->source_file.has_value()) {
+            inferred_format = InferSourceFormatFromPath(*bind_data->source_file);
+        } else if (!bind_data->source_uris.empty()) {
+            inferred_format = InferSourceFormatFromSources(bind_data->source_uris);
+        }
+        if (!inferred_format.empty()) {
+            bind_data->options.source_format = inferred_format;
+        }
+    }
+
+    if (bind_data->source_table.has_value() && bind_data->options.source_format != "PARQUET") {
+        throw BinderException("source_table loads are staged as Parquet and require source_format='PARQUET'");
+    }
+    ValidateLoadOptionCombinations(bind_data->options, !bind_data->source_uris.empty());
 
     if (bind_data->source_table.has_value()) {
         bind_data->source_file = MaterializeSourceTableToParquet(context, *bind_data->source_table);
@@ -382,21 +651,9 @@ static void BigQueryLoadFunc(ClientContext &context, TableFunctionInput &data_p,
 
     google::cloud::bigquery::v2::Job job;
     if (data.source_file.has_value()) {
-        job = data.bq_client->LoadParquetFile(data.destination_table,
-                                              *data.source_file,
-                                              data.write_disposition,
-                                              data.create_disposition,
-                                              data.location,
-                                              data.labels,
-                                              data.timeout_ms);
+        job = data.bq_client->LoadFile(data.destination_table, *data.source_file, data.options);
     } else if (!data.source_uris.empty()) {
-        job = data.bq_client->LoadParquetUris(data.destination_table,
-                                              data.source_uris,
-                                              data.write_disposition,
-                                              data.create_disposition,
-                                              data.location,
-                                              data.labels,
-                                              data.timeout_ms);
+        job = data.bq_client->LoadUris(data.destination_table, data.source_uris, data.options);
     } else {
         throw InternalException("bigquery_load has no source to load");
     }
@@ -434,13 +691,43 @@ BigQueryLoadFunction::BigQueryLoadFunction()
     named_parameters["source_uris"] = LogicalType::ANY;
     named_parameters["source_table"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["table"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["source_format"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["write_disposition"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["create_disposition"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["location"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["billing_project"] = LogicalType(LogicalTypeId::VARCHAR);
-    named_parameters["api_endpoint"] = LogicalType(LogicalTypeId::VARCHAR);
     named_parameters["labels"] = LogicalType::MAP(LogicalType::VARCHAR, LogicalType::VARCHAR);
     named_parameters["timeout_ms"] = LogicalType::BIGINT;
+    named_parameters["autodetect"] = LogicalType::BOOLEAN;
+    named_parameters["schema_update_options"] = LogicalType::ANY;
+    named_parameters["max_bad_records"] = LogicalType::BIGINT;
+    named_parameters["ignore_unknown_values"] = LogicalType::BOOLEAN;
+
+    named_parameters["csv_field_delimiter"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["csv_skip_leading_rows"] = LogicalType::BIGINT;
+    named_parameters["csv_quote"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["csv_allow_quoted_newlines"] = LogicalType::BOOLEAN;
+    named_parameters["csv_allow_jagged_rows"] = LogicalType::BOOLEAN;
+    named_parameters["csv_encoding"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["csv_null_marker"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["csv_null_markers"] = LogicalType::ANY;
+    named_parameters["csv_preserve_ascii_control_characters"] = LogicalType::BOOLEAN;
+
+    named_parameters["date_format"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["datetime_format"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["time_format"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["timestamp_format"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["time_zone"] = LogicalType(LogicalTypeId::VARCHAR);
+
+    named_parameters["json_extension"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["avro_use_logical_types"] = LogicalType::BOOLEAN;
+    named_parameters["parquet_enable_list_inference"] = LogicalType::BOOLEAN;
+    named_parameters["parquet_enum_as_string"] = LogicalType::BOOLEAN;
+    named_parameters["reference_file_schema_uri"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["decimal_target_types"] = LogicalType::ANY;
+
+    named_parameters["hive_partitioning_mode"] = LogicalType(LogicalTypeId::VARCHAR);
+    named_parameters["hive_partitioning_source_uri_prefix"] = LogicalType(LogicalTypeId::VARCHAR);
 }
 
 } // namespace bigquery

--- a/src/include/bigquery_client.hpp
+++ b/src/include/bigquery_client.hpp
@@ -41,6 +41,46 @@ struct ListJobsParams {
 
 enum class BigqueryDmlStatementType { DML_UPDATE, DML_DELETE };
 
+struct BigQueryLoadOptions {
+    string source_format = "PARQUET";
+    string write_disposition = "WRITE_TRUNCATE";
+    string create_disposition = "CREATE_IF_NEEDED";
+    string location;
+    std::map<string, string> labels;
+    std::optional<int> timeout_ms;
+
+    std::optional<bool> autodetect;
+    vector<string> schema_update_options;
+    std::optional<int> max_bad_records;
+    std::optional<bool> ignore_unknown_values;
+
+    string csv_field_delimiter;
+    std::optional<int> csv_skip_leading_rows;
+    std::optional<string> csv_quote;
+    std::optional<bool> csv_allow_quoted_newlines;
+    std::optional<bool> csv_allow_jagged_rows;
+    string csv_encoding;
+    std::optional<string> csv_null_marker;
+    vector<string> csv_null_markers;
+    std::optional<bool> csv_preserve_ascii_control_characters;
+
+    string date_format;
+    string datetime_format;
+    string time_format;
+    string timestamp_format;
+    string time_zone;
+
+    string json_extension;
+    std::optional<bool> avro_use_logical_types;
+    std::optional<bool> parquet_enable_list_inference;
+    std::optional<bool> parquet_enum_as_string;
+    string reference_file_schema_uri;
+    vector<string> decimal_target_types;
+
+    string hive_partitioning_mode;
+    string hive_partitioning_source_uri_prefix;
+};
+
 class BigqueryClient {
 public:
     explicit BigqueryClient(ClientContext &context, const BigqueryConfig &config);
@@ -85,6 +125,12 @@ public:
     vector<google::cloud::bigquery::v2::ListFormatJob> ListJobs(const ListJobsParams &params);
     google::cloud::bigquery::v2::Job GetJob(const string &job_id, const string &location = "");
     google::cloud::bigquery::v2::Job GetJobByReference(const google::cloud::bigquery::v2::JobReference &job_ref);
+    google::cloud::bigquery::v2::Job LoadFile(const BigqueryTableRef &destination_table,
+                                              const string &file_path,
+                                              const BigQueryLoadOptions &options);
+    google::cloud::bigquery::v2::Job LoadUris(const BigqueryTableRef &destination_table,
+                                              const vector<string> &source_uris,
+                                              const BigQueryLoadOptions &options);
     google::cloud::bigquery::v2::Job LoadParquetFile(const BigqueryTableRef &destination_table,
                                                      const string &file_path,
                                                      const string &write_disposition = "WRITE_TRUNCATE",
@@ -192,10 +238,7 @@ private:
                                                                        const string &location,
                                                                        const std::map<string, string> &labels);
     google::cloud::bigquery::v2::InsertJobRequest BuildLoadJobRequest(const BigqueryTableRef &destination_table,
-                                                                      const string &write_disposition,
-                                                                      const string &create_disposition,
-                                                                      const string &location,
-                                                                      const std::map<string, string> &labels);
+                                                                      const BigQueryLoadOptions &options);
     google::cloud::bigquery::v2::InsertJobRequest BuildExtractJobRequest(
         const BigqueryTableRef &source_table,
         const vector<string> &destination_uris,
@@ -210,18 +253,12 @@ private:
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const BigqueryTableRef &destination_table,
         const string &file_path,
-        const string &write_disposition,
-        const string &create_disposition,
-        const string &location,
-        const std::map<string, string> &labels);
+        const BigQueryLoadOptions &options);
     google::cloud::StatusOr<google::cloud::bigquery::v2::Job> InsertLoadJobFromUrisInternal(
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const BigqueryTableRef &destination_table,
         const vector<string> &source_uris,
-        const string &write_disposition,
-        const string &create_disposition,
-        const string &location,
-        const std::map<string, string> &labels);
+        const BigQueryLoadOptions &options);
     google::cloud::StatusOr<google::cloud::bigquery::v2::Job> InsertExtractJobInternal(
         google::cloud::bigquerycontrol_v2::JobServiceClient &job_client,
         const BigqueryTableRef &source_table,

--- a/test/data/load_events.csv
+++ b/test/data/load_events.csv
@@ -1,0 +1,3 @@
+id|name|amount
+1|alpha|10.5
+2|beta|20.25

--- a/test/data/load_events.ndjson
+++ b/test/data/load_events.ndjson
@@ -1,0 +1,2 @@
+{"id":1,"name":"alpha","active":true}
+{"id":2,"name":"beta","active":false}

--- a/test/sql/functions/function_bigquery_load.test
+++ b/test/sql/functions/function_bigquery_load.test
@@ -20,6 +20,12 @@ statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_table_table;
 
 statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_csv_table;
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_json_table;
+
+statement ok
 CREATE OR REPLACE TEMP TABLE local_load_source AS
 SELECT * FROM read_parquet('test/data/multiple_row_groups.parquet');
 
@@ -54,6 +60,69 @@ CALL bigquery_load(
 ----
 Invalid Input Error: Timeout must fit in a 32-bit integer
 
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/multiple_row_groups.parquet',
+	api_endpoint := 'http://localhost:9050'
+);
+----
+<REGEX>:Binder Error: .*api_endpoint.*
+
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/multiple_row_groups.parquet',
+	source_format := 'PARQUET',
+	csv_field_delimiter := ','
+);
+----
+Binder Error: CSV-specific bigquery_load options require source_format='CSV'
+
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/load_events.csv',
+	source_format := 'CSV',
+	parquet_enum_as_string := true
+);
+----
+Binder Error: Parquet-specific bigquery_load options require source_format='PARQUET'
+
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/load_events.csv',
+	source_format := 'ORC',
+	date_format := 'YYYY-MM-DD'
+);
+----
+Binder Error: Temporal parsing options require source_format='CSV' or source_format='NEWLINE_DELIMITED_JSON'
+
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_file := 'test/data/multiple_row_groups.parquet',
+	hive_partitioning_mode := 'AUTO'
+);
+----
+Binder Error: Hive partitioning options require source_uris
+
+statement error
+CALL bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_file_table',
+	source_table := 'local_load_source',
+	source_format := 'CSV'
+);
+----
+Binder Error: source_table loads are staged as Parquet and require source_format='PARQUET'
+
 statement ok
 CREATE OR REPLACE TEMP TABLE load_file_job AS
 SELECT *
@@ -85,6 +154,7 @@ query I
 SELECT count(*) = 1
 FROM bigquery_jobs('bq', maxResults=50)
 WHERE job_id = (SELECT job_id FROM load_file_job)
+	AND contains(configuration::VARCHAR, '"sourceFormat":"PARQUET"')
 	AND contains(configuration::VARCHAR, '"duckdb_label_env":"test"')
 	AND contains(configuration::VARCHAR, '"duckdb_load_label":"load_job"');
 ----
@@ -132,7 +202,80 @@ SELECT (
 true
 
 statement ok
+CREATE OR REPLACE TEMP TABLE load_csv_job AS
+SELECT *
+FROM bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_csv_table',
+	source_file := 'test/data/load_events.csv',
+	autodetect := true,
+	csv_skip_leading_rows := 1,
+	csv_field_delimiter := '|',
+	location := 'europe-west3',
+	labels := MAP {'duckdb_load_label': 'csv_load'}
+);
+
+sleep 5 seconds
+
+query I
+SELECT (
+	SELECT count(*)
+	FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_csv_table`')
+) = 2;
+----
+true
+
+query I
+SELECT count(*) = 1
+FROM bigquery_jobs('bq', maxResults=50)
+WHERE job_id = (SELECT job_id FROM load_csv_job)
+	AND contains(configuration::VARCHAR, '"sourceFormat":"CSV"')
+	AND contains(configuration::VARCHAR, '"autodetect":true')
+	AND contains(configuration::VARCHAR, '"fieldDelimiter":"|"')
+	AND contains(configuration::VARCHAR, '"duckdb_load_label":"csv_load"');
+----
+true
+
+statement ok
+CREATE OR REPLACE TEMP TABLE load_json_job AS
+SELECT *
+FROM bigquery_load(
+	'bq',
+	'${BQ_TEST_DATASET}.load_json_table',
+	source_file := 'test/data/load_events.ndjson',
+	autodetect := true,
+	location := 'europe-west3',
+	labels := MAP {'duckdb_load_label': 'json_load'}
+);
+
+sleep 5 seconds
+
+query I
+SELECT (
+	SELECT count(*)
+	FROM bigquery_query('bq', 'SELECT * FROM `${BQ_TEST_PROJECT}.${BQ_TEST_DATASET}.load_json_table`')
+) = 2;
+----
+true
+
+query I
+SELECT count(*) = 1
+FROM bigquery_jobs('bq', maxResults=50)
+WHERE job_id = (SELECT job_id FROM load_json_job)
+	AND contains(configuration::VARCHAR, '"sourceFormat":"NEWLINE_DELIMITED_JSON"')
+	AND contains(configuration::VARCHAR, '"autodetect":true')
+	AND contains(configuration::VARCHAR, '"duckdb_load_label":"json_load"');
+----
+true
+
+statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_file_table;
 
 statement ok
 DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_table_table;
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_csv_table;
+
+statement ok
+DROP TABLE IF EXISTS bq.${BQ_TEST_DATASET}.load_json_table;


### PR DESCRIPTION
Extends `bigquery_load` into a more flexible load-job wrapper with `source_format`, `autodetect`, CSV/JSON/Avro/Parquet/ORC options, schema update options, and Hive partitioning for GCS URIs. Removes api_endpoint from the public load API; custom endpoints still go through `ATTACH`. Adds binder and load coverage for CSV/NDJSON, plus updated README docs. 

```sql
SELECT * FROM bigquery_load(
    'bq',
    'analytics.events_csv',
    source_file := '/data/events.csv',
    source_format := 'CSV',
    autodetect := true,
    csv_skip_leading_rows := 1,
    csv_field_delimiter := ',',
    write_disposition := 'WRITE_TRUNCATE',
    location := 'EU',
    labels := MAP {'pipeline': 'daily_load', 'format': 'csv'}
);
```

Added the following `bigquery_load` variants and option groups:

| Added variant | Example options |
| --- | --- |
| CSV loads | `source_format := 'CSV'`, `csv_field_delimiter`, `csv_skip_leading_rows`, `csv_quote`, `csv_allow_quoted_newlines`, `csv_allow_jagged_rows`, `csv_encoding`, `csv_null_marker`, `csv_null_markers`, `csv_preserve_ascii_control_characters` |
| Newline-delimited JSON loads | `source_format := 'NEWLINE_DELIMITED_JSON'`, `json_extension` |
| Avro loads | `source_format := 'AVRO'`, `avro_use_logical_types`, `decimal_target_types`, `reference_file_schema_uri` |
| ORC loads | `source_format := 'ORC'`, `decimal_target_types`, `reference_file_schema_uri` |
| Parquet load options | `source_format := 'PARQUET'`, `parquet_enable_list_inference`, `parquet_enum_as_string`, `decimal_target_types`, `reference_file_schema_uri` |
| BigQuery autodetect | `autodetect := true` |
| Schema update behavior | `schema_update_options := ['ALLOW_FIELD_ADDITION', 'ALLOW_FIELD_RELAXATION']` |
| Bad-record handling | `max_bad_records`, `ignore_unknown_values` |
| CSV/JSON temporal parsing | `date_format`, `datetime_format`, `time_format`, `timestamp_format`, `time_zone` |
| Hive partitioned GCS loads | `source_uris := 'gs://...'`, `hive_partitioning_mode`, `hive_partitioning_source_uri_prefix` |