### PR TITLE
Add MkDocs documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,94 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - CHANGELOG.md
+      - LICENSE
+      - docs-requirements.txt
+      - mkdocs.yml
+      - scripts/check_docs.py
+      - .github/workflows/docs.yml
+  pull_request:
+    paths:
+      - "docs/**"
+      - CHANGELOG.md
+      - LICENSE
+      - docs-requirements.txt
+      - mkdocs.yml
+      - scripts/check_docs.py
+      - .github/workflows/docs.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: docs-requirements.txt
+
+      - name: Install documentation dependencies
+        run: python -m pip install -r docs-requirements.txt
+
+      - name: Check documentation conventions
+        run: python scripts/check_docs.py
+
+      - name: Check workflow syntax
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - name: Check documentation links
+        uses: lycheeverse/lychee-action@v2.9.0
+        with:
+          args: >-
+            --root-dir "${{ github.workspace }}"
+            --max-retries 3
+            --retry-wait-time 2
+            --timeout 30
+            "docs/**/*.md"
+            "CHANGELOG.md"
+
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v6
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: build/docs-site
+
+  deploy:
+    name: Deploy documentation
+    if: github.event_name != 'pull_request'
+    needs: build
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy GitHub Pages site
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -48,7 +48,7 @@ jobs:
         run: python scripts/check_docs.py
 
       - name: Check workflow syntax
-        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/docs.yml
 
       - name: Build documentation
         run: mkdocs build --strict

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,362 @@
+# Changelog
+
+Notable user-facing changes to the DuckDB BigQuery extension are recorded here.
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+No user-facing changes have been recorded since v0.12.0.
+
+## [0.12.0] - 2026-07-22 ([compare][0.12.0 diff])
+
+### Added
+
+- Added `bigquery_extract` for BigQuery table extract jobs ([#199]).
+- Expanded `bigquery_load` with CSV, newline-delimited JSON, Avro, ORC, Hive
+  partitioning, schema-update, and format-specific options ([#202]).
+- Added experimental aggregate pushdown, including grouped and distinct
+  aggregates and selected scalar expressions ([#204], [#206], [#207], [#208],
+  [#209], [#210]).
+
+### Changed
+
+- An attached dataset now becomes the default schema for its BigQuery catalog
+  ([#201]).
+- Updated the extension toolchain to DuckDB v1.5.4 ([#205]).
+
+### Fixed
+
+- Avoided a redundant Storage Read request at stream EOF ([#200]).
+- Fixed billing-project handling for `bigquery_query` dry runs ([#211]).
+
+## [0.11.0] - 2026-06-04 ([compare][0.11.0 diff])
+
+### Added
+
+- Added `destination_table`, `write_disposition`, and `create_disposition` to
+  `bigquery_execute` for query-to-table jobs ([#196]).
+- Added per-call `timeout_ms` support for BigQuery query polling ([#195]).
+
+### Changed
+
+- `ATTACH` now validates that configured credentials can obtain a token
+  ([#193]).
+- Updated the extension toolchain to DuckDB v1.5.3 ([#192]).
+
+### Fixed
+
+- DML operations return affected-row counts and avoid unnecessary scans
+  ([#188], [#189]).
+- Improved filter rendering, stale catalog rebinding, query polling, and
+  parallel Storage Read behavior ([#190], [#191], [#195], [#197]).
+
+## [0.10.0] - 2026-05-19 ([compare][0.10.0 diff])
+
+### Added
+
+- Added GCS URI sources, billing projects, and labels to `bigquery_load`
+  ([#178], [#179], [#182]).
+- Added OAuth authorized-user credentials to BigQuery secrets ([#181]).
+
+### Changed
+
+- Upgraded `google-cloud-cpp` to 2.47.1 ([#180]).
+
+### Fixed
+
+- Improved ADC metadata authentication, authentication timeouts, CA retry,
+  read-only catalog enforcement, catalog-cache stability, and Storage Write
+  startup retry ([#183], [#184], [#185], [#186], [#187]).
+
+## Earlier Releases
+
+### [0.9.0] - 2026-05-06 ([compare][0.9.0 diff])
+
+Introduced the `bigquery_load` job function and improved permission error
+handling ([#176], [#177]).
+
+### [0.8.1] - 2026-04-22 ([compare][0.8.1 diff])
+
+Improved protobuf write throughput with fail-fast error handling and windowed
+in-flight `AppendRows` requests ([#173], [#174], [#175]).
+
+### [0.8.0] - 2026-04-16 ([compare][0.8.0 diff])
+
+Removed the legacy scan implementation, added the REST fast path for
+`bigquery_query`, improved GEOGRAPHY normalization, and updated to DuckDB
+v1.5.2 ([#158], [#159], [#160], [#161], [#167], [#168], [#169], [#172]).
+
+### [0.7.4] - 2026-03-30 ([compare][0.7.4 diff])
+
+Improved GEOGRAPHY query handling, standardized BIGNUMERIC reads as `VARCHAR`,
+and updated to DuckDB v1.5.1 ([#153], [#154], [#156]).
+
+### [0.7.3] - 2026-03-28 ([compare][0.7.3 diff])
+
+Improved Storage Write throughput through buffered requests and cached column
+bindings ([#150], [#151]).
+
+### [0.7.2] - 2026-03-13 ([compare][0.7.2 diff])
+
+Updated to DuckDB v1.5.0, mapped BigQuery `GEOGRAPHY` directly to DuckDB
+`GEOMETRY('OGC:CRS84')`, and added positional parameters to `bigquery_query`
+([#138], [#146], [#148]).
+
+### [0.7.2_andium] - 2026-03-13 ([compare][0.7.2_andium diff])
+
+Published the positional-query-parameter work with a Windows build backport for
+the Andium compatibility line ([#146], [#148]).
+
+### [0.7.1] - 2026-02-21 ([compare][0.7.1 diff])
+
+Fixed polygon ring winding for GEOGRAPHY inserts ([#143]).
+
+### [0.7.0] - 2026-02-08 ([compare][0.7.0 diff])
+
+Added experimental `PARTITION BY`, `CLUSTER BY`, and `OPTIONS` parsing, fixed
+GEOGRAPHY table creation, and updated to DuckDB v1.4.4 ([#140], [#141],
+[#142]).
+
+### [0.6.3] - 2025-12-11 ([compare][0.6.3 diff])
+
+Updated to DuckDB v1.4.3 ([#137]).
+
+### [0.6.2] - 2025-11-16 ([compare][0.6.2 diff])
+
+Updated to DuckDB v1.4.2 and improved `AppendRows` request sizing and
+post-insert scans ([#135], [#136]).
+
+### [0.6.1] - 2025-11-02 ([compare][0.6.1 diff])
+
+Allowed catalog-load retries, fixed projected-column ordering, and added
+code-quality CI checks ([#127], [#129], [#131]).
+
+### [0.6.0] - 2025-10-18 ([compare][0.6.0 diff])
+
+Added DuckDB Secrets integration and clarified BIGNUMERIC limitations
+([#124], [#126]).
+
+### [0.5.1] - 2025-10-10 ([compare][0.5.1 diff])
+
+Added `dry_run` to `bigquery_query` and `bigquery_execute` and updated to
+DuckDB v1.4.1 ([#119], [#122]).
+
+### [0.5.0] - 2025-09-17 ([compare][0.5.0 diff])
+
+Added BigQuery GEOGRAPHY read/write support, expanded platform builds, and
+updated to DuckDB v1.4.0 ([#110], [#111], [#114], [#115]).
+
+### [0.4.2] - 2025-08-24 ([compare][0.4.2 diff])
+
+Made the Arrow-based reader the default `bigquery_scan` implementation and
+fixed billing-project job lookup ([#105], [#108]).
+
+### [0.4.1] - 2025-07-10 ([compare][0.4.1 diff])
+
+Updated to DuckDB v1.3.2 ([#100]).
+
+### [0.4.0] - 2025-06-20 ([compare][0.4.0 diff])
+
+Introduced the Arrow reader, parallel read streams, Arrow compression, and
+explicit Storage Read filters, and updated to DuckDB v1.3.1 ([#88], [#89],
+[#90], [#92], [#93], [#97]).
+
+### [0.3.1] - 2025-05-25 ([compare][0.3.1 diff])
+
+Updated to DuckDB v1.3.0 ([#87]).
+
+### [0.3.0] - 2025-04-29 ([compare][0.3.0 diff])
+
+Improved nested-structure support, removed inconsistent HUGEINT support,
+refactored complex type mapping, and added experimental BigQuery `OPTIONS`
+support ([#79], [#81], [#82], [#85]).
+
+### [0.2.2] - 2025-04-09 ([compare][0.2.2 diff])
+
+Updated to DuckDB v1.2.2 and refreshed extension CI integration ([#72], [#76],
+[#78]).
+
+### [0.2.1] - 2025-03-12 ([compare][0.2.1 diff])
+
+Updated to DuckDB v1.2.1 ([#71]).
+
+### [0.2.0] - 2025-02-06 ([compare][0.2.0 diff])
+
+Updated the BigQuery Control client, fixed catalog pagination and dataset
+selection, improved CA handling, and added configurable query timeouts ([#57],
+[#62], [#63], [#65], [#68]).
+
+### [0.1.2] - 2025-01-02 ([compare][0.1.2 diff])
+
+Improved NUMERIC and BIGNUMERIC support and optimized information-schema
+catalog queries ([#55], [#56]).
+
+### [0.1.1] - 2024-12-31 ([compare][0.1.1 diff])
+
+Updated to DuckDB v1.1.3, added parameterized data types, and improved CA
+bundle detection ([#49], [#51], [#52], [#53]).
+
+### [0.1.0] - 2024-11-03 (initial release)
+
+Introduced `bigquery_query`, `bigquery_jobs`, and faster BigQuery catalog
+loading.
+
+[Unreleased]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.12.0
+[0.11.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.11.0
+[0.10.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.10.0
+[0.9.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.9.0
+[0.8.1]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.8.1
+[0.8.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.8.0
+[0.7.4]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.7.4
+[0.7.3]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.7.3
+[0.7.2]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.7.2
+[0.7.2_andium]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.7.2_andium
+[0.7.1]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.7.1
+[0.7.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.7.0
+[0.6.3]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.6.3
+[0.6.2]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.6.2
+[0.6.1]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.6.1
+[0.6.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.6.0
+[0.5.1]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.5.1
+[0.5.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.5.0
+[0.4.2]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.4.2
+[0.4.1]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.4.1
+[0.4.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.4.0
+[0.3.1]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.3.1
+[0.3.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.3.0
+[0.2.2]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.2.2
+[0.2.1]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.2.1
+[0.2.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.2.0
+[0.1.2]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.1.2
+[0.1.1]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.1.1
+[0.1.0]: https://github.com/hafenkran/duckdb-bigquery/releases/tag/v0.1.0
+
+[0.12.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.11.0...v0.12.0
+[0.11.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.10.0...v0.11.0
+[0.10.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.9.0...v0.10.0
+[0.9.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.8.1...v0.9.0
+[0.8.1 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.8.0...v0.8.1
+[0.8.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.7.4...v0.8.0
+[0.7.4 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.7.3...v0.7.4
+[0.7.3 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.7.2...v0.7.3
+[0.7.2 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.7.1...v0.7.2
+[0.7.2_andium diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.7.2...v0.7.2_andium
+[0.7.1 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.7.0...v0.7.1
+[0.7.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.6.3...v0.7.0
+[0.6.3 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.6.2...v0.6.3
+[0.6.2 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.6.1...v0.6.2
+[0.6.1 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.6.0...v0.6.1
+[0.6.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.5.1...v0.6.0
+[0.5.1 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.5.0...v0.5.1
+[0.5.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.4.2...v0.5.0
+[0.4.2 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.4.1...v0.4.2
+[0.4.1 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.4.0...v0.4.1
+[0.4.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.3.1...v0.4.0
+[0.3.1 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.3.0...v0.3.1
+[0.3.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.2.2...v0.3.0
+[0.2.2 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.2.1...v0.2.2
+[0.2.1 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.2.0...v0.2.1
+[0.2.0 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.1.2...v0.2.0
+[0.1.2 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.1.1...v0.1.2
+[0.1.1 diff]: https://github.com/hafenkran/duckdb-bigquery/compare/v0.1.0...v0.1.1
+
+[#49]: https://github.com/hafenkran/duckdb-bigquery/pull/49
+[#51]: https://github.com/hafenkran/duckdb-bigquery/pull/51
+[#52]: https://github.com/hafenkran/duckdb-bigquery/pull/52
+[#53]: https://github.com/hafenkran/duckdb-bigquery/pull/53
+[#55]: https://github.com/hafenkran/duckdb-bigquery/pull/55
+[#56]: https://github.com/hafenkran/duckdb-bigquery/pull/56
+[#57]: https://github.com/hafenkran/duckdb-bigquery/pull/57
+[#62]: https://github.com/hafenkran/duckdb-bigquery/pull/62
+[#63]: https://github.com/hafenkran/duckdb-bigquery/pull/63
+[#65]: https://github.com/hafenkran/duckdb-bigquery/pull/65
+[#68]: https://github.com/hafenkran/duckdb-bigquery/pull/68
+[#71]: https://github.com/hafenkran/duckdb-bigquery/pull/71
+[#72]: https://github.com/hafenkran/duckdb-bigquery/pull/72
+[#76]: https://github.com/hafenkran/duckdb-bigquery/pull/76
+[#78]: https://github.com/hafenkran/duckdb-bigquery/pull/78
+[#79]: https://github.com/hafenkran/duckdb-bigquery/pull/79
+[#81]: https://github.com/hafenkran/duckdb-bigquery/pull/81
+[#82]: https://github.com/hafenkran/duckdb-bigquery/pull/82
+[#85]: https://github.com/hafenkran/duckdb-bigquery/pull/85
+[#87]: https://github.com/hafenkran/duckdb-bigquery/pull/87
+[#88]: https://github.com/hafenkran/duckdb-bigquery/pull/88
+[#89]: https://github.com/hafenkran/duckdb-bigquery/pull/89
+[#90]: https://github.com/hafenkran/duckdb-bigquery/pull/90
+[#92]: https://github.com/hafenkran/duckdb-bigquery/pull/92
+[#93]: https://github.com/hafenkran/duckdb-bigquery/pull/93
+[#97]: https://github.com/hafenkran/duckdb-bigquery/pull/97
+[#100]: https://github.com/hafenkran/duckdb-bigquery/pull/100
+[#105]: https://github.com/hafenkran/duckdb-bigquery/pull/105
+[#108]: https://github.com/hafenkran/duckdb-bigquery/pull/108
+[#110]: https://github.com/hafenkran/duckdb-bigquery/pull/110
+[#111]: https://github.com/hafenkran/duckdb-bigquery/pull/111
+[#114]: https://github.com/hafenkran/duckdb-bigquery/pull/114
+[#115]: https://github.com/hafenkran/duckdb-bigquery/pull/115
+[#119]: https://github.com/hafenkran/duckdb-bigquery/pull/119
+[#122]: https://github.com/hafenkran/duckdb-bigquery/pull/122
+[#124]: https://github.com/hafenkran/duckdb-bigquery/pull/124
+[#126]: https://github.com/hafenkran/duckdb-bigquery/pull/126
+[#127]: https://github.com/hafenkran/duckdb-bigquery/pull/127
+[#129]: https://github.com/hafenkran/duckdb-bigquery/pull/129
+[#131]: https://github.com/hafenkran/duckdb-bigquery/pull/131
+[#135]: https://github.com/hafenkran/duckdb-bigquery/pull/135
+[#136]: https://github.com/hafenkran/duckdb-bigquery/pull/136
+[#137]: https://github.com/hafenkran/duckdb-bigquery/pull/137
+[#138]: https://github.com/hafenkran/duckdb-bigquery/pull/138
+[#140]: https://github.com/hafenkran/duckdb-bigquery/pull/140
+[#141]: https://github.com/hafenkran/duckdb-bigquery/pull/141
+[#142]: https://github.com/hafenkran/duckdb-bigquery/pull/142
+[#143]: https://github.com/hafenkran/duckdb-bigquery/pull/143
+[#146]: https://github.com/hafenkran/duckdb-bigquery/pull/146
+[#148]: https://github.com/hafenkran/duckdb-bigquery/pull/148
+[#150]: https://github.com/hafenkran/duckdb-bigquery/pull/150
+[#151]: https://github.com/hafenkran/duckdb-bigquery/pull/151
+[#153]: https://github.com/hafenkran/duckdb-bigquery/pull/153
+[#154]: https://github.com/hafenkran/duckdb-bigquery/pull/154
+[#156]: https://github.com/hafenkran/duckdb-bigquery/pull/156
+[#158]: https://github.com/hafenkran/duckdb-bigquery/pull/158
+[#159]: https://github.com/hafenkran/duckdb-bigquery/pull/159
+[#160]: https://github.com/hafenkran/duckdb-bigquery/pull/160
+[#161]: https://github.com/hafenkran/duckdb-bigquery/pull/161
+[#167]: https://github.com/hafenkran/duckdb-bigquery/pull/167
+[#168]: https://github.com/hafenkran/duckdb-bigquery/pull/168
+[#169]: https://github.com/hafenkran/duckdb-bigquery/pull/169
+[#172]: https://github.com/hafenkran/duckdb-bigquery/pull/172
+[#173]: https://github.com/hafenkran/duckdb-bigquery/pull/173
+[#174]: https://github.com/hafenkran/duckdb-bigquery/pull/174
+[#175]: https://github.com/hafenkran/duckdb-bigquery/pull/175
+[#176]: https://github.com/hafenkran/duckdb-bigquery/pull/176
+[#177]: https://github.com/hafenkran/duckdb-bigquery/pull/177
+[#178]: https://github.com/hafenkran/duckdb-bigquery/pull/178
+[#179]: https://github.com/hafenkran/duckdb-bigquery/pull/179
+[#180]: https://github.com/hafenkran/duckdb-bigquery/pull/180
+[#181]: https://github.com/hafenkran/duckdb-bigquery/pull/181
+[#182]: https://github.com/hafenkran/duckdb-bigquery/pull/182
+[#183]: https://github.com/hafenkran/duckdb-bigquery/pull/183
+[#184]: https://github.com/hafenkran/duckdb-bigquery/pull/184
+[#185]: https://github.com/hafenkran/duckdb-bigquery/pull/185
+[#186]: https://github.com/hafenkran/duckdb-bigquery/pull/186
+[#187]: https://github.com/hafenkran/duckdb-bigquery/pull/187
+[#188]: https://github.com/hafenkran/duckdb-bigquery/pull/188
+[#189]: https://github.com/hafenkran/duckdb-bigquery/pull/189
+[#190]: https://github.com/hafenkran/duckdb-bigquery/pull/190
+[#191]: https://github.com/hafenkran/duckdb-bigquery/pull/191
+[#192]: https://github.com/hafenkran/duckdb-bigquery/pull/192
+[#193]: https://github.com/hafenkran/duckdb-bigquery/pull/193
+[#195]: https://github.com/hafenkran/duckdb-bigquery/pull/195
+[#196]: https://github.com/hafenkran/duckdb-bigquery/pull/196
+[#197]: https://github.com/hafenkran/duckdb-bigquery/pull/197
+[#200]: https://github.com/hafenkran/duckdb-bigquery/pull/200
+[#199]: https://github.com/hafenkran/duckdb-bigquery/pull/199
+[#201]: https://github.com/hafenkran/duckdb-bigquery/pull/201
+[#202]: https://github.com/hafenkran/duckdb-bigquery/pull/202
+[#204]: https://github.com/hafenkran/duckdb-bigquery/pull/204
+[#205]: https://github.com/hafenkran/duckdb-bigquery/pull/205
+[#206]: https://github.com/hafenkran/duckdb-bigquery/pull/206
+[#207]: https://github.com/hafenkran/duckdb-bigquery/pull/207
+[#208]: https://github.com/hafenkran/duckdb-bigquery/pull/208
+[#209]: https://github.com/hafenkran/duckdb-bigquery/pull/209
+[#210]: https://github.com/hafenkran/duckdb-bigquery/pull/210
+[#211]: https://github.com/hafenkran/duckdb-bigquery/pull/211

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Alternatively, you can authenticate using a service account. First, create a ser
 export GOOGLE_APPLICATION_CREDENTIALS="/path/to/my/service-account-credentials.json"
 
 # On Windows
-set GOOGLE_APPLICATION_CREDENTIALS="C:\path\to\my\service-account-credentials.json"
+set "GOOGLE_APPLICATION_CREDENTIALS=C:\path\to\my\service-account-credentials.json"
 ```
 
 On Dataproc, Compute Engine, GKE, and Cloud Run, no service-account key file is required when the runtime has an

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # DuckDB BigQuery Extension
 
+<p align="center">
+  <a href="https://duckdb.org/community_extensions/extensions/bigquery"><img alt="DuckDB Community Extension" src="https://img.shields.io/badge/DuckDB-Community%20Extension-FFF000?logo=duckdb&amp;logoColor=000"></a>
+  <a href="https://github.com/hafenkran/duckdb-bigquery/releases/latest"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hafenkran/duckdb-bigquery?label=Latest%20Release"></a>
+  <a href="https://github.com/hafenkran/duckdb-bigquery/actions/workflows/MainDistributionPipeline.yml"><img alt="Build and Test" src="https://img.shields.io/github/actions/workflow/status/hafenkran/duckdb-bigquery/MainDistributionPipeline.yml?branch=main&amp;label=Build"></a>
+  <a href="https://github.com/hafenkran/duckdb-bigquery/actions/workflows/docs.yml"><img alt="Documentation" src="https://img.shields.io/github/actions/workflow/status/hafenkran/duckdb-bigquery/docs.yml?branch=main&amp;label=Documentation"></a>
+  <a href="https://github.com/hafenkran/duckdb-bigquery/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/hafenkran/duckdb-bigquery?label=License"></a>
+</p>
+
 This community extension allows [DuckDB](https://duckdb.org) to query data from Google BigQuery using a mix of BigQuery Storage (Read/Write) and REST API. It enables users to access, manage, and manipulate their BigQuery datasets/tables directly from DuckDB using standard SQL queries. Inspired by official DuckDB RDBMS extensions like [MySQL](https://duckdb.org/docs/extensions/mysql.html), [PostgreSQL](https://github.com/duckdb/postgres_scanner), and [SQLite](https://github.com/duckdb/sqlite_scanner), this extension offers a similar feel. See [Important Notes](#important-notes-on-using-google-bigquery) for disclaimers and usage information.
 
 > This extension supports the following builds: `linux_amd64`, `linux_arm64`, `osx_amd64`, `osx_arm64`, and `windows_amd64`. The builds `wasm_mvp`, `wasm_eh`, `wasm_threads`, and `windows_amd64_mingw` are not supported.

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,2 @@
+mkdocs>=1.6.1,<2
+mkdocs-material>=9.7.7,<10

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,1 @@
+--8<-- "CHANGELOG.md"

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -1,0 +1,277 @@
+# Architecture
+
+The extension connects DuckDB's SQL engine and catalog to several BigQuery
+services. It is therefore not a single REST wrapper: DuckDB plans and executes
+the local parts of a statement, while the extension selects the appropriate
+BigQuery API for metadata, remote computation, or data transfer.
+
+A single operation may use more than one API. For example,
+`bigquery_query` starts a query through the BigQuery REST API and normally reads
+the resulting temporary table through the BigQuery Storage Read API.
+
+```text
+DuckDB SQL
+    |
+    +-- binder, planner, and attached BigQuery catalog
+    |       |
+    |       +-- BigQuery REST API -------- metadata, jobs, DDL, and DML
+    |       +-- Storage Read API (gRPC) --- BigQuery to DuckDB, as Arrow
+    |       +-- Storage Write API (gRPC) -- DuckDB to BigQuery, as protobuf
+    |
+    +-- DuckDB execution engine ---------- local operators and result vectors
+```
+
+The extension uses
+[`google-cloud-cpp`](https://cloud.google.com/cpp/docs/reference) to construct
+authenticated clients, configure REST and gRPC transports, apply retry policies,
+and work with the generated BigQuery request and response types. The extension
+itself remains responsible for DuckDB integration, SQL translation, catalog
+caching, parallel scan scheduling, and conversion between DuckDB, Arrow,
+protobuf, and BigQuery types.
+
+## Responsibilities by Layer
+
+| Layer | Responsibility |
+| --- | --- |
+| DuckDB | Parses SQL, binds names and types, builds plans, runs local operators, and exposes results as DuckDB vectors. |
+| Extension catalog and hooks | Maps BigQuery resources into DuckDB, intercepts supported DDL and DML, and chooses a remote execution path. |
+| `BigqueryClient` | Holds project, billing project, endpoints, and credentials; creates the required `google-cloud-cpp` clients for each operation. |
+| BigQuery REST API | Manages datasets and tables, submits and monitors jobs, executes GoogleSQL, and optionally returns query rows directly. |
+| BigQuery Storage Read API | Transfers table data and materialized query results to DuckDB using parallel gRPC streams and Arrow. |
+| BigQuery Storage Write API | Appends DuckDB rows to BigQuery using a bidirectional gRPC stream and protobuf messages. |
+
+## `google-cloud-cpp` and the Transports
+
+`google-cloud-cpp` is the client-library layer between the extension and Google
+Cloud. It does not decide whether work belongs in DuckDB or BigQuery; the
+extension makes that decision and then creates the appropriate library client:
+
+- the generated `bigquerycontrol_v2` dataset, table, and job clients use the
+  library's REST transport;
+- the generated `bigquery_storage_v1` read and write clients use gRPC; and
+- the common library supplies credentials, endpoints, retry and backoff
+  policies, status handling, and protobuf request and response types.
+
+This lets all API paths use the same extension configuration and authentication
+model without the extension implementing HTTP, OAuth, or gRPC framing itself.
+The REST and Storage APIs remain distinct BigQuery services with different
+purposes, permissions, quotas, and network behavior.
+
+## BigQuery APIs
+
+### BigQuery REST API
+
+The extension uses the [BigQuery v2 REST API](https://cloud.google.com/bigquery/docs/reference/rest)
+as its control plane. Calls are made through the REST transport of the
+`google-cloud-cpp` BigQuery control clients.
+
+The REST path handles:
+
+- listing and reading dataset and table metadata;
+- submitting GoogleSQL DDL jobs that create, alter, and delete datasets and
+  tables;
+- submitting and polling query, load, and extract jobs;
+- running translated DDL, `UPDATE`, and `DELETE` statements as GoogleSQL jobs;
+- listing jobs and retrieving their status and statistics; and
+- returning paginated query rows when `bigquery_query(..., use_rest_api := true)`
+  is selected.
+
+REST is used for coordination even when it does not carry the result data. A
+query can be submitted and monitored over REST before its result is transferred
+through Storage Read.
+
+### BigQuery Storage Read API
+
+The [BigQuery Storage Read API](https://cloud.google.com/bigquery/docs/reference/storage)
+is the main high-throughput path from BigQuery to DuckDB. The extension creates
+a read session for a BigQuery table, requests Arrow as the wire format, and asks
+BigQuery for one or more read streams.
+
+At session creation, the extension can pass:
+
+- the columns required by the DuckDB plan;
+- supported filters as a BigQuery row restriction; and
+- a maximum number of streams based on the available DuckDB execution threads.
+
+DuckDB workers consume the returned streams in parallel. Arrow record batches
+are exposed through the Arrow C Data Interface and converted into DuckDB
+vectors. Any type-specific post-processing is applied after the batches enter
+DuckDB.
+
+Storage Read reads table storage; it does not execute arbitrary GoogleSQL or
+manage datasets, tables, and jobs. Consequently, a direct native-table scan can
+use Storage Read without creating a query job, while a GoogleSQL query must be
+executed first and produces a table that Storage Read can consume.
+
+### BigQuery Storage Write API
+
+The extension uses the [BigQuery Storage Write API](https://cloud.google.com/bigquery/docs/write-api)
+for attached `INSERT` and `CREATE TABLE AS` data transfer. DuckDB produces
+`DataChunk` values, and the extension builds a protobuf schema and serializes
+the rows into protobuf messages.
+
+Writes use an application-created pending stream:
+
+1. `CreateWriteStream` creates the pending stream.
+2. `AppendRows` sends batches over a bidirectional gRPC connection.
+3. `FinalizeWriteStream` closes the stream for further appends.
+4. `BatchCommitWriteStreams` makes the pending rows visible in BigQuery.
+
+The extension can keep several append requests in flight while preserving their
+order. Pending streams provide an atomic commit boundary for the rows sent to
+that stream. This boundary belongs to BigQuery, however, and is not a rollback
+mechanism for a surrounding DuckDB transaction.
+
+## Connection and Authentication
+
+Direct functions such as `bigquery_scan` build a connection configuration from
+their arguments. Operations on an attached database reuse the configuration of
+its `BigqueryCatalog`, including the project, optional dataset, billing project,
+API endpoints, and access mode.
+
+Each DuckDB transaction on an attached BigQuery catalog owns a shared
+`BigqueryClient`. This keeps metadata calls, jobs, and storage sessions within
+that transaction on the same configuration. It does not turn remote BigQuery
+operations into DuckDB transactions: once a remote DDL, DML, or committed write
+has succeeded, a later DuckDB rollback cannot undo it.
+
+For both REST and gRPC, the client first looks for a matching DuckDB BigQuery
+secret. If none is available, it uses Google Application Default Credentials.
+The resulting Google Cloud credentials are shared by the API paths, although
+REST and gRPC can have separate endpoint settings. See
+[Authentication & Secrets](../getting-started/authentication-and-secrets.md) for the supported
+credential providers.
+
+## Attached Catalog and Planning
+
+An attached BigQuery database presents remote resources as DuckDB catalog
+objects:
+
+| BigQuery | DuckDB |
+| --- | --- |
+| Project or attached dataset scope | Attached database |
+| Dataset | Schema |
+| Table | Table catalog entry |
+| BigQuery column type | DuckDB logical type |
+
+During binding, the extension resolves the remote object and retrieves enough
+metadata to expose its columns and types to DuckDB. Metadata is cached in the
+attached catalog. Catalog discovery can fetch individual resources through
+REST, or use the optional `INFORMATION_SCHEMA` optimization, which submits a
+metadata query job for a dataset and caches the returned table information.
+
+DDL and DML statements pass through extension hooks. The extension converts
+supported DuckDB statements and expressions to GoogleSQL, while ordinary local
+operators remain in the DuckDB plan. A connection callback can clear stale
+metadata and request one rebind when a remote schema change causes a missing
+column error.
+
+## Execution Paths
+
+The operation determines which services participate in execution:
+
+| DuckDB operation | Remote execution | Data transfer |
+| --- | --- | --- |
+| Attached table `SELECT` or `bigquery_scan` | No query job for a native table scan | Storage Read API |
+| `bigquery_query` | GoogleSQL query job through REST | Storage Read API by default |
+| `bigquery_query(..., use_rest_api := true)` | GoogleSQL through REST with optional job creation | Paginated REST rows |
+| Attached `INSERT` | DuckDB executes the input plan | Storage Write API |
+| `CREATE TABLE AS` | A GoogleSQL DDL job through REST creates the table; DuckDB executes the input plan | Storage Write API |
+| Attached DDL, `UPDATE`, or `DELETE` | Translated GoogleSQL job through REST | Job status and affected-row statistics through REST |
+| `bigquery_load` or `bigquery_extract` | BigQuery load or extract job through REST | BigQuery or Cloud Storage performs the bulk transfer |
+| `bigquery_jobs` | Job listing or lookup through REST | REST metadata |
+
+### Native Table Read
+
+For `bigquery_scan` and a scan of an attached native table:
+
+1. The binder obtains table metadata and maps the schema to DuckDB types.
+2. DuckDB determines the required columns and applicable filters.
+3. The extension creates a Storage Read session with projection and row
+   restrictions.
+4. BigQuery returns one or more Arrow streams.
+5. DuckDB schedules those streams across workers and consumes the resulting
+   vectors in the rest of the local plan.
+
+Logical views and external tables require BigQuery to execute their defining
+logic, so they are not equivalent to a direct native-table Storage Read scan.
+
+### GoogleSQL Query
+
+The default `bigquery_query` flow has a control phase and a transfer phase:
+
+1. The extension submits GoogleSQL through the REST API with job creation
+   required.
+2. BigQuery executes the query and materializes its result in a destination
+   table.
+3. The extension retrieves the destination table reference from the completed
+   job.
+4. The normal Storage Read path reads that table into DuckDB.
+
+With `use_rest_api := true`, the extension instead requests optional job
+creation and decodes rows from the REST response and any following result
+pages. This avoids Storage Read session setup, but is intended for result sets
+that fit the REST-oriented path.
+
+### Insert and Create Table As
+
+For an attached `INSERT`, DuckDB runs the statement's input plan locally. The
+extension receives the produced chunks, maps the destination schema to
+protobuf, and appends the encoded rows through Storage Write. `CREATE TABLE AS`
+first creates the remote table with a GoogleSQL DDL job submitted through REST
+and then uses the same insert sink.
+
+This is deliberately different from `UPDATE` and `DELETE`: those statements
+are translated as whole statements and executed by BigQuery as GoogleSQL jobs,
+rather than streaming changed rows from DuckDB.
+
+### Jobs, Load, and Extract
+
+Query, DDL, DML, load, and extract operations use BigQuery jobs. The extension
+constructs the job configuration, submits it over REST, polls its state, maps
+errors to DuckDB exceptions, and returns selected statistics or status fields.
+
+For load and extract jobs, the bulk bytes do not pass through DuckDB result
+vectors. BigQuery reads the configured source or writes the destination in
+Cloud Storage. A local file is uploaded with the load-job request. A DuckDB
+table source is first materialized as a temporary Parquet file and then follows
+that upload path.
+
+## Pushdown and Execution Ownership
+
+The boundary between DuckDB and BigQuery depends on which parts of a plan can
+be represented remotely:
+
+- Column projection and supported filters can be pushed into a Storage Read
+  session, reducing the data sent to DuckDB.
+- Supported aggregate plans can be rewritten as GoogleSQL. In that case,
+  BigQuery performs the aggregation as a query job and DuckDB reads the result.
+- Operators that are not pushed down continue to run in DuckDB after the remote
+  scan.
+- DDL, `UPDATE`, and `DELETE` are translated and owned by BigQuery as complete
+  remote statements.
+
+This distinction matters for performance and observability. A native scan may
+show Storage Read activity without a BigQuery query job, whereas an aggregate
+pushdown or `bigquery_query` creates a job before any result transfer begins.
+
+## Data Conversion Boundaries
+
+There are three primary representations at the DuckDB–BigQuery boundary:
+
+- **Arrow** for Storage Read responses and the efficient conversion of
+  columnar batches into DuckDB vectors.
+- **Protocol buffers** for rows sent through Storage Write.
+- **BigQuery REST response messages** for metadata, job information, and the
+  optional paginated query-result path.
+
+The extension also converts DuckDB expressions and statements to GoogleSQL for
+remote execution. Type mappings are not always one-to-one; nested values,
+high-precision numerics, and `GEOGRAPHY` require specific handling. See
+[Data Type Mapping](data-types.md) for the general conversion rules and
+[Working with Geometries](../user-guide/geometry-support.md) for the `GEOGRAPHY` boundary.
+
+For task-oriented examples, continue with
+[Reading & Queries](../user-guide/reading-and-queries.md),
+[Writing & Modifying Data](../user-guide/writing.md), or
+[Executing & Monitoring Jobs](../user-guide/jobs-and-transfers.md).

--- a/docs/concepts/data-types.md
+++ b/docs/concepts/data-types.md
@@ -1,0 +1,79 @@
+# Data Type Mapping
+
+The extension maps BigQuery schemas to DuckDB types for reads and converts
+DuckDB types to BigQuery types for attached table creation and writes.
+
+## BigQuery to DuckDB
+
+| BigQuery | DuckDB | Notes |
+| --- | --- | --- |
+| `BOOL` | `BOOLEAN` | Direct mapping |
+| `INT64` | `BIGINT` | BigQuery has one signed integer type |
+| `FLOAT64` | `DOUBLE` | Direct mapping |
+| `NUMERIC(p,s)` | `DECIMAL(p,s)` | DuckDB precision must not exceed 38 |
+| `BIGNUMERIC` | `VARCHAR` | BigQuery precision exceeds DuckDB `DECIMAL` |
+| `STRING` | `VARCHAR` | Parameterized strings are accepted |
+| `JSON` | `VARCHAR` | JSON text |
+| `BYTES` | `BLOB` | Binary data |
+| `DATE` | `DATE` | Direct mapping |
+| `TIME` | `TIME` | Microsecond precision |
+| `DATETIME` | `TIMESTAMP` | No time-zone component |
+| `TIMESTAMP` | `TIMESTAMP` | BigQuery timestamps are UTC |
+| `INTERVAL` | `INTERVAL` | Direct semantic mapping |
+| `GEOGRAPHY` | `GEOMETRY('OGC:CRS84')` | WKT interchange |
+| `ARRAY<T>` | `LIST<T>` | Element types are mapped recursively |
+| `STRUCT<...>` | `STRUCT(...)` | Fields are mapped recursively |
+
+## DuckDB to BigQuery
+
+| DuckDB | BigQuery | Notes |
+| --- | --- | --- |
+| `BOOLEAN` | `BOOL` | Direct mapping |
+| signed integers through `BIGINT` | `INT64` | All widths map to `INT64` |
+| `UTINYINT`, `USMALLINT`, `UINTEGER` | `INT64` | Values fit in signed `INT64` |
+| `FLOAT`, `DOUBLE` | `FLOAT64` | Direct mapping |
+| `DECIMAL` | `NUMERIC` | BigQuery `NUMERIC` limits apply |
+| `VARCHAR`, `UUID` | `STRING` | UUID is serialized as text |
+| `BLOB` | `BYTES` | Binary data |
+| `DATE`, `TIME` | `DATE`, `TIME` | Direct mapping |
+| `TIMESTAMP`, `TIMESTAMP_S`, `TIMESTAMP_MS` | `TIMESTAMP` | Normalized to BigQuery timestamp precision |
+| `INTERVAL` | `INTERVAL` | Serialized as a BigQuery interval |
+| `GEOMETRY` | `GEOGRAPHY` | Normalized to BigQuery-compatible winding |
+| `LIST<T>`, `ARRAY<T>` | `ARRAY<T>` | Nested arrays are rejected |
+| `STRUCT(...)` | `STRUCT<...>` | Fields are mapped recursively |
+
+`HUGEINT`, `UHUGEINT`, `UBIGINT`, `TIMESTAMP_TZ`, and `TIMESTAMP_NS` are not
+supported for attached BigQuery table creation. Convert them explicitly before
+writing.
+
+## BIGNUMERIC and Arrays
+
+BigQuery `BIGNUMERIC` has precision 76 and scale 38: up to 38 digits before and
+38 digits after the decimal point. DuckDB `DECIMAL` supports at most 38 digits
+in total, so the full `BIGNUMERIC` range cannot be represented losslessly and
+is read as exact `VARCHAR`. For writes, prefer quoted exact decimal text or an
+appropriate `DECIMAL` rather than floating-point literals.
+
+BigQuery does not support arrays of arrays. A DuckDB list whose child is
+another list or fixed array is rejected during schema conversion.
+
+The `use_rest_api := true` query path decodes BigQuery `ARRAY` and `STRUCT`
+results recursively as DuckDB `LIST` and `STRUCT` values. DuckDB-specific
+`MAP` and `UNION` types are not part of BigQuery result schemas.
+
+## Geometry and Geography
+
+BigQuery `GEOGRAPHY` maps to DuckDB `GEOMETRY('OGC:CRS84')`, and DuckDB
+`GEOMETRY` maps back to BigQuery `GEOGRAPHY`. The extension uses WKT at the API
+boundary and normalizes polygon topology before Storage Write operations.
+
+Since DuckDB 1.5.0, `GEOMETRY` is a built-in DuckDB type and does not require
+the `spatial` extension. Most spatial analysis and transformation functions
+still require `spatial`.
+
+See [Working with Geometries](../user-guide/geometry-support.md) for the read and write flows, CRS
+requirements, polygon normalization, and the semantic difference between
+DuckDB's Cartesian geometry and BigQuery's spherical geography.
+
+Continue with [Managing Tables & Datasets](../user-guide/managing-tables-and-schemas.md),
+or [Writing & Modifying Data](../user-guide/writing.md).

--- a/docs/concepts/index.md
+++ b/docs/concepts/index.md
@@ -1,0 +1,17 @@
+# Concepts
+
+This section explains the ideas behind the extension rather than individual
+SQL workflows. Use it to understand how DuckDB connects its catalog and
+execution engine to BigQuery, which BigQuery APIs handle reads and writes, and
+how values cross the boundary between both type systems.
+
+- [Architecture](architecture.md) explains how DuckDB, the attached catalog,
+  `google-cloud-cpp`, the BigQuery REST API, and the Storage Read and Write APIs
+  work together.
+- [Data Type Mapping](data-types.md) documents bidirectional
+  schema conversion, nested and unsupported types, `BIGNUMERIC`, and
+  `GEOGRAPHY` interchange.
+
+For task-oriented instructions, return to the [User Guide](../user-guide/attach.md). For
+complete SQL signatures and options, use the
+[Function Reference](../function-reference/index.md).

--- a/docs/function-reference/bigquery-attach.md
+++ b/docs/function-reference/bigquery-attach.md
@@ -1,0 +1,71 @@
+# `bigquery_attach`
+
+Enumerates the native tables in one BigQuery dataset and creates local DuckDB
+views backed by `bigquery_scan`.
+
+!!! note "Compatibility helper"
+
+    Prefer [`ATTACH ... (TYPE bigquery)`](../user-guide/attach.md)
+    for catalog, transaction, DDL, and write integration.
+
+## Signature
+
+```sql
+CALL bigquery_attach(
+    'PROJECT.DATASET',
+    overwrite := false
+);
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `dataset` | `VARCHAR` | required | Project and dataset identifier. |
+| `overwrite` | `BOOLEAN` | `false` | Replace colliding local views. |
+
+## Example
+
+The current implementation emits no row. The output below comes from
+querying one of the local views it creates. Because the view name is the fully
+qualified BigQuery table identifier, quote it as one DuckDB identifier.
+
+```sql
+-- Create local compatibility views for the dataset's native tables.
+CALL bigquery_attach(
+      'my-gcp-project.quacking_dataset',
+      overwrite := false
+  );
+
+-- Query one of the generated local views.
+SELECT
+      i,
+      s
+  FROM "my-gcp-project.quacking_dataset.duck_tbl"
+  ORDER BY i;
+┌───────┬────────────────┐
+│   i   │       s        │
+│ int64 │    varchar     │
+├───────┼────────────────┤
+│    12 │ quack 🦆       │
+│    13 │ quack quack 🦆 │
+└───────┴────────────────┘
+```
+
+## Result and Behavior
+
+The function declares one `Success BOOLEAN` result column. The current
+implementation performs the view-creation side effects but emits no row, so
+invoke it with `CALL`.
+
+Reading the created views uses `bigquery_scan` and therefore inherits its
+Storage Read permissions, cost, and native-table limitations. The function
+uses the direct project's default credentials and endpoints; it does not reuse
+an attached catalog.
+
+Typical errors include an identifier other than `project.dataset`, failed
+dataset discovery, missing permissions, and a local view-name collision when
+`overwrite=false`.
+
+See [ATTACH](../user-guide/attach.md) for
+the recommended attachment workflow.

--- a/docs/function-reference/bigquery-clear-cache.md
+++ b/docs/function-reference/bigquery-clear-cache.md
@@ -1,0 +1,44 @@
+# `bigquery_clear_cache`
+
+Clears the extension's local metadata caches for every attached BigQuery
+catalog.
+
+## Signature
+
+```sql
+CALL bigquery_clear_cache();
+```
+
+## Parameters
+
+This function takes no arguments.
+
+## Example
+
+`bigquery_clear_cache` returns one row after clearing every attached BigQuery
+catalog's local metadata cache.
+
+```sql
+-- Clear local metadata caches for all attached BigQuery catalogs.
+CALL bigquery_clear_cache();
+┌─────────┐
+│ success │
+│ boolean │
+├─────────┤
+│ true    │
+└─────────┘
+```
+
+## Result
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `success` | `BOOLEAN` | `true` after local cache invalidation completes. |
+
+The function does not issue a BigQuery query, delete remote resources, detach
+catalogs, or clear BigQuery's query-result cache. Calling it without an
+attached BigQuery catalog is valid. Later catalog access can issue fresh
+metadata requests.
+
+See [Refresh Metadata](../user-guide/attach.md#refresh-metadata-and-detach)
+for the surrounding catalog workflow.

--- a/docs/function-reference/bigquery-execute.md
+++ b/docs/function-reference/bigquery-execute.md
@@ -1,0 +1,108 @@
+# `bigquery_execute`
+
+Runs GoogleSQL and returns execution metadata instead of query rows. It is
+intended for DDL, DML, scripts, and materializing a query into a destination
+table.
+
+For task-oriented examples and alternatives through attached SQL, see
+[Execute GoogleSQL](../user-guide/jobs-and-transfers.md#execute-googlesql).
+
+## Signature
+
+```sql
+SELECT *
+  FROM bigquery_execute(
+      'PROJECT_OR_CATALOG',
+      'GOOGLESQL',
+      dry_run := false,
+      timeout_ms := 0,
+      destination_table := 'DATASET.TABLE',
+      write_disposition := 'WRITE_TRUNCATE',
+      create_disposition := 'CREATE_IF_NEEDED',
+      api_endpoint := 'BIGQUERY_REST_ENDPOINT',
+      grpc_endpoint := 'BIGQUERY_GRPC_ENDPOINT'
+  );
+```
+
+Use `CALL bigquery_execute(...)` when the result row is not needed.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `project_or_catalog` | `VARCHAR` | required | Google Cloud project ID or attached BigQuery catalog. |
+| `sql` | `VARCHAR` | required | GoogleSQL statement, query, or script. |
+| `dry_run` | `BOOLEAN` | `false` | Validate and estimate without executing. |
+| `timeout_ms` | `BIGINT` | `bq_query_timeout_ms` | Maximum local wait; `0` waits indefinitely. |
+| `destination_table` | `VARCHAR` | none | `dataset.table` or `project.dataset.table` for query materialization. |
+| `write_disposition` | `VARCHAR` | `WRITE_TRUNCATE` | `WRITE_TRUNCATE`, `WRITE_APPEND`, or `WRITE_EMPTY`. |
+| `create_disposition` | `VARCHAR` | `CREATE_IF_NEEDED` | `CREATE_IF_NEEDED` or `CREATE_NEVER`. |
+| `api_endpoint` | `VARCHAR` | Google default | BigQuery REST endpoint override. |
+| `grpc_endpoint` | `VARCHAR` | Google default | BigQuery gRPC endpoint override stored in the direct-call configuration. |
+
+`destination_table` cannot be combined with `dry_run`. Disposition values are
+used only with a destination.
+
+The function has no `billing_project` parameter. Use a catalog configured with
+`billing_project` when billing should use another project. An attached catalog
+must be read-write and supplies its own endpoints, so function-level endpoint
+overrides are rejected for catalog calls.
+
+## Example
+
+A dry run validates the GoogleSQL and returns an estimate without executing
+the statement. Selecting stable checks keeps the output useful even though
+the concrete location can vary by project.
+
+```sql
+-- Validate a query and inspect its estimated execution metadata.
+SELECT
+      total_bytes_processed = 0 AS no_bytes_processed,
+      NOT cache_hit AS cache_miss,
+      location <> '' AS has_location
+  FROM bigquery_execute(
+      'my-gcp-project',
+      'SELECT 1 AS id',
+      dry_run := true
+  );
+┌────────────────────┬────────────┬──────────────┐
+│ no_bytes_processed │ cache_miss │ has_location │
+│      boolean       │  boolean   │   boolean    │
+├────────────────────┼────────────┼──────────────┤
+│ true               │ true       │ true         │
+└────────────────────┴────────────┴──────────────┘
+```
+
+## Result
+
+Normal execution returns one row:
+
+| Column | Type |
+| --- | --- |
+| `success` | `BOOLEAN` |
+| `job_id` | `VARCHAR` |
+| `project_id` | `VARCHAR` |
+| `location` | `VARCHAR` |
+| `total_rows` | `UBIGINT` |
+| `total_bytes_processed` | `BIGINT` |
+| `num_dml_affected_rows` | `BIGINT` |
+
+Fields BigQuery does not report for a statement can be `NULL`.
+
+A dry run instead returns:
+
+| Column | Type |
+| --- | --- |
+| `total_bytes_processed` | `BIGINT` |
+| `cache_hit` | `BOOLEAN` |
+| `location` | `VARCHAR` |
+
+## Errors and Timeouts
+
+Typical errors include invalid GoogleSQL, a read-only catalog, missing job or
+destination-table permissions, a disposition without `destination_table`,
+combining `destination_table` with `dry_run`, and conflicting endpoints for an
+attached catalog.
+
+`timeout_ms` stops local waiting but does not guarantee cancellation. Inspect
+submitted work with [`bigquery_jobs`](bigquery-jobs.md).

--- a/docs/function-reference/bigquery-extract.md
+++ b/docs/function-reference/bigquery-extract.md
@@ -1,0 +1,112 @@
+# `bigquery_extract`
+
+Creates an extract job that exports one BigQuery table to one or more Cloud
+Storage objects.
+
+For export workflows and examples, see
+[Extract Data](../user-guide/extract-and-load.md#extract-data).
+
+## Signature
+
+```sql
+SELECT *
+  FROM bigquery_extract(
+      'PROJECT_OR_CATALOG',
+      source_table := 'DATASET.TABLE',
+      destination_uris := ['gs://bucket/export-*.parquet'],
+      format := 'PARQUET',
+      compression := 'ZSTD',
+      api_endpoint := 'BIGQUERY_REST_ENDPOINT'
+  );
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `project_or_catalog` | `VARCHAR` | required | Google Cloud project ID or attached BigQuery catalog. |
+| `source_table` | `VARCHAR` | required | `dataset.table` or qualified BigQuery table identifier. |
+| `destination_uris` | `VARCHAR` or `LIST<VARCHAR>` | required | One or more nonempty `gs://` destinations. |
+| `format` | `VARCHAR` | inferred | `CSV`, `JSON`, `NEWLINE_DELIMITED_JSON`, `AVRO`, or `PARQUET`. |
+| `compression` | `VARCHAR` | BigQuery default | Format-compatible compression. |
+| `csv_print_header` | `BOOLEAN` | BigQuery default | Include a CSV header; CSV only. |
+| `csv_field_delimiter` | `VARCHAR` | BigQuery default | CSV field delimiter; CSV only. |
+| `avro_use_logical_types` | `BOOLEAN` | BigQuery default | Use Avro logical types; Avro only. |
+| `location` | `VARCHAR` | `bq_default_location` | BigQuery job location. |
+| `labels` | `MAP(VARCHAR, VARCHAR)` | none | Job labels. |
+| `billing_project` | `VARCHAR` | project | Consumer project for a direct project call. |
+| `timeout_ms` | `BIGINT` | `bq_query_timeout_ms` | Maximum local wait; `0` waits indefinitely. |
+| `api_endpoint` | `VARCHAR` | Google default | BigQuery REST endpoint override for a direct project call. |
+
+`JSON` is normalized to `NEWLINE_DELIMITED_JSON`. Without `format`, every URI
+must imply the same format from `.csv`, `.csv.gz`, `.json`, `.json.gz`,
+`.avro`, or `.parquet`.
+
+For an attached catalog, `billing_project` and `api_endpoint` are rejected;
+configure them in `ATTACH`. The attachment must be read-write.
+
+## Compression
+
+| Format | Allowed values |
+| --- | --- |
+| CSV | `NONE`, `GZIP` |
+| Newline-delimited JSON | `NONE`, `GZIP` |
+| Avro | `NONE`, `DEFLATE`, `SNAPPY` |
+| Parquet | `NONE`, `GZIP`, `SNAPPY`, `ZSTD` |
+
+## Example
+
+The example exports the table used on the Home page. BigQuery writes the
+objects to Cloud Storage; replace the project and bucket placeholders before
+running it.
+
+```sql
+-- Attach the source dataset and reuse its connection configuration.
+ATTACH
+    'project=my-gcp-project dataset=quacking_dataset'
+  AS bq (TYPE bigquery);
+
+-- Submit the extract job and inspect stable result fields.
+SELECT
+      success,
+      format,
+      input_bytes >= 0 AS has_input_stats
+  FROM bigquery_extract(
+      'bq',
+      source_table := 'quacking_dataset.duck_tbl',
+      destination_uris := 'gs://my-bucket/exports/ducks-*.parquet',
+      format := 'PARQUET'
+  );
+┌─────────┬─────────┬─────────────────┐
+│ success │ format  │ has_input_stats │
+│ boolean │ varchar │     boolean     │
+├─────────┼─────────┼─────────────────┤
+│ true    │ PARQUET │ true            │
+└─────────┴─────────┴─────────────────┘
+```
+
+## Result
+
+| Column | Type |
+| --- | --- |
+| `success` | `BOOLEAN` |
+| `job_id` | `VARCHAR` |
+| `project_id` | `VARCHAR` |
+| `location` | `VARCHAR` |
+| `source_table` | `VARCHAR` |
+| `destination_uris` | `VARCHAR[]` |
+| `format` | `VARCHAR` |
+| `destination_uri_file_counts` | `BIGINT[]` |
+| `input_bytes` | `BIGINT` |
+| `status` | `JSON` |
+
+Job-statistics fields can be `NULL` when BigQuery does not report them.
+
+## Errors and Timeouts
+
+The source must be a table; arbitrary query text is not accepted. Typical
+errors include missing or non-GCS destination URIs, incompatible format and
+compression combinations, conflicting inferred URI formats, a read-only
+catalog, and insufficient source-table or Cloud Storage permissions.
+
+A timed-out extract job can continue remotely and write Cloud Storage objects.

--- a/docs/function-reference/bigquery-jobs.md
+++ b/docs/function-reference/bigquery-jobs.md
@@ -1,0 +1,108 @@
+# `bigquery_jobs`
+
+Lists BigQuery jobs or retrieves one job by ID. The function performs metadata
+requests and does not create a query job.
+
+For dry-run and monitoring workflows, see
+[Monitor Jobs](../user-guide/jobs-and-transfers.md#monitor-jobs).
+
+## Signature
+
+```sql
+SELECT *
+  FROM bigquery_jobs(
+      'PROJECT_OR_CATALOG',
+      jobId := 'JOB_ID',
+      allUsers := false,
+      maxResults := 1000,
+      minCreationTime := '2026-01-01 00:00:00',
+      maxCreationTime := '2026-02-01 00:00:00',
+      stateFilter := 'DONE',
+      parentJobId := 'PARENT_JOB_ID',
+      api_endpoint := 'BIGQUERY_REST_ENDPOINT'
+  );
+```
+
+Parameter names mirror the official
+[`jobs.list` API](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/list)
+and intentionally use camel case.
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `project_or_catalog` | `VARCHAR` | required | Google Cloud project ID or attached BigQuery catalog. |
+| `jobId` | `VARCHAR` | none | Retrieve one job instead of listing jobs. |
+| `allUsers` | `BOOLEAN` | BigQuery default | Include other users' jobs when permitted. |
+| `maxResults` | `INTEGER` | `1000` | Maximum rows to collect. |
+| `minCreationTime` | `VARCHAR` | none | Timestamp-like lower creation-time bound. |
+| `maxCreationTime` | `VARCHAR` | none | Timestamp-like upper creation-time bound. |
+| `stateFilter` | `VARCHAR` | none | `DONE`, `PENDING`, or `RUNNING`, case-insensitive. |
+| `parentJobId` | `VARCHAR` | none | List child jobs for a script or parent job. |
+| `api_endpoint` | `VARCHAR` | Google default | BigQuery REST endpoint override for a direct project call. |
+
+An attached catalog supplies its own REST endpoint. Do not combine a catalog
+name with the function-level `api_endpoint` parameter.
+
+## Example
+
+Store the metadata returned by `bigquery_execute`, then use its job ID to find
+the corresponding job. This is the same list-and-filter flow covered by the
+jobs SQLLogicTest.
+
+```sql
+-- Submit a query and retain its returned job ID.
+CREATE TEMP TABLE submitted_job AS
+SELECT *
+  FROM bigquery_execute(
+      'my-gcp-project',
+      'SELECT 1 AS result'
+  );
+
+-- Locate the submitted job in recent job metadata.
+SELECT
+      state,
+      job_type,
+      status
+  FROM bigquery_jobs(
+      'my-gcp-project',
+      maxResults := 10
+  )
+  WHERE job_id = (SELECT job_id FROM submitted_job);
+┌───────────┬──────────┬──────────────────┐
+│   state   │ job_type │      status      │
+│  varchar  │ varchar  │       json       │
+├───────────┼──────────┼──────────────────┤
+│ Completed │ QUERY    │ {"state":"DONE"} │
+└───────────┴──────────┴──────────────────┘
+```
+
+## Result
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `state` | `VARCHAR` | Mapped state such as `Completed`, `Error`, `Queued`, or `Active`. |
+| `job_id` | `VARCHAR` | Job ID. |
+| `project` | `VARCHAR` | Job project. |
+| `location` | `VARCHAR` | Job location. |
+| `creation_time` | `TIMESTAMP` | Creation time. |
+| `start_time` | `TIMESTAMP` | Start time. |
+| `end_time` | `TIMESTAMP` | End time. |
+| `duration_ms` | `INTERVAL` | Elapsed interval. |
+| `bytes_processed` | `BIGINT` | Processed bytes when available. |
+| `total_slot_time_ms` | `BIGINT` | Total slot milliseconds when available. |
+| `user_email` | `VARCHAR` | Job owner email when visible. |
+| `principal_subject` | `VARCHAR` | Principal subject when visible. |
+| `job_type` | `VARCHAR` | Query, load, extract, or another job type. |
+| `statistics` | `JSON` | Full BigQuery statistics object. |
+| `configuration` | `JSON` | Full job configuration object. |
+| `status` | `JSON` | Full job status object. |
+
+Fields that BigQuery omits can be `NULL`. Listing other users' jobs requires
+the corresponding IAM permission.
+
+## Errors
+
+Typical errors include an unknown `jobId`, invalid state or time filters,
+missing `jobs.list` or `jobs.listAll` permissions, and a function-level
+endpoint combined with an attached catalog.

--- a/docs/function-reference/bigquery-load.md
+++ b/docs/function-reference/bigquery-load.md
@@ -1,0 +1,173 @@
+# `bigquery_load`
+
+Creates a BigQuery load job from exactly one source family: a local file,
+Cloud Storage URIs, or a DuckDB table or view.
+
+For complete import workflows, see
+[Load Data](../user-guide/extract-and-load.md#load-data).
+
+## Signature
+
+```sql
+SELECT *
+  FROM bigquery_load(
+      'PROJECT_OR_CATALOG',
+      'DATASET.TABLE',
+      source_file := '/path/input.parquet'
+      -- or source_uris := ['gs://bucket/input-*.parquet']
+      -- or source_table := 'duckdb_table'
+  );
+```
+
+The first two positional arguments are required.
+
+## Positional Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `project_or_catalog` | `VARCHAR` | required | Google Cloud project ID or attached BigQuery catalog. |
+| `destination_table` | `VARCHAR` | required | BigQuery destination as `dataset.table` or a qualified identifier. |
+
+## Source Parameters
+
+Specify exactly one source family.
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `source_file` | `VARCHAR` | none | Local file. A `gs://` value is treated as `source_uris`. |
+| `file` | `VARCHAR` | none | Alias for `source_file`; do not combine them. |
+| `source_uris` | `VARCHAR` or `LIST<VARCHAR>` | none | One or more nonempty `gs://` URIs. |
+| `source_table` | `VARCHAR` | none | DuckDB table or view to stage as a local Parquet file. |
+| `table` | `VARCHAR` | none | Alias for `source_table`; do not combine them. |
+| `source_format` | `VARCHAR` | inferred or `PARQUET` | `PARQUET`, `CSV`, `NEWLINE_DELIMITED_JSON`, `AVRO`, or `ORC`. |
+
+The format is inferred from consistent recognized source suffixes when
+possible; otherwise it defaults to `PARQUET`. A `source_table` is always staged
+as Parquet and therefore requires `source_format='PARQUET'` when the format is
+specified.
+
+## Job Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `write_disposition` | `VARCHAR` | `WRITE_TRUNCATE` | `WRITE_TRUNCATE`, `WRITE_APPEND`, or `WRITE_EMPTY`. |
+| `create_disposition` | `VARCHAR` | `CREATE_IF_NEEDED` | `CREATE_IF_NEEDED` or `CREATE_NEVER`. |
+| `location` | `VARCHAR` | `bq_default_location` | BigQuery job location. |
+| `billing_project` | `VARCHAR` | project | Consumer project for a direct project call. |
+| `labels` | `MAP(VARCHAR, VARCHAR)` | none | Job labels. |
+| `timeout_ms` | `BIGINT` | `bq_query_timeout_ms` | Maximum local wait; `0` waits indefinitely. |
+| `autodetect` | `BOOLEAN` | BigQuery default | Enable schema and format-option detection. |
+| `schema_update_options` | `VARCHAR` or `LIST<VARCHAR>` | none | `ALLOW_FIELD_ADDITION` and/or `ALLOW_FIELD_RELAXATION`. |
+| `max_bad_records` | `BIGINT` | BigQuery default | Nonnegative maximum rejected records. |
+| `ignore_unknown_values` | `BOOLEAN` | BigQuery default | Ignore extra input fields when supported. |
+
+For an attached catalog, configure billing in `ATTACH`; a per-call
+`billing_project` is rejected. The attachment must be read-write.
+
+## CSV Parameters
+
+These parameters require `source_format='CSV'`.
+
+| Parameter | Type | Default |
+| --- | --- | --- |
+| `csv_field_delimiter` | `VARCHAR` | BigQuery default |
+| `csv_skip_leading_rows` | `BIGINT` | BigQuery default |
+| `csv_quote` | `VARCHAR` | BigQuery default |
+| `csv_allow_quoted_newlines` | `BOOLEAN` | BigQuery default |
+| `csv_allow_jagged_rows` | `BOOLEAN` | BigQuery default |
+| `csv_encoding` | `VARCHAR` | BigQuery default |
+| `csv_null_marker` | `VARCHAR` | BigQuery default |
+| `csv_null_markers` | `VARCHAR` or `LIST<VARCHAR>` | BigQuery default |
+| `csv_preserve_ascii_control_characters` | `BOOLEAN` | BigQuery default |
+
+`csv_skip_leading_rows` must be nonnegative. `csv_null_marker` and
+`csv_null_markers` cannot be used together.
+
+## Format-Specific Parameters
+
+| Parameter | Type | Default | Applies to |
+| --- | --- | --- | --- |
+| `date_format` | `VARCHAR` | BigQuery default | CSV or newline-delimited JSON |
+| `datetime_format` | `VARCHAR` | BigQuery default | CSV or newline-delimited JSON |
+| `time_format` | `VARCHAR` | BigQuery default | CSV or newline-delimited JSON |
+| `timestamp_format` | `VARCHAR` | BigQuery default | CSV or newline-delimited JSON |
+| `time_zone` | `VARCHAR` | BigQuery default | CSV or newline-delimited JSON |
+| `json_extension` | `VARCHAR` | none | Newline-delimited JSON; only `GEOJSON` |
+| `avro_use_logical_types` | `BOOLEAN` | BigQuery default | Avro |
+| `parquet_enable_list_inference` | `BOOLEAN` | BigQuery default | Parquet |
+| `parquet_enum_as_string` | `BOOLEAN` | BigQuery default | Parquet |
+| `reference_file_schema_uri` | `VARCHAR` | none | Avro, Parquet, or ORC |
+| `decimal_target_types` | `VARCHAR` or `LIST<VARCHAR>` | none | Avro, Parquet, or ORC; `NUMERIC`, `BIGNUMERIC`, `STRING` |
+
+## Hive Partitioning Parameters
+
+These parameters require `source_uris`.
+
+| Parameter | Type | Default | Values |
+| --- | --- | --- | --- |
+| `hive_partitioning_mode` | `VARCHAR` | none | `AUTO`, `STRINGS`, or `CUSTOM` |
+| `hive_partitioning_source_uri_prefix` | `VARCHAR` | none | Cloud Storage URI prefix |
+
+## Example
+
+This example follows the tested `source_table` path. The extension stages the
+local relation as Parquet, submits a load job, and reports the number of rows
+written.
+
+```sql
+-- Attach the destination dataset.
+ATTACH 'project=my-gcp-project dataset=quacking_dataset'
+  AS bq (TYPE bigquery);
+
+-- Create the DuckDB relation that will be staged for the load job.
+CREATE TEMP TABLE local_ducks AS
+SELECT *
+  FROM (VALUES
+      (12, 'quack'),
+      (13, 'quack quack')
+  ) ducks(i, s);
+
+-- Submit the load job and inspect its stable result fields.
+SELECT
+      success,
+      output_rows
+  FROM bigquery_load(
+      'bq',
+      'quacking_dataset.loaded_ducks',
+      source_table := 'local_ducks',
+      write_disposition := 'WRITE_TRUNCATE'
+  );
+┌─────────┬─────────────┐
+│ success │ output_rows │
+│ boolean │   uint64    │
+├─────────┼─────────────┤
+│ true    │           2 │
+└─────────┴─────────────┘
+```
+
+## Result
+
+The function returns one row:
+
+| Column | Type |
+| --- | --- |
+| `success` | `BOOLEAN` |
+| `job_id` | `VARCHAR` |
+| `project_id` | `VARCHAR` |
+| `location` | `VARCHAR` |
+| `destination_table` | `VARCHAR` |
+| `output_rows` | `UBIGINT` |
+| `status` | `JSON` |
+
+`output_rows` can be `NULL` when BigQuery does not report load statistics.
+
+## Errors and Timeouts
+
+Typical errors include specifying zero or several source families, mixed or
+unknown source suffixes without an explicit format, incompatible
+format-specific parameters, invalid Cloud Storage URIs, a read-only catalog,
+insufficient bucket or destination permissions, and insufficient local
+temporary space for `source_table`.
+
+A `source_table` is copied to a temporary local Parquet file before upload and
+removed afterward. A timed-out load job can continue remotely.

--- a/docs/function-reference/bigquery-normalize-geography.md
+++ b/docs/function-reference/bigquery-normalize-geography.md
@@ -1,0 +1,46 @@
+# `bigquery_normalize_geography`
+
+Normalizes a DuckDB geometry for BigQuery geography writes, including polygon
+winding and touching-hole topology.
+
+## Signature
+
+```text
+bigquery_normalize_geography(GEOMETRY) -> GEOMETRY
+```
+
+## Parameters
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `geometry` | `GEOMETRY` | Geometry to normalize for a BigQuery write. |
+
+## Example
+
+The polygon starts with BigQuery-incompatible winding. The normalized output
+reverses the ring while preserving the same area. This input and result come
+from the local geography normalization SQLLogicTest.
+
+```sql
+-- Preview the geometry used by the BigQuery write path.
+SELECT bigquery_normalize_geography(
+      'POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))'
+          ::GEOMETRY('OGC:CRS84')
+  ) AS normalized;
+┌──────────────────────────────────────────────┐
+│                  normalized                  │
+│                   geometry                   │
+├──────────────────────────────────────────────┤
+│ POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))     │
+└──────────────────────────────────────────────┘
+```
+
+## Result and Behavior
+
+The function returns one `GEOMETRY` value. It runs locally and has no project,
+billing, credential, endpoint, or setting parameters. It does not issue a
+billable BigQuery request. A non-geometry argument fails during binding or
+casting.
+
+See [Working with Geometries](../user-guide/geometry-support.md) for the automatic write path,
+CRS requirements, and the difference between geometry and geography.

--- a/docs/function-reference/bigquery-query.md
+++ b/docs/function-reference/bigquery-query.md
@@ -1,0 +1,103 @@
+# `bigquery_query`
+
+Runs GoogleSQL in BigQuery and returns the result rows to DuckDB. It is also the
+read path for logical views, materialized views, and ordinary external tables.
+
+For workflow examples and help choosing a result path, see
+[Execute GoogleSQL](../user-guide/reading-and-queries.md#bigquery-query).
+
+## Signature
+
+```sql
+SELECT *
+  FROM bigquery_query(
+      'PROJECT_OR_CATALOG',
+      'GOOGLESQL',
+      [POSITIONAL_PARAMETER, ...],
+      billing_project := 'BILLING_PROJECT',
+      use_rest_api := false,
+      dry_run := false,
+      timeout_ms := 0,
+      api_endpoint := 'BIGQUERY_REST_ENDPOINT',
+      grpc_endpoint := 'STORAGE_READ_ENDPOINT'
+  );
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `project_or_catalog` | `VARCHAR` | required | Google Cloud project ID or attached BigQuery catalog. |
+| `sql` | `VARCHAR` | required | [GoogleSQL](https://cloud.google.com/bigquery/docs/introduction-sql) query. |
+| positional values | scalar | none | Values for `?` placeholders, in order. |
+| `billing_project` | `VARCHAR` | project | Consumer project for a direct project call. |
+| `use_rest_api` | `BOOLEAN` | `false` | Decode query results through the REST endpoint. |
+| `dry_run` | `BOOLEAN` | `false` | Validate and estimate the query without executing it. |
+| `timeout_ms` | `BIGINT` | `bq_query_timeout_ms` | Maximum local wait; `0` waits indefinitely. |
+| `api_endpoint` | `VARCHAR` | Google default | BigQuery REST endpoint override for job and REST result requests. |
+| `grpc_endpoint` | `VARCHAR` | Google default | Storage Read gRPC endpoint override for the standard result path. |
+
+When `project_or_catalog` names an attached catalog, billing and endpoints are
+taken from the attachment. Conflicting per-call values are rejected.
+
+Positional values bind to `?` placeholders. Cast `NULL` to a concrete type.
+List values are not supported as query parameters.
+
+## Example
+
+Positional values after the GoogleSQL string bind to `?` placeholders in
+order. This example follows the parameter-binding cases in the query
+SQLLogicTests and does not require an existing table.
+
+```sql
+-- Bind DuckDB values to GoogleSQL parameters by position.
+SELECT *
+  FROM bigquery_query(
+      'my-gcp-project',
+      'SELECT ? AS answer, ? AS sound',
+      42,
+      'quack'
+  );
+┌────────┬─────────┐
+│ answer │  sound  │
+│ int64  │ varchar │
+├────────┼─────────┤
+│     42 │ quack   │
+└────────┴─────────┘
+```
+
+## Result
+
+Normal result columns and types are derived from the BigQuery query schema.
+
+A dry run returns one row:
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `total_bytes_processed` | `BIGINT` | BigQuery processed-byte estimate. |
+| `cache_hit` | `BOOLEAN` | Whether BigQuery reports a cache hit. |
+| `location` | `VARCHAR` | BigQuery job location. |
+
+## Execution Paths
+
+By default, the function creates a query job, materializes its result, and
+reads that result through the
+[Storage Read API](https://cloud.google.com/bigquery/docs/reference/storage).
+
+With `use_rest_api := true`, results are decoded inline through
+[`jobs.query`](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query).
+The REST path decodes BigQuery `ARRAY` and `STRUCT` results recursively as
+DuckDB `LIST` and `STRUCT` values. BigQuery does not expose native `MAP` or
+union result types, and it rejects final query results whose arrays contain
+`NULL` elements. BigQuery can still create a job under its
+[`JOB_CREATION_OPTIONAL` behavior](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query#JobCreationMode).
+
+## Errors and Timeouts
+
+Typical errors include invalid GoogleSQL, a placeholder count or type mismatch,
+missing job or source-object permissions, an unusable billing project,
+conflicting catalog options, malformed REST result shapes, and result arrays
+containing `NULL` elements.
+
+`timeout_ms` stops local waiting but does not guarantee cancellation. Inspect
+timed-out work with [`bigquery_jobs`](bigquery-jobs.md).

--- a/docs/function-reference/bigquery-scan.md
+++ b/docs/function-reference/bigquery-scan.md
@@ -1,0 +1,83 @@
+# `bigquery_scan`
+
+Reads one native BigQuery table through the BigQuery Storage Read API without
+creating a DuckDB catalog.
+
+For a guided comparison with attached table reads, see
+[Reading and Queries](../user-guide/reading-and-queries.md#bigquery-scan).
+
+## Signature
+
+```sql
+SELECT *
+  FROM bigquery_scan(
+      'PROJECT.DATASET.TABLE',
+      billing_project := 'BILLING_PROJECT',
+      filter := 'ROW_RESTRICTION',
+      api_endpoint := 'BIGQUERY_REST_ENDPOINT',
+      grpc_endpoint := 'STORAGE_READ_ENDPOINT'
+  );
+```
+
+## Parameters
+
+| Parameter | Type | Default | Description |
+| --- | --- | --- | --- |
+| `table` | `VARCHAR` | required | Fully qualified `project.dataset.table` identifier. |
+| `billing_project` | `VARCHAR` | storage project | Consumer project for billing and quota. |
+| `filter` | `VARCHAR` | none | Explicit Storage Read row restriction. |
+| `api_endpoint` | `VARCHAR` | Google default | BigQuery REST endpoint override. |
+| `grpc_endpoint` | `VARCHAR` | Google default | Storage Read gRPC endpoint override. |
+
+The result columns and DuckDB types are derived from the BigQuery table schema.
+
+## Example
+
+The example uses the `duck_tbl` table introduced in
+[Install, Attach, and Query](../getting-started/install-attach-and-query.md).
+The projection order and filter behavior mirror the scan SQLLogicTests.
+
+```sql
+-- Read and filter the table through the Storage Read API.
+SELECT
+      i,
+      s
+  FROM bigquery_scan(
+      'my-gcp-project.quacking_dataset.duck_tbl'
+  )
+  WHERE i >= 12
+  ORDER BY i;
+┌───────┬────────────────┐
+│   i   │       s        │
+│ int64 │    varchar     │
+├───────┼────────────────┤
+│    12 │ quack 🦆       │
+│    13 │ quack quack 🦆 │
+└───────┴────────────────┘
+```
+
+## Behavior
+
+DuckDB pushes projected columns into the Storage Read session. With
+`bq_experimental_filter_pushdown=true`, eligible DuckDB filters are translated
+to Storage Read row restrictions. The explicit `filter` argument is passed as
+trusted
+[`TableReadOptions.row_restriction`](https://cloud.google.com/bigquery/docs/reference/storage/rpc/google.cloud.bigquery.storage.v1#google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions)
+text and is not a parameterized DuckDB expression.
+
+`bq_max_read_streams`, `bq_arrow_compression`, and
+`bq_experimental_filter_pushdown` control the read path. See
+[Additional Settings](../user-guide/configuration.md#settings).
+
+## Limitations and Errors
+
+The function reads native BigQuery tables. It does not directly read logical
+views, materialized views, or ordinary external tables. Use
+[`bigquery_query`](bigquery-query.md) for those relations.
+
+Typical errors include an invalid three-part table name, missing Storage Read
+permissions, an invalid row restriction, an unusable billing project, and an
+unreachable endpoint override.
+Review Google's
+[Storage Read API limitations](https://cloud.google.com/bigquery/docs/reference/storage#limitations)
+for service-level constraints.

--- a/docs/function-reference/index.md
+++ b/docs/function-reference/index.md
@@ -1,0 +1,65 @@
+# Function Reference
+
+This chapter is the canonical reference for every SQL function registered by
+the BigQuery extension. Each function page contains its complete signature,
+parameters, defaults, result columns, configuration rules, and local
+validation behavior.
+
+Use the capability pages for end-to-end workflows and examples. Use this
+chapter when you need to look up a function or configure a specific call.
+
+Each function page includes commented DuckDB SQL and its result when the
+statement returns rows. The examples use the placeholder projects, datasets,
+and tables introduced on the Home page. Job examples select stable result
+fields because generated IDs, timestamps, locations, and byte counts vary
+between executions.
+
+## Read Functions
+
+- **[`bigquery_scan`](bigquery-scan.md)**<br>
+  Read one native BigQuery table through the Storage Read API.
+  [Reading and Queries →](../user-guide/reading-and-queries.md#bigquery-scan)
+
+- **[`bigquery_query`](bigquery-query.md)**<br>
+  Run GoogleSQL and return its rows.
+  [Reading and Queries →](../user-guide/reading-and-queries.md#bigquery-query)
+
+## Job and Transfer Functions
+
+- **[`bigquery_execute`](bigquery-execute.md)**<br>
+  Run GoogleSQL and return execution metadata.
+  [Execute GoogleSQL →](../user-guide/jobs-and-transfers.md#execute-googlesql)
+
+- **[`bigquery_load`](bigquery-load.md)**<br>
+  Load local files, Cloud Storage objects, or DuckDB relations into BigQuery.
+  [Load Data →](../user-guide/extract-and-load.md#load-data)
+
+- **[`bigquery_extract`](bigquery-extract.md)**<br>
+  Export a BigQuery table to Cloud Storage.
+  [Extract Data →](../user-guide/extract-and-load.md#extract-data)
+
+- **[`bigquery_jobs`](bigquery-jobs.md)**<br>
+  List BigQuery jobs or retrieve one job.
+  [Monitor Jobs →](../user-guide/jobs-and-transfers.md#monitor-jobs)
+
+## Utilities and Compatibility
+
+- **[`bigquery_attach`](bigquery-attach.md)**<br>
+  Create local views for the native tables in one dataset.
+  [ATTACH Compatibility Helper →](../user-guide/attach.md#compatibility-helper)
+
+- **[`bigquery_clear_cache`](bigquery-clear-cache.md)**<br>
+  Clear metadata caches for attached BigQuery catalogs.
+  [Refresh Metadata →](../user-guide/attach.md#refresh-metadata-and-detach)
+
+- **[`bigquery_normalize_geography`](bigquery-normalize-geography.md)**<br>
+  Normalize a geometry for BigQuery geography semantics.
+  [Data Type Mapping →](../concepts/data-types.md#geometry-and-geography)
+
+Many functions accept either a Google Cloud project ID or the name of an
+attached BigQuery catalog as their first argument. A catalog reuses its
+project, billing project, endpoint, credentials, access mode, and transaction
+context. Per-call options that would conflict with catalog-owned configuration
+are rejected. Each function page documents the exact rule.
+
+For non-function interfaces, use the topic pages in the main navigation.

--- a/docs/getting-started/authentication-and-secrets.md
+++ b/docs/getting-started/authentication-and-secrets.md
@@ -1,0 +1,223 @@
+# Authentication & Secrets
+
+You must configure authentication before using the BigQuery extension. The
+extension supports [Google Application Default Credentials
+(ADC)](https://cloud.google.com/docs/authentication/application-default-credentials)
+and project-scoped credentials managed by DuckDB. Common setup paths are:
+
+1. **[User Account ADC](#user-account-adc)** — Create local Application
+   Default Credentials with `gcloud auth application-default login`.
+2. **[Service Account ADC](#service-account-adc)** — Use a credential file
+   through `GOOGLE_APPLICATION_CREDENTIALS`, or use the service account
+   attached to a Google-hosted runtime.
+3. **[DuckDB Secrets](#duckdb-secrets)** — Best for multi-tenant or server use,
+   with project-scoped credentials, per-connection isolation, and easy
+   rotation.
+
+DuckDB secrets take priority when their scope matches the target project. If no
+secret matches, the Google client library resolves ADC, including
+`GOOGLE_APPLICATION_CREDENTIALS`, local gcloud ADC files, and service accounts
+attached to Google-hosted runtimes.
+
+Authentication identifies the caller. The selected identity must also have the
+[permissions required](required-permissions.md) by each
+operation.
+
+## Option 1: User Account ADC { #user-account-adc }
+
+To authenticate with your Google Account, first install the [Google Cloud
+CLI](https://cloud.google.com/sdk/docs/install). Then create local Application
+Default Credentials and follow the browser-based login flow:
+
+```bash title="Command line"
+gcloud auth application-default login
+```
+
+This differs from `gcloud auth login`: the extension uses application-default
+credentials, not the Google Cloud CLI's user-session credentials. See the
+[`gcloud` documentation](https://cloud.google.com/sdk/gcloud) for additional
+CLI configuration.
+
+User account ADC is convenient for local development. It is generally not the
+right credential source for unattended production workloads.
+
+## Option 2: Service Account ADC { #service-account-adc }
+
+You can authenticate with a service account by creating the account in Google
+Cloud, assigning the necessary roles, and downloading its JSON key file. Set
+`GOOGLE_APPLICATION_CREDENTIALS` to the file path before starting DuckDB:
+
+=== "Linux and macOS"
+
+    ```bash title="Command line"
+    export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
+    ```
+
+=== "Windows"
+
+    ```batch title="Command line"
+    set GOOGLE_APPLICATION_CREDENTIALS=C:\path\to\service-account.json
+    ```
+
+Service-account keys are long-lived credentials. Keep the file outside the
+repository, restrict access to it, and rotate it according to your
+organization's security policy.
+
+### Attached Service Account
+
+On Dataproc, Compute Engine, GKE, Cloud Run, and similar Google-hosted
+environments, no service-account key file is required when the workload has an
+attached service account. ADC obtains tokens from the metadata server. Make
+sure the attached identity has the required IAM permissions and, where
+applicable, access scopes.
+
+Prefer an attached service account or Workload Identity Federation over
+downloaded keys for deployed workloads.
+
+## Option 3: DuckDB Secrets { #duckdb-secrets }
+
+DuckDB secrets are particularly useful in multi-tenant scenarios where
+different credentials must access different BigQuery projects from the same
+DuckDB process. Create separate secrets with project-specific `SCOPE` values,
+and the extension automatically selects the matching secret for each
+operation. The
+[DuckDB Secrets Manager](https://duckdb.org/docs/stable/configuration/secrets_manager)
+documentation covers secret scopes, storage, inspection, and deletion in more
+detail.
+
+The following authentication parameters are currently supported:
+
+- **`ACCESS_TOKEN`** — Temporary OAuth2 access token, obtainable with
+  `gcloud auth print-access-token`.
+- **`SERVICE_ACCOUNT_PATH`** — Path to a service-account key file.
+- **`SERVICE_ACCOUNT_JSON`** — Inline JSON content of a service-account key.
+- **`EXTERNAL_ACCOUNT_PATH`** — Path to an external-account credential file
+  for Workload Identity Federation.
+- **`EXTERNAL_ACCOUNT_JSON`** — Inline external-account JSON for Workload
+  Identity Federation.
+- **`REFRESH_TOKEN` + `CLIENT_ID` + `CLIENT_SECRET`** — OAuth authorized-user
+  credentials. `TOKEN_URI` is optional and defaults to Google's OAuth token
+  endpoint.
+
+Use `bq://PROJECT_ID` or `bigquery://PROJECT_ID` as the scope. The following
+examples show the supported credential forms:
+
+=== "Access token"
+
+    ```sql
+    -- Create a process-local secret with a temporary access token.
+    CREATE SECRET bigquery_token (
+        TYPE bigquery,
+        SCOPE 'bq://my-gcp-project',
+        ACCESS_TOKEN 'temporary-access-token'
+    );
+    ┌─────────┐
+    │ Success │
+    │ boolean │
+    ├─────────┤
+    │ true    │
+    └─────────┘
+    ```
+
+=== "Service-account JSON"
+
+    ```sql
+    -- Create a process-local secret with inline service-account JSON.
+    CREATE SECRET bigquery_service_account_json (
+        TYPE bigquery,
+        SCOPE 'bq://my-gcp-project',
+        SERVICE_ACCOUNT_JSON '{"type":"service_account", "...":"..."}'
+    );
+    ┌─────────┐
+    │ Success │
+    │ boolean │
+    ├─────────┤
+    │ true    │
+    └─────────┘
+    ```
+
+=== "External-account file"
+
+    ```sql
+    -- Create a persistent secret backed by an external-account file.
+    CREATE PERSISTENT SECRET bigquery_external_account (
+        TYPE bigquery,
+        SCOPE 'bq://my-gcp-project',
+        EXTERNAL_ACCOUNT_PATH '/path/to/external-account.json'
+    );
+    ┌─────────┐
+    │ Success │
+    │ boolean │
+    ├─────────┤
+    │ true    │
+    └─────────┘
+    ```
+
+=== "External-account JSON"
+
+    ```sql
+    -- Create a process-local secret with inline external-account JSON.
+    CREATE SECRET bigquery_external_account_json (
+        TYPE bigquery,
+        SCOPE 'bq://my-gcp-project',
+        EXTERNAL_ACCOUNT_JSON '{"type":"external_account", "...":"..."}'
+    );
+    ┌─────────┐
+    │ Success │
+    │ boolean │
+    ├─────────┤
+    │ true    │
+    └─────────┘
+    ```
+
+=== "OAuth refresh token"
+
+    ```sql
+    -- Create a process-local secret with OAuth user credentials.
+    CREATE SECRET bigquery_oauth (
+        TYPE bigquery,
+        SCOPE 'bq://my-gcp-project',
+        REFRESH_TOKEN 'refresh-token',
+        CLIENT_ID 'oauth-client-id',
+        CLIENT_SECRET 'oauth-client-secret'
+    );
+    ┌─────────┐
+    │ Success │
+    │ boolean │
+    ├─────────┤
+    │ true    │
+    └─────────┘
+    ```
+
+By default, `CREATE SECRET` keeps a credential in memory for the lifetime of
+the DuckDB instance. Use `CREATE OR REPLACE SECRET` to update it when the
+credential changes or expires.
+
+Add `PERSISTENT` when DuckDB should load the credential again in later
+sessions. Use `CREATE PERSISTENT SECRET` for a new persistent credential and
+`CREATE OR REPLACE PERSISTENT SECRET` to update it. The external-account file
+example above demonstrates the persistent form.
+
+Persistent secrets are stored in unencrypted binary form under
+`~/.duckdb/stored_secrets` by default. Use the `secret_directory` setting to
+choose another location, and protect that directory like any other credential
+store.
+
+### Secret Validation
+
+- Credential methods cannot be combined.
+- `REFRESH_TOKEN`, `CLIENT_ID`, and `CLIENT_SECRET` must be supplied together.
+- `TOKEN_URI` is optional only for the refresh-token method.
+- Credential paths must exist and be readable.
+- Inline JSON is parsed when the secret is created.
+- Secret values are redacted from normal DuckDB secret inspection.
+
+## Authentication Preflight
+
+`ATTACH` immediately checks that the selected credentials can provide an
+authentication token. It does not load catalog metadata or verify BigQuery
+permissions for datasets, tables, jobs, or Storage APIs. Those checks occur
+when the corresponding objects or operations are used.
+
+When `ACCESS_TOKEN` is configured directly, BigQuery may only reject an invalid
+or expired token on the first API request.

--- a/docs/getting-started/authentication-and-secrets.md
+++ b/docs/getting-started/authentication-and-secrets.md
@@ -41,9 +41,6 @@ credentials, not the Google Cloud CLI's user-session credentials. See the
 [`gcloud` documentation](https://cloud.google.com/sdk/gcloud) for additional
 CLI configuration.
 
-User account ADC is convenient for local development. It is generally not the
-right credential source for unattended production workloads.
-
 ## Option 2: Service Account ADC { #service-account-adc }
 
 You can authenticate with a service account by creating the account in Google
@@ -58,9 +55,6 @@ export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
 set "GOOGLE_APPLICATION_CREDENTIALS=C:\path\to\service-account.json"
 ```
 
-Service-account keys are long-lived credentials. Keep the file outside the
-repository, restrict access to it, and rotate it according to your
-organization's security policy.
 
 ### Attached Service Account
 

--- a/docs/getting-started/authentication-and-secrets.md
+++ b/docs/getting-started/authentication-and-secrets.md
@@ -5,14 +5,17 @@ extension supports [Google Application Default Credentials
 (ADC)](https://cloud.google.com/docs/authentication/application-default-credentials)
 and project-scoped credentials managed by DuckDB. Common setup paths are:
 
-1. **[User Account ADC](#user-account-adc)** — Create local Application
-   Default Credentials with `gcloud auth application-default login`.
-2. **[Service Account ADC](#service-account-adc)** — Use a credential file
-   through `GOOGLE_APPLICATION_CREDENTIALS`, or use the service account
-   attached to a Google-hosted runtime.
-3. **[DuckDB Secrets](#duckdb-secrets)** — Best for multi-tenant or server use,
-   with project-scoped credentials, per-connection isolation, and easy
-   rotation.
+- **[User Account ADC](#user-account-adc)**<br>
+  Create local Application Default Credentials with
+  `gcloud auth application-default login`.
+
+- **[Service Account ADC](#service-account-adc)**<br>
+  Use a credential file through `GOOGLE_APPLICATION_CREDENTIALS`, or use the
+  service account attached to a Google-hosted runtime.
+
+- **[DuckDB Secrets](#duckdb-secrets)**<br>
+  Manage project-scoped credentials with per-connection isolation and easy
+  rotation, particularly for multi-tenant or server use.
 
 DuckDB secrets take priority when their scope matches the target project. If no
 secret matches, the Google client library resolves ADC, including
@@ -47,17 +50,13 @@ You can authenticate with a service account by creating the account in Google
 Cloud, assigning the necessary roles, and downloading its JSON key file. Set
 `GOOGLE_APPLICATION_CREDENTIALS` to the file path before starting DuckDB:
 
-=== "Linux and macOS"
+```bash title="Command line"
+# Linux and macOS
+export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
 
-    ```bash title="Command line"
-    export GOOGLE_APPLICATION_CREDENTIALS="/path/to/service-account.json"
-    ```
-
-=== "Windows"
-
-    ```batch title="Command line"
-    set GOOGLE_APPLICATION_CREDENTIALS=C:\path\to\service-account.json
-    ```
+# Windows Command Prompt
+set "GOOGLE_APPLICATION_CREDENTIALS=C:\path\to\service-account.json"
+```
 
 Service-account keys are long-lived credentials. Keep the file outside the
 repository, restrict access to it, and rotate it according to your

--- a/docs/getting-started/install-attach-and-query.md
+++ b/docs/getting-started/install-attach-and-query.md
@@ -1,0 +1,52 @@
+# Install, Attach, and Query
+
+Install the BigQuery extension from the official
+[Community Extension Repository](https://duckdb.org/community_extensions/extensions/bigquery).
+The extension does not require unsigned-extension mode.
+
+Before continuing, configure one of the supported
+[authentication methods](authentication-and-secrets.md). The following
+example then installs the extension, attaches a BigQuery project, and queries a
+table:
+
+```sql
+-- Install the BigQuery extension from the Community Extension Repository.
+FORCE INSTALL 'bigquery' FROM community;
+
+-- Load the extension.
+LOAD 'bigquery';
+
+-- Attach every accessible dataset in the project as a read-only catalog.
+ATTACH 'project=my-gcp-project' AS bq (TYPE bigquery, READ_ONLY);
+
+-- List tables from the attached datasets.
+SHOW ALL TABLES;
+┌──────────┬──────────────────┬──────────┬──────────────┬───────────────────┬───────────┐
+│ database │      schema      │   name   │ column_names │   column_types    │ temporary │
+│ varchar  │     varchar      │ varchar  │  varchar[]   │     varchar[]     │  boolean  │
+├──────────┼──────────────────┼──────────┼──────────────┼───────────────────┼───────────┤
+│ bq       │ quacking_dataset │ duck_tbl │ [i, s]       │ [BIGINT, VARCHAR] │ false     │
+│ bq       │ barking_dataset  │ dog_tbl  │ [i, s]       │ [BIGINT, VARCHAR] │ false     │
+└──────────┴──────────────────┴──────────┴──────────────┴───────────────────┴───────────┘
+
+-- Query a table through the attached catalog.
+SELECT *
+  FROM bq.quacking_dataset.duck_tbl;
+┌───────┬────────────────┐
+│   i   │       s        │
+│ int64 │    varchar     │
+├───────┼────────────────┤
+│    12 │ quack 🦆       │
+│    13 │ quack quack 🦆 │
+└───────┴────────────────┘
+```
+
+For attachment options such as dataset scope, billing projects, endpoints, and
+write access, continue with
+[Attaching Projects](../user-guide/attach.md).
+
+!!! warning "Windows TLS configuration"
+
+    Windows may require an additional gRPC trust-store configuration. If HTTPS
+    or gRPC requests fail because a root certificate cannot be found, follow
+    [TLS and certificates](../troubleshooting.md#tls-and-certificates).

--- a/docs/getting-started/required-permissions.md
+++ b/docs/getting-started/required-permissions.md
@@ -1,0 +1,82 @@
+# Required Permissions
+
+Authentication identifies the caller; Google Cloud IAM determines which
+projects, datasets, tables, jobs, and write operations that identity may use.
+Configure an [authentication method](authentication-and-secrets.md) first,
+then grant only the permissions required by the intended workflow.
+
+## Where Permissions Apply
+
+BigQuery separates the project that creates a job from the datasets and tables
+that the job accesses. Cloud Storage permissions are managed on the source or
+destination bucket. A `billing_project` can supply quota and receive charges,
+but it does not grant access to data in another project.
+
+## Common Roles
+
+| Scope | Role | Typical use |
+| --- | --- | --- |
+| Project | `roles/bigquery.jobUser` | Create query, load, and extract jobs |
+| Project | `roles/bigquery.readSessionUser` | Create Storage Read sessions |
+| Dataset or table | `roles/bigquery.dataViewer` | Read table and view data |
+| Dataset or table | `roles/bigquery.dataEditor` | Create and modify table data |
+| Project | `roles/bigquery.resourceViewer` | List jobs created by all users in the project |
+| Bucket | `roles/storage.objectViewer` | Read Cloud Storage objects used by a load job |
+| Bucket | `roles/storage.objectAdmin` | Create and, when necessary, replace extract objects |
+
+Prefer least-privilege custom roles when the predefined roles grant more access
+than the workload requires.
+
+## Permissions by Operation
+
+| Operation | Required access | Scope |
+| --- | --- | --- |
+| Attached native-table read or `bigquery_scan` | `roles/bigquery.dataViewer` and `roles/bigquery.readSessionUser` | Data role on the dataset or table; read-session role on the project that owns the read session |
+| `bigquery_query` | `roles/bigquery.jobUser`, read access to every referenced relation, and `roles/bigquery.readSessionUser` for the standard result path | Job and read-session roles on the job project; data role on source datasets or tables |
+| `bigquery_execute` | `roles/bigquery.jobUser` plus permissions required by the submitted GoogleSQL | Job project and every referenced source or destination |
+| Attached `INSERT`, `UPDATE`, `DELETE`, DDL, or CTAS | `roles/bigquery.dataEditor` or equivalent narrower permissions | Destination dataset or table; job permissions are additionally required for job-backed operations |
+| List the caller's jobs | `bigquery.jobs.list` | Project containing the jobs |
+| List all users' jobs | `bigquery.jobs.listAll`, included in `roles/bigquery.resourceViewer` | Project containing the jobs |
+
+The standard `bigquery_query` path materializes a result and reads it with the
+Storage Read API. With `use_rest_api := true`, result rows use the REST path,
+but the query still requires job and source-data permissions.
+
+## Load Jobs
+
+Every load job needs `bigquery.jobs.create` on its job project and write access
+to the destination dataset or table. The additional source permissions depend
+on the selected source:
+
+- A local file is uploaded by the extension and does not require caller access
+  to an existing Cloud Storage object.
+- A DuckDB table or view is staged as a local Parquet file and follows the
+  local-file upload path.
+- A `gs://` source requires `storage.objects.get` on every object. URI
+  wildcards additionally require `storage.objects.list` on the bucket. The
+  predefined `roles/storage.objectViewer` role contains both permissions.
+
+See Google's [batch loading permissions](https://cloud.google.com/bigquery/docs/batch-loading-data)
+for the exact permissions and service restrictions.
+
+## Extract Jobs
+
+An extract job needs `bigquery.jobs.create` on the job project, read access to
+the source table, and Cloud Storage permissions on the destination bucket.
+Writing to an existing bucket requires `storage.objects.create`; replacing
+objects can also require `storage.objects.delete`. The predefined
+`roles/storage.objectAdmin` role contains both permissions.
+
+See Google's [export permissions](https://cloud.google.com/bigquery/docs/exporting-data)
+for the current role recommendations.
+
+## Billing and Quota Projects
+
+When `billing_project` differs from the data project, job creation and quota
+permissions apply to the billing project while data permissions remain on the
+source and destination resources. Organizations using service-usage controls
+can also require `serviceusage.services.use` on the quota project.
+
+IAM failures identify the missing permission and resource in the BigQuery or
+Cloud Storage error. Grant the narrowest role at the lowest appropriate scope,
+then continue with [Attaching Projects](../user-guide/attach.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,12 @@
 # DuckDB BigQuery Extension
 
+<p align="center">
+  <a href="https://duckdb.org/community_extensions/extensions/bigquery"><img alt="DuckDB Community Extension" src="https://img.shields.io/badge/DuckDB-Community%20Extension-FFF000?logo=duckdb&amp;logoColor=000"></a>
+  <a href="https://github.com/hafenkran/duckdb-bigquery/releases/latest"><img alt="Latest Release" src="https://img.shields.io/github/v/release/hafenkran/duckdb-bigquery?label=Latest%20Release"></a>
+  <a href="https://github.com/hafenkran/duckdb-bigquery/actions/workflows/MainDistributionPipeline.yml"><img alt="Build and Test" src="https://img.shields.io/github/actions/workflow/status/hafenkran/duckdb-bigquery/MainDistributionPipeline.yml?branch=main&amp;label=Build"></a>
+  <a href="https://github.com/hafenkran/duckdb-bigquery/blob/main/LICENSE"><img alt="License: MIT" src="https://img.shields.io/github/license/hafenkran/duckdb-bigquery?label=License"></a>
+</p>
+
 This community extension allows [DuckDB](https://duckdb.org) to query data
 from Google BigQuery using a mix of BigQuery Storage (Read/Write) and REST APIs.
 You can explore, query, create, and modify BigQuery tables and datasets
@@ -42,16 +49,6 @@ See [Important Notes](#important-notes) for disclaimers and usage information.
 
 To make your first connection, follow
 [Install, Attach, and Query](getting-started/install-attach-and-query.md).
-
-## Example Conventions
-
-Examples use `my-gcp-project` and `my-billing-project` as Google Cloud project
-IDs. Names such as `my_dataset`, `quacking_dataset`, and `barking_dataset` are
-BigQuery datasets. After an attachment, `bq` is the local DuckDB catalog name,
-so `bq.my_dataset.my_table` refers to a BigQuery table through that catalog.
-
-Replace project IDs, dataset names, table names, bucket names, and file paths
-with resources available to your credentials before running an example.
 
 ## Important Notes
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,15 +10,15 @@
 This community extension allows [DuckDB](https://duckdb.org) to query data
 from Google BigQuery using a mix of BigQuery Storage (Read/Write) and REST APIs.
 You can explore, query, create, and modify BigQuery tables and datasets
-directly from DuckDB using standard SQL queries. Inspired by official DuckDB
+directly from DuckDB using standard SQL queries. Dedicated functions cover direct table scans, GoogleSQL queries,
+load and extract jobs, and job inspection.
+
+Inspired by official DuckDB
 storage extensions like
 [MySQL](https://duckdb.org/docs/current/core_extensions/mysql),
 [PostgreSQL](https://github.com/duckdb/duckdb-postgres), and
 [SQLite](https://github.com/duckdb/duckdb-sqlite), this extension offers a
-similar feel. Dedicated functions cover direct table scans, GoogleSQL queries,
-load and extract jobs, and job inspection.
-
-See [Important Notes](#important-notes) for disclaimers and usage information.
+similar feel.
 
 !!! warning "Disclaimer: Independent community project"
 
@@ -51,6 +51,8 @@ To make your first connection, follow
 [Install, Attach, and Query](getting-started/install-attach-and-query.md).
 
 ## Important Notes
+
+
 
 When using this software with Google BigQuery, please ensure your usage complies with the [Google API Terms of Service](https://developers.google.com/terms). Be mindful of the usage limits and quotas, and adhere to Google's Fair Use Policy.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,71 @@
+# DuckDB BigQuery Extension
+
+This community extension allows [DuckDB](https://duckdb.org) to query data
+from Google BigQuery using a mix of BigQuery Storage (Read/Write) and REST APIs.
+You can explore, query, create, and modify BigQuery tables and datasets
+directly from DuckDB using standard SQL queries. Inspired by official DuckDB
+storage extensions like
+[MySQL](https://duckdb.org/docs/current/core_extensions/mysql),
+[PostgreSQL](https://github.com/duckdb/duckdb-postgres), and
+[SQLite](https://github.com/duckdb/duckdb-sqlite), this extension offers a
+similar feel. Dedicated functions cover direct table scans, GoogleSQL queries,
+load and extract jobs, and job inspection.
+
+See [Important Notes](#important-notes) for disclaimers and usage information.
+
+!!! warning "Disclaimer: Independent community project"
+
+    This project is independently maintained and is not affiliated with,
+    endorsed by, or officially supported by Google LLC or DuckDB Labs.
+    BigQuery and DuckDB are trademarks of their respective owners. The
+    extension is provided without warranties; users are responsible for their
+    use, compliance, and incurred charges.
+
+## What You Can Do
+
+- Attach a project or dataset as a DuckDB catalog and explore it with `SHOW`
+  and `DESCRIBE`.
+- Read native tables through the BigQuery Storage Read API with projection and
+  filter pushdown.
+- Run GoogleSQL and read views, materialized views, and external tables.
+- Create and alter datasets, tables, and views with DuckDB SQL.
+- Insert, update, and delete data, or write DuckDB query results to BigQuery.
+- Submit and inspect query, load, and extract jobs.
+- Read and write BigQuery `GEOGRAPHY` as DuckDB
+  [`GEOMETRY('OGC:CRS84')`](user-guide/geometry-support.md).
+
+!!! info "Supported builds"
+
+    Community builds are available for `linux_amd64`, `linux_arm64`,
+    `osx_amd64`, `osx_arm64`, and `windows_amd64`.
+    The builds `wasm_mvp`, `wasm_eh`, `wasm_threads`, and `windows_amd64_mingw` are not supported.
+
+To make your first connection, follow
+[Install, Attach, and Query](getting-started/install-attach-and-query.md).
+
+## Example Conventions
+
+Examples use `my-gcp-project` and `my-billing-project` as Google Cloud project
+IDs. Names such as `my_dataset`, `quacking_dataset`, and `barking_dataset` are
+BigQuery datasets. After an attachment, `bq` is the local DuckDB catalog name,
+so `bq.my_dataset.my_table` refers to a BigQuery table through that catalog.
+
+Replace project IDs, dataset names, table names, bucket names, and file paths
+with resources available to your credentials before running an example.
+
+## Important Notes
+
+When using this software with Google BigQuery, please ensure your usage complies with the [Google API Terms of Service](https://developers.google.com/terms). Be mindful of the usage limits and quotas, and adhere to Google's Fair Use Policy.
+
+### Billing and Costs
+
+Please be aware that using Google BigQuery through this software can incur costs. Google
+BigQuery is a paid service, and charges may apply based on the amount of data processed,
+stored, and the number of queries executed. Users are responsible for any costs associated
+with their use of Google BigQuery. For detailed information on BigQuery pricing, please
+refer to the [Google BigQuery Pricing](https://cloud.google.com/bigquery/pricing) page.
+It is recommended to monitor your usage and set up budget alerts in the Google Cloud Console
+to avoid unexpected charges.
+
+By using this software, you acknowledge and agree that you are solely responsible for any
+charges incurred from Google BigQuery.

--- a/docs/license.md
+++ b/docs/license.md
@@ -1,0 +1,3 @@
+# License
+
+--8<-- "LICENSE"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,114 @@
+# Troubleshooting
+
+Use this page for operational failures and current extension limitations.
+For tuning and the complete settings reference, see
+[Additional Settings](user-guide/configuration.md).
+
+## Permission Failures
+
+If [authentication](getting-started/authentication-and-secrets.md) succeeds but a later API
+request fails, the active identity usually lacks dataset, table, job, Storage
+Read, or Storage Write permissions.
+
+Check:
+
+1. which storage and billing projects are configured;
+2. whether the identity can use the billing project;
+3. the operation-specific [IAM permissions](getting-started/required-permissions.md).
+
+## TLS and Certificates
+
+Set a readable CA bundle for cURL-based REST clients:
+
+```sql
+-- Use an explicit CA bundle for REST requests.
+SET bq_curl_ca_bundle_path = '/path/to/ca-bundle.pem';
+```
+
+On Windows, gRPC may additionally need
+`GRPC_DEFAULT_SSL_ROOTS_FILE_PATH` before DuckDB starts. Follow the Google
+Cloud C++ client's
+[Windows TLS setup](https://github.com/googleapis/google-cloud-cpp/blob/f2bd9a9af590f58317a216627ae9e2399c245bab/google/cloud/storage/quickstart/README.md#windows)
+and keep the root bundle current. Do not disable certificate verification.
+
+See [`bq_curl_ca_bundle_path`](user-guide/configuration.md#type-and-diagnostic-settings)
+for the setting details.
+
+## Common Problems
+
+### A View or External Table Does Not Scan
+
+Storage Read cannot directly scan logical views, materialized views, or
+ordinary external tables. Use `bigquery_query` as described under
+[Reading and Queries](user-guide/reading-and-queries.md#bigquery-query).
+
+### Schema Changes Are Not Visible
+
+Clear attached metadata caches:
+
+```sql
+-- Invalidate cached metadata for attached BigQuery catalogs.
+CALL bigquery_clear_cache();
+```
+
+BigQuery metadata can also have a short propagation delay.
+
+### Reads Are Not Parallel
+
+Parallel Storage Read streams require insertion-order preservation to be
+disabled:
+
+```sql
+-- Allow parallel result consumption.
+SET preserve_insertion_order = false;
+
+-- Request up to the configured DuckDB thread count.
+SET bq_max_read_streams = 0;
+```
+
+BigQuery can return fewer streams than requested. See
+[Storage Read Settings](user-guide/configuration.md#storage-read-settings) for details.
+
+### A Function Rejects Billing Options
+
+When the first argument names an attached catalog, configure billing in
+`ATTACH`. The catalog is authoritative, so conflicting per-call parameters
+are rejected. `bigquery_execute` has no `billing_project` parameter.
+
+### A Timed-Out Job Is Still Running
+
+Timeouts stop local waiting but do not guarantee cancellation. Inspect the job
+with `bigquery_jobs` or the Google Cloud console. See
+[Executing & Monitoring Jobs](user-guide/jobs-and-transfers.md#timeouts-and-costs) for job timeout
+semantics.
+
+### Inspect Generated GoogleSQL
+
+```sql
+-- Print generated GoogleSQL for subsequent remote operations.
+SET bq_debug_show_queries = true;
+```
+
+This prints remote SQL to standard output. Avoid enabling it where SQL text
+could contain sensitive values. See
+[Type and Diagnostic Settings](user-guide/configuration.md#type-and-diagnostic-settings)
+for details.
+
+## Known Limitations
+
+| Area | Current limitation | Alternative or details |
+| --- | --- | --- |
+| Platforms | Community builds do not support WebAssembly or Windows MinGW | Use one of the platforms listed on [Home](index.md#what-you-can-do) |
+| Native scans | Views and ordinary external tables cannot be scanned directly | Use [`bigquery_query`](user-guide/reading-and-queries.md#bigquery-query) |
+| REST results | BigQuery rejects result arrays containing `NULL` elements and may still create a job in optional job-creation mode | See [`bigquery_query`](user-guide/reading-and-queries.md#bigquery-query) |
+| Type reads | `BIGNUMERIC` is exposed as exact `VARCHAR` | See [Data Type Mapping](concepts/data-types.md#bignumeric-and-arrays) |
+| Type writes | Several very wide, unsigned, and timestamp types are unsupported; nested arrays are rejected | See [Data Type Mapping](concepts/data-types.md) |
+| Attached SQL | Only documented DDL and row-mutation forms are supported | See [Managing Tables & Datasets](user-guide/managing-tables-and-schemas.md) and [Writing & Modifying Data](user-guide/writing.md) |
+| Table clauses | `PARTITION BY`, `CLUSTER BY`, and `OPTIONS` require the experimental parser | See [table options](user-guide/managing-tables-and-schemas.md#create-a-table-with-options) and [partitioning and clustering](user-guide/managing-tables-and-schemas.md#partition-and-cluster-a-table) |
+| Timeouts | Stopping the local wait does not cancel a remote job | See [Executing & Monitoring Jobs](user-guide/jobs-and-transfers.md#timeouts-and-costs) |
+| Metadata | Attached metadata is cached and remote changes can propagate slowly | See [Refresh Metadata](user-guide/attach.md#refresh-metadata-and-detach) |
+| Transactions | Remote API operations are not part of a multi-statement cross-system transaction | Keep execution boundaries explicit |
+
+GoogleSQL and DuckDB can differ in casting, floating-point, string, and
+timestamp semantics. Make the execution boundary explicit when exact semantics
+matter.

--- a/docs/user-guide/attach.md
+++ b/docs/user-guide/attach.md
@@ -1,0 +1,231 @@
+# Attaching Projects
+
+`ATTACH ... (TYPE bigquery)` makes a BigQuery project or dataset available as
+a DuckDB catalog. BigQuery datasets appear as schemas, and tables can be
+addressed with three-part names such as `bq.my_dataset.my_table`.
+
+Complete [Install, Attach, and Query](../getting-started/install-attach-and-query.md)
+first if the extension is not installed yet. Before attaching, configure one
+of the supported [authentication methods](../getting-started/authentication-and-secrets.md).
+Authentication identifies the caller; the
+[Required Permissions](../getting-started/required-permissions.md) guide covers the Google Cloud
+IAM access required by each operation.
+
+## Attach a Project
+
+The standard form attaches all accessible datasets in a project. The name
+after `AS` is the local DuckDB catalog name; `bq` does not rename or create
+anything in BigQuery:
+
+```sql
+-- Attach every accessible dataset in the project as a read-only catalog.
+ATTACH 'project=my-gcp-project' AS bq (TYPE bigquery, READ_ONLY);
+
+-- List tables from the attached datasets.
+SHOW ALL TABLES;
+┌──────────┬────────────┬────────────────────┬──────────────┬───────────────────────────┬───────────┐
+│ database │   schema   │        name        │ column_names │       column_types        │ temporary │
+│ varchar  │ varchar    │ varchar            │ varchar[]    │ varchar[]                 │ boolean   │
+├──────────┼────────────┼────────────────────┼──────────────┼───────────────────────────┼───────────┤
+│ bq       │ my_dataset │ function_scan_test │ [a, b, c]    │ [BIGINT, BIGINT, VARCHAR] │ false     │
+│ bq       │ archive    │ old_events         │ [event_id]   │ [BIGINT]                   │ false     │
+└──────────┴────────────┴────────────────────┴──────────────┴───────────────────────────┴───────────┘
+
+-- Inspect one BigQuery table's columns.
+DESCRIBE TABLE bq.my_dataset.function_scan_test;
+┌─────────────┬─────────────┬──────┬──────┬─────────┬───────┐
+│ column_name │ column_type │ null │ key  │ default │ extra │
+├─────────────┼─────────────┼──────┼──────┼─────────┼───────┤
+│ a           │ BIGINT      │ YES  │ NULL │ NULL    │ NULL  │
+│ b           │ BIGINT      │ YES  │ NULL │ NULL    │ NULL  │
+│ c           │ VARCHAR     │ YES  │ NULL │ NULL    │ NULL  │
+└─────────────┴─────────────┴──────┴──────┴─────────┴───────┘
+```
+
+`SHOW ALL TABLES` lists relations from every accessible dataset in the
+attached project. The `my_dataset` and `archive` rows make that project-wide
+scope visible. `DESCRIBE TABLE` retrieves the schema of one relation.
+
+## Attach One Dataset
+
+Add `dataset` to restrict discovery to one dataset. This is useful when a
+project contains many datasets or the connection should have an unambiguous
+default schema:
+
+```sql
+-- Attach only my_dataset as a read-only catalog.
+ATTACH 'project=my-gcp-project dataset=my_dataset'
+  AS bq (TYPE bigquery, READ_ONLY);
+
+-- List tables from the attached dataset.
+SHOW ALL TABLES;
+┌──────────┬────────────┬────────────────────┬──────────────┬───────────────────────────┬───────────┐
+│ database │   schema   │        name        │ column_names │       column_types        │ temporary │
+│ varchar  │ varchar    │ varchar            │ varchar[]    │ varchar[]                 │ boolean   │
+├──────────┼────────────┼────────────────────┼──────────────┼───────────────────────────┼───────────┤
+│ bq       │ my_dataset │ function_scan_test │ [a, b, c]    │ [BIGINT, BIGINT, VARCHAR] │ false     │
+└──────────┴────────────┴────────────────────┴──────────────┴───────────────────────────┴───────────┘
+```
+
+Unlike the project attachment, this result contains no relations from
+`archive`. The shorthand `ATTACH 'my-gcp-project.my_dataset' AS bq (TYPE
+bigquery, READ_ONLY)` is equivalent. After a dataset-scoped attachment,
+`USE bq` selects that dataset as the current schema.
+
+## Attach Public or Cross-Project Data
+
+Use `billing_project` when the project storing the data differs from the
+project that supplies quota and receives applicable charges. This is commonly
+required for public datasets:
+
+```sql
+-- Read public data while billing queries to my-gcp-project.
+ATTACH 'project=bigquery-public-data dataset=geo_us_boundaries billing_project=my-gcp-project'
+  AS bq (TYPE bigquery, READ_ONLY);
+
+-- List tables in the public dataset.
+SHOW ALL TABLES;
+┌──────────┬───────────────────┬───────────────────┬───┬───────────┐
+│ database │      schema       │       name        │ … │ temporary │
+│ varchar  │ varchar           │ varchar           │ … │ boolean   │
+├──────────┼───────────────────┼───────────────────┼───┼───────────┤
+│ bq       │ geo_us_boundaries │ adjacent_counties │ … │ false     │
+│ bq       │ geo_us_boundaries │ cnecta            │ … │ false     │
+│ bq       │ geo_us_boundaries │ coastline         │ … │ false     │
+│    ·     │         ·         │         ·         │ · │     ·     │
+│    ·     │         ·         │         ·         │ · │     ·     │
+│ bq       │ geo_us_boundaries │ zip_codes         │ … │ false     │
+└──────────┴───────────────────┴───────────────────┴───┴───────────┘
+
+-- Query a table through the attached catalog.
+SELECT count(*)
+  FROM bq.geo_us_boundaries.cnecta;
+┌──────────────┐
+│ count_star() │
+│ int64        │
+├──────────────┤
+│ 7            │
+└──────────────┘
+```
+
+Here, `project` identifies the project containing the data and
+`billing_project` identifies the project used for billing and quota. The
+setting does not grant access; the active credentials still need the required
+IAM [permissions](../getting-started/required-permissions.md).
+
+## Access Mode
+
+Use `READ_ONLY` for exploration and analytics unless the connection is
+intended to modify BigQuery:
+
+```sql
+-- Prevent operations that modify BigQuery.
+ATTACH 'project=my-gcp-project dataset=my_dataset'
+  AS bq (TYPE bigquery, READ_ONLY);
+```
+
+A read-only catalog rejects attached DDL and DML, Storage Write operations,
+load and extract jobs, and `bigquery_execute` calls made through that catalog.
+Omit `READ_ONLY` to permit supported mutations:
+
+```sql
+-- Allow supported write operations through the catalog.
+ATTACH 'project=my-gcp-project dataset=my_dataset'
+  AS bq (TYPE bigquery);
+```
+
+This only removes the local read-only guard; IAM still controls every remote
+operation. DuckDB external access must also be enabled. Start with
+[Writing & Modifying Data](writing.md), then use
+[Managing Tables & Datasets](managing-tables-and-schemas.md) and
+[Executing & Monitoring Jobs](jobs-and-transfers.md) for the supported
+operations.
+
+Several projects can be attached at the same time by giving each one a
+different local catalog name.
+
+## Use the Attached Catalog
+
+In `bq.my_dataset.my_table`, `bq` is the attached DuckDB catalog,
+`my_dataset` is the BigQuery dataset, and `my_table` is the relation.
+`USE` can shorten subsequent names:
+
+```sql
+-- Select the attached dataset as the current schema.
+USE bq.my_dataset;
+
+-- Query a table without its catalog and schema prefixes.
+SELECT *
+  FROM function_scan_test
+  ORDER BY a;
+┌───────┬───────┬─────────┐
+│ a     │ b     │ c       │
+│ int64 │ int64 │ varchar │
+├───────┼───────┼─────────┤
+│     1 │     2 │ alpha   │
+│     3 │     4 │ beta    │
+└───────┴───────┴─────────┘
+```
+
+For a dataset-scoped attachment, `USE bq` selects its configured dataset
+automatically. Functions that accept a project or attached catalog can also
+receive `'bq'`, reusing its credentials, billing project, access mode, and
+transaction context. Conflicting function-level billing options are rejected.
+
+For the available read paths and their differences, see
+[Reading and Queries](reading-and-queries.md).
+
+<a id="refresh-metadata-and-detach"></a>
+
+## Refresh Metadata
+
+Attached catalogs cache dataset and table metadata. The catalog reloads
+relations that are missing from the cache and can rebind after stale column
+metadata. If a longer-lived connection still sees outdated metadata after an
+external schema change, clear all attached BigQuery metadata explicitly:
+
+```sql
+-- Clear cached metadata for all attached BigQuery catalogs.
+CALL bigquery_clear_cache();
+┌─────────┐
+│ success │
+│ boolean │
+├─────────┤
+│ true    │
+└─────────┘
+```
+
+This clears metadata for every attached BigQuery catalog. It does not detach a
+catalog, delete a remote resource, or clear BigQuery's query-result cache. See
+the [`bigquery_clear_cache` reference](../function-reference/bigquery-clear-cache.md)
+for the result contract.
+
+## Detach the Catalog
+
+`DETACH` removes the local DuckDB catalog. It does not delete or modify the
+BigQuery project, datasets, or tables:
+
+```sql
+-- Remove the local catalog without changing BigQuery resources.
+DETACH bq;
+```
+
+<a id="compatibility-helper"></a>
+
+## Legacy Compatibility Helper
+
+The older `bigquery_attach` helper enumerates one dataset and creates local
+DuckDB views backed by `bigquery_scan`:
+
+```sql
+-- Create compatibility views for one BigQuery dataset.
+CALL bigquery_attach(
+    'my-gcp-project.my_dataset',
+    overwrite := false
+);
+```
+
+Prefer storage `ATTACH` for catalog lookup, configuration reuse, transactions,
+DDL, and writes. Use the helper only when compatibility with its local-view
+workflow is required; its complete contract is documented in the
+[`bigquery_attach` reference](../function-reference/bigquery-attach.md).

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,0 +1,232 @@
+# Additional Settings
+
+The BigQuery extension registers its settings when it is loaded. Use regular
+DuckDB `SET` statements to change them. Function parameters and `ATTACH`
+options are documented with their respective interfaces; they are not global
+extension settings.
+
+List the available BigQuery settings and their current values through
+`duckdb_settings()`:
+
+```sql
+-- Load the extension and register its settings.
+LOAD 'bigquery';
+
+-- Inspect all settings registered by the BigQuery extension.
+SELECT
+      name,
+      value,
+      description
+  FROM duckdb_settings()
+  WHERE name LIKE 'bq_%'
+  ORDER BY name;
+┌──────────────────────────┬─────────┬────────────────────────────────────────────┐
+│ name                     │ value   │ description                                │
+│ varchar                  │ varchar │ varchar                                    │
+├──────────────────────────┼─────────┼────────────────────────────────────────────┤
+│ bq_arrow_compression     │ ZSTD    │ Arrow compression codec                    │
+│ bq_auth_timeout_s        │ 10      │ Authentication request timeout in seconds  │
+│ bq_default_location      │ US      │ Default BigQuery location                  │
+│            ·             │  ·      │                     ·                      │
+└──────────────────────────┴─────────┴────────────────────────────────────────────┘
+```
+
+For operational errors and known limitations, see
+[Troubleshooting](../troubleshooting.md).
+
+## Settings
+
+| Setting | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `bq_default_location` | `VARCHAR` | `US` | Fallback for location-aware operations without an explicit location |
+| `bq_query_timeout_ms` | `BIGINT` | `0` | Maximum local wait for query-job completion; `0` waits indefinitely |
+| `bq_auth_timeout_s` | `BIGINT` | `10` | Timeout for authentication token requests |
+| `bq_max_read_streams` | `BIGINT` | `0` | Maximum requested Storage Read streams; `0` follows the DuckDB thread count |
+| `bq_arrow_compression` | `VARCHAR` | `ZSTD` | Arrow compression for Storage Read: `UNSPECIFIED`, `LZ4_FRAME`, or `ZSTD` |
+| `bq_experimental_filter_pushdown` | `BOOLEAN` | `true` | Translate eligible DuckDB filters to Storage Read row restrictions |
+| `bq_enable_aggregate_pushdown` | `BOOLEAN` | `false` | Rewrite supported aggregates as BigQuery query jobs |
+| `bq_experimental_use_info_schema` | `BOOLEAN` | `true` | Fetch catalog metadata with job-backed `INFORMATION_SCHEMA` queries |
+| `bq_experimental_enable_sql_parser` | `BOOLEAN` | `false` | Parse supported BigQuery-specific `CREATE` clauses |
+| `bq_enable_inflight_request_windowing` | `BOOLEAN` | `true` | Allow multiple unacknowledged Storage Write requests in flight |
+| `bq_bignumeric_as_varchar` | `BOOLEAN` | `true` | Expose BigQuery `BIGNUMERIC` as exact `VARCHAR` values |
+| `bq_debug_show_queries` | `BOOLEAN` | `false` | Print generated GoogleSQL to standard output |
+| `bq_curl_ca_bundle_path` | `VARCHAR` | empty | Set a readable CA bundle for cURL-based REST requests |
+
+Timeout and stream-count values must be nonnegative and fit in a signed
+32-bit integer. BigQuery can return fewer read streams than requested.
+
+## Location and Timeouts
+
+### Default Location
+
+`bq_default_location` provides the fallback for location-aware operations.
+When a function accepts an explicit `location` parameter, that value overrides
+the setting for that call.
+
+```sql
+-- Use EU when an operation does not specify its own location.
+SET bq_default_location = 'EU';
+```
+
+The effective location, whether explicit or inherited from the setting, must
+be compatible with the datasets involved in the operation. A mismatch is
+rejected by BigQuery rather than moving data between regions.
+
+### Query and Authentication Timeouts
+
+`bq_query_timeout_ms` limits how long DuckDB waits locally for a BigQuery
+query job. The default `0` waits until the job completes. Reaching the timeout
+stops the local wait but does not guarantee that BigQuery cancels the remote
+job.
+
+`bq_auth_timeout_s` limits authentication token fetches. Increase it only
+when the metadata server or OAuth endpoint is expected to respond slowly.
+
+```sql
+-- Wait up to one minute for a BigQuery query job.
+SET bq_query_timeout_ms = 60000;
+
+-- Wait up to 30 seconds for an authentication token.
+SET bq_auth_timeout_s = 30;
+```
+
+## Storage Read Settings
+
+### Parallel Read Streams
+
+`bq_max_read_streams` controls the maximum number of streams requested from
+the BigQuery Storage Read API. Its default `0` uses DuckDB's configured thread
+count. BigQuery may still grant fewer streams based on table size and service
+limits.
+
+Parallel reads also require DuckDB's `preserve_insertion_order` setting to be
+disabled:
+
+```sql
+-- Allow parallel result consumption.
+SET preserve_insertion_order = false;
+
+-- Request up to the configured DuckDB thread count.
+SET bq_max_read_streams = 0;
+```
+
+Setting a value greater than `1` while preserving insertion order produces a
+warning and still limits the read path to one stream.
+
+### Arrow Compression
+
+`bq_arrow_compression` selects the compression requested for Arrow record
+batches returned by Storage Read. `ZSTD` is the default. `LZ4_FRAME` can be a
+useful alternative when lower decompression overhead matters more than wire
+size. `UNSPECIFIED` requests no specific codec. Tests with the current service
+behavior have not shown additional compression for this value, but the enum
+does not guarantee a particular codec or response encoding.
+
+```sql
+-- Request LZ4 frame compression for Storage Read responses.
+SET bq_arrow_compression = 'LZ4_FRAME';
+```
+
+### Filter Pushdown
+
+`bq_experimental_filter_pushdown` is enabled by default. Eligible filters on
+native BigQuery tables become Storage Read row restrictions, reducing the
+rows transferred to DuckDB. Unsupported filters remain in the local DuckDB
+plan.
+
+```sql
+-- Keep all filtering in DuckDB for comparison or diagnosis.
+SET bq_experimental_filter_pushdown = false;
+```
+
+Use `EXPLAIN` as described under
+[Filter Pushdown](reading-and-queries.md#filter-pushdown) to inspect
+the execution plan.
+
+## Storage Write Settings
+
+`bq_enable_inflight_request_windowing` allows multiple Storage Write
+`AppendRows` requests to remain in flight before the extension waits for
+acknowledgements. The default is optimized for throughput. Disable it to
+reduce the amount of unacknowledged data buffered in memory, at the cost of
+lower write throughput.
+
+```sql
+-- Wait for each append acknowledgement before sending more data.
+SET bq_enable_inflight_request_windowing = false;
+```
+
+## Experimental Planning and Parsing
+
+### Aggregate Pushdown
+
+`bq_enable_aggregate_pushdown` is disabled by default. When enabled, the
+optimizer can translate supported aggregates, filters, grouping expressions,
+and compatible `DISTINCT` aggregates to GoogleSQL and execute them in
+BigQuery.
+
+```sql
+-- Allow supported aggregate queries to run in BigQuery.
+SET bq_enable_aggregate_pushdown = true;
+```
+
+Unsupported query shapes fall back to DuckDB before a remote job starts.
+Errors from an already started BigQuery job are not retried locally.
+GoogleSQL casting, string, and floating-point semantics can also differ from
+DuckDB semantics. Use `EXPLAIN` to confirm the selected execution path.
+
+### Catalog Metadata through INFORMATION_SCHEMA
+
+`bq_experimental_use_info_schema` is enabled by default and can make catalog
+discovery significantly faster than fetching each table through the REST API.
+The extension submits an `INFORMATION_SCHEMA` query job for each dataset
+location involved in discovery. This requires permission to create BigQuery
+jobs and can incur query costs.
+
+Disable the setting to fetch table metadata through REST requests without
+submitting these metadata query jobs. This is also useful when comparing
+metadata behavior or diagnosing catalog discovery:
+
+```sql
+-- Fetch catalog metadata without the INFORMATION_SCHEMA optimization.
+SET bq_experimental_use_info_schema = false;
+```
+
+### BigQuery-specific CREATE Clauses
+
+`bq_experimental_enable_sql_parser` enables the parser extension for supported
+BigQuery-specific `OPTIONS`, `PARTITION BY`, and `CLUSTER BY` clauses. It is
+disabled by default because it changes how the extension preprocesses
+`CREATE` statements.
+
+```sql
+-- Enable supported BigQuery-specific CREATE clauses.
+SET bq_experimental_enable_sql_parser = true;
+```
+
+See [Managing Tables & Datasets](managing-tables-and-schemas.md) for
+the supported forms and examples.
+
+## Type and Diagnostic Settings
+
+`bq_bignumeric_as_varchar` is retained for compatibility with older
+workflows. Current versions expose `BIGNUMERIC` as exact `VARCHAR` values
+because its precision exceeds DuckDB's maximum decimal precision. See
+[Data Type Mapping](../concepts/data-types.md#bignumeric-and-arrays).
+
+`bq_debug_show_queries` prints generated remote SQL to standard output. Use it
+only for short-lived diagnosis because the SQL text can contain sensitive
+values:
+
+```sql
+-- Print generated GoogleSQL for subsequent remote operations.
+SET bq_debug_show_queries = true;
+```
+
+`bq_curl_ca_bundle_path` overrides the CA bundle used by cURL-based REST
+requests. The file must exist and be readable:
+
+```sql
+-- Use an explicit CA bundle for REST requests.
+SET bq_curl_ca_bundle_path = '/path/to/ca-bundle.pem';
+```

--- a/docs/user-guide/extract-and-load.md
+++ b/docs/user-guide/extract-and-load.md
@@ -1,0 +1,319 @@
+# Extract and Load
+
+BigQuery provides native batch operations for moving data in both directions:
+
+- **Load:** A
+  [BigQuery load job](https://docs.cloud.google.com/bigquery/docs/batch-loading-data)
+  imports batch data from local files or Cloud Storage into a BigQuery table.
+  The job handles formats such as CSV, JSON, Avro, Parquet, and ORC, including
+  schema detection and whether data is appended or overwritten.
+
+- **Export:** BigQuery exports table data to Cloud Storage with an extract
+  job—the same operation exposed by the `bq extract` command. Google documents
+  this under
+  [Export table data to Cloud Storage](https://docs.cloud.google.com/bigquery/docs/exporting-data):
+  **export** is the user-facing capability, while **extract job** is the
+  underlying BigQuery job type.
+
+Use `bigquery_load` and `bigquery_extract` to run these operations from DuckDB
+SQL. Both functions wait for completion and return the job identity, status,
+and transfer statistics; the following sections cover their inputs, options,
+and operational requirements.
+
+## Load Data into BigQuery {#load-data}
+
+`bigquery_load` creates a BigQuery load job with exactly one source family. A
+local file is uploaded directly, Cloud Storage URIs are read by BigQuery, and
+a DuckDB table or view is first written to a temporary Parquet file. All three
+paths write to a BigQuery `dataset.table`.
+
+Load a local file:
+
+=== "Project ID"
+
+    ```sql
+    -- Load a local Parquet file into a BigQuery table.
+    SELECT *
+      FROM bigquery_load(
+          'my-gcp-project',
+          'my_dataset.events',
+          source_file := '/absolute/path/events.parquet',
+          source_format := 'PARQUET',
+          billing_project := 'my-billing-project'
+      );
+    ┌─────────┬──────────────┬────────────────┬──────────┬──────────────────────────────────┬─────────────┬──────────────────┐
+    │ success │ job_id       │ project_id     │ location │ destination_table                │ output_rows │ status           │
+    │ boolean │ varchar      │ varchar        │ varchar  │ varchar                          │ uint64      │ json             │
+    ├─────────┼──────────────┼────────────────┼──────────┼──────────────────────────────────┼─────────────┼──────────────────┤
+    │ true    │ load_job_123 │ my-gcp-project │ EU       │ my-gcp-project.my_dataset.events │        1250 │ {"state":"DONE"} │
+    └─────────┴──────────────┴────────────────┴──────────┴──────────────────────────────────┴─────────────┴──────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the destination dataset with its billing project.
+    ATTACH 'project=my-gcp-project dataset=my_dataset billing_project=my-billing-project'
+      AS bq (TYPE bigquery);
+
+    -- Load a local Parquet file through the attached catalog.
+    SELECT *
+      FROM bigquery_load(
+          'bq',
+          'my_dataset.events',
+          source_file := '/absolute/path/events.parquet',
+          source_format := 'PARQUET'
+      );
+    ┌─────────┬──────────────┬────────────────┬──────────┬──────────────────────────────────┬─────────────┬──────────────────┐
+    │ success │ job_id       │ project_id     │ location │ destination_table                │ output_rows │ status           │
+    │ boolean │ varchar      │ varchar        │ varchar  │ varchar                          │ uint64      │ json             │
+    ├─────────┼──────────────┼────────────────┼──────────┼──────────────────────────────────┼─────────────┼──────────────────┤
+    │ true    │ load_job_234 │ my-gcp-project │ EU       │ my-gcp-project.my_dataset.events │        1250 │ {"state":"DONE"} │
+    └─────────┴──────────────┴────────────────┴──────────┴──────────────────────────────────┴─────────────┴──────────────────┘
+    ```
+
+The job ID and row count in the example output depend on the submitted file.
+
+Load one or more Cloud Storage objects. URI wildcards are passed to BigQuery:
+
+=== "Project ID"
+
+    ```sql
+    -- Append matching Cloud Storage objects to a BigQuery table.
+    SELECT *
+      FROM bigquery_load(
+          'my-gcp-project',
+          'my_dataset.events',
+          source_uris := ['gs://my-bucket/events/part-*.parquet'],
+          source_format := 'PARQUET',
+          write_disposition := 'WRITE_APPEND'
+      );
+    ┌─────────┬──────────────┬────────────────┬──────────┬──────────────────────────────────┬─────────────┬──────────────────┐
+    │ success │ job_id       │ project_id     │ location │ destination_table                │ output_rows │ status           │
+    │ boolean │ varchar      │ varchar        │ varchar  │ varchar                          │ uint64      │ json             │
+    ├─────────┼──────────────┼────────────────┼──────────┼──────────────────────────────────┼─────────────┼──────────────────┤
+    │ true    │ load_job_345 │ my-gcp-project │ EU       │ my-gcp-project.my_dataset.events │        5000 │ {"state":"DONE"} │
+    └─────────┴──────────────┴────────────────┴──────────┴──────────────────────────────────┴─────────────┴──────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the destination dataset.
+    ATTACH 'project=my-gcp-project dataset=my_dataset'
+      AS bq (TYPE bigquery);
+
+    -- Append matching Cloud Storage objects through the attached catalog.
+    SELECT *
+      FROM bigquery_load(
+          'bq',
+          'my_dataset.events',
+          source_uris := ['gs://my-bucket/events/part-*.parquet'],
+          source_format := 'PARQUET',
+          write_disposition := 'WRITE_APPEND'
+      );
+    ┌─────────┬──────────────┬────────────────┬──────────┬──────────────────────────────────┬─────────────┬──────────────────┐
+    │ success │ job_id       │ project_id     │ location │ destination_table                │ output_rows │ status           │
+    │ boolean │ varchar      │ varchar        │ varchar  │ varchar                          │ uint64      │ json             │
+    ├─────────┼──────────────┼────────────────┼──────────┼──────────────────────────────────┼─────────────┼──────────────────┤
+    │ true    │ load_job_456 │ my-gcp-project │ EU       │ my-gcp-project.my_dataset.events │        5000 │ {"state":"DONE"} │
+    └─────────┴──────────────┴────────────────┴──────────┴──────────────────────────────────┴─────────────┴──────────────────┘
+    ```
+
+BigQuery reads Cloud Storage sources itself, so the job identity needs access
+to the objects. The bucket must also satisfy BigQuery's location rules for the
+destination dataset. Google's
+[batch loading documentation](https://cloud.google.com/bigquery/docs/batch-loading-data)
+describes supported Cloud Storage layouts, wildcard behavior, permissions,
+locations, service limits, and format-specific restrictions.
+
+To load a DuckDB relation, pass its catalog-qualified name through
+`source_table`:
+
+=== "Project ID"
+
+    ```sql
+    -- Prepare a local DuckDB relation for the load job.
+    CREATE TEMP TABLE prepared_events AS
+      SELECT *
+      FROM read_parquet('/absolute/path/source/*.parquet');
+
+    -- Replace the destination table with the prepared relation.
+    SELECT *
+      FROM bigquery_load(
+          'my-gcp-project',
+          'my_dataset.events',
+          source_table := 'prepared_events',
+          write_disposition := 'WRITE_TRUNCATE'
+      );
+    ┌─────────┬──────────────┬────────────────┬──────────┬──────────────────────────────────┬─────────────┬──────────────────┐
+    │ success │ job_id       │ project_id     │ location │ destination_table                │ output_rows │ status           │
+    │ boolean │ varchar      │ varchar        │ varchar  │ varchar                          │ uint64      │ json             │
+    ├─────────┼──────────────┼────────────────┼──────────┼──────────────────────────────────┼─────────────┼──────────────────┤
+    │ true    │ load_job_567 │ my-gcp-project │ EU       │ my-gcp-project.my_dataset.events │        1250 │ {"state":"DONE"} │
+    └─────────┴──────────────┴────────────────┴──────────┴──────────────────────────────────┴─────────────┴──────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the destination dataset.
+    ATTACH 'project=my-gcp-project dataset=my_dataset'
+      AS bq (TYPE bigquery);
+
+    -- Prepare a local DuckDB relation for the load job.
+    CREATE TEMP TABLE prepared_events AS
+      SELECT *
+      FROM read_parquet('/absolute/path/source/*.parquet');
+
+    -- Replace the destination table through the attached catalog.
+    SELECT *
+      FROM bigquery_load(
+          'bq',
+          'my_dataset.events',
+          source_table := 'prepared_events',
+          write_disposition := 'WRITE_TRUNCATE'
+      );
+    ┌─────────┬──────────────┬────────────────┬──────────┬──────────────────────────────────┬─────────────┬──────────────────┐
+    │ success │ job_id       │ project_id     │ location │ destination_table                │ output_rows │ status           │
+    │ boolean │ varchar      │ varchar        │ varchar  │ varchar                          │ uint64      │ json             │
+    ├─────────┼──────────────┼────────────────┼──────────┼──────────────────────────────────┼─────────────┼──────────────────┤
+    │ true    │ load_job_678 │ my-gcp-project │ EU       │ my-gcp-project.my_dataset.events │        1250 │ {"state":"DONE"} │
+    └─────────┴──────────────┴────────────────┴──────────┴──────────────────────────────────┴─────────────┴──────────────────┘
+    ```
+
+The extension stages the relation as a temporary local Parquet file, uploads
+it, and removes it after the operation. The temporary directory must have
+enough free space for the complete staged relation.
+
+The extension accepts Parquet, CSV, newline-delimited JSON, Avro, and ORC.
+Recognized and consistent file suffixes can determine the format; otherwise
+specify `source_format`. CSV, JSON, Avro, Parquet, ORC, schema evolution, and
+Hive partitioning each have additional options in the
+[`bigquery_load` reference](../function-reference/bigquery-load.md). Google's
+[loading overview](https://cloud.google.com/bigquery/docs/loading-data)
+places batch load jobs alongside streaming, transfer, and federation options
+that are outside this function's scope.
+
+!!! warning "Default write disposition"
+
+    `bigquery_load` defaults to `WRITE_TRUNCATE`. Set
+    `write_disposition := 'WRITE_APPEND'` to append, or `WRITE_EMPTY` to
+    require an empty destination. `create_disposition` independently controls
+    whether BigQuery may create a missing table.
+
+## Extract a Table to Cloud Storage {#extract-data}
+
+`bigquery_extract` creates an extract job for one BigQuery table and writes one
+or more objects to Cloud Storage:
+
+=== "Project ID"
+
+    ```sql
+    -- Export a BigQuery table to compressed Parquet objects.
+    SELECT *
+      FROM bigquery_extract(
+          'my-gcp-project',
+          source_table := 'my_dataset.events',
+          destination_uris := 'gs://my-bucket/exports/events-*.parquet',
+          format := 'PARQUET',
+          compression := 'ZSTD',
+          billing_project := 'my-billing-project'
+      );
+    ┌─────────┬─────────────────┬────────────────┬───┬─────────────────────────────┬─────────────┬──────────────────┐
+    │ success │ job_id          │ project_id     │ … │ destination_uri_file_counts │ input_bytes │ status           │
+    │ boolean │ varchar         │ varchar        │ … │ bigint[]                    │ bigint      │ json             │
+    ├─────────┼─────────────────┼────────────────┼───┼─────────────────────────────┼─────────────┼──────────────────┤
+    │ true    │ extract_job_123 │ my-gcp-project │ … │ [2]                         │      983040 │ {"state":"DONE"} │
+    └─────────┴─────────────────┴────────────────┴───┴─────────────────────────────┴─────────────┴──────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the source dataset with its billing project.
+    ATTACH 'project=my-gcp-project dataset=my_dataset billing_project=my-billing-project'
+      AS bq (TYPE bigquery);
+
+    -- Export a table through the attached catalog.
+    SELECT *
+      FROM bigquery_extract(
+          'bq',
+          source_table := 'my_dataset.events',
+          destination_uris := 'gs://my-bucket/exports/events-*.parquet',
+          format := 'PARQUET',
+          compression := 'ZSTD'
+      );
+    ┌─────────┬─────────────────┬────────────────┬───┬─────────────────────────────┬─────────────┬──────────────────┐
+    │ success │ job_id          │ project_id     │ … │ destination_uri_file_counts │ input_bytes │ status           │
+    │ boolean │ varchar         │ varchar        │ … │ bigint[]                    │ bigint      │ json             │
+    ├─────────┼─────────────────┼────────────────┼───┼─────────────────────────────┼─────────────┼──────────────────┤
+    │ true    │ extract_job_234 │ my-gcp-project │ … │ [2]                         │      983040 │ {"state":"DONE"} │
+    └─────────┴─────────────────┴────────────────┴───┴─────────────────────────────┴─────────────┴──────────────────┘
+    ```
+
+Job IDs, file counts, and byte counts vary by execution. DuckDB may collapse
+wide result sets with `…`; the
+[`bigquery_extract` reference](../function-reference/bigquery-extract.md#result)
+lists every result column.
+
+The source is a table identifier, not arbitrary GoogleSQL. To export the
+result of a query, either materialize it into a table first or execute
+GoogleSQL's
+[`EXPORT DATA` statement](https://cloud.google.com/bigquery/docs/reference/standard-sql/export-statements)
+with `bigquery_execute`.
+
+The destination must use `gs://`. Use a wildcard when BigQuery may need to
+produce multiple objects. BigQuery limits a single export file to 1 GB of
+logical data; larger exports require multiple files. Output order is not
+guaranteed for a table extract. Google's
+[table export documentation](https://cloud.google.com/bigquery/docs/exporting-data)
+explains destination URI rules, location requirements, export limits, and
+Cloud Storage behavior.
+
+The extension supports CSV, newline-delimited JSON, Avro, and Parquet exports.
+It can infer a format when every destination URI has a consistent recognized
+suffix, or `format` can be set explicitly. Compression is format-specific:
+
+| Format | Supported compression |
+| --- | --- |
+| CSV | `NONE`, `GZIP` |
+| Newline-delimited JSON | `NONE`, `GZIP` |
+| Avro | `NONE`, `DEFLATE`, `SNAPPY` |
+| Parquet | `NONE`, `GZIP`, `SNAPPY`, `ZSTD` |
+
+CSV cannot represent nested and repeated BigQuery values. Prefer Avro,
+newline-delimited JSON, or Parquet for those schemas. The
+[`bigquery_extract` reference](../function-reference/bigquery-extract.md)
+contains the complete parameters, format inference rules, CSV and Avro
+options, and result columns.
+
+## Permissions, Locations, and Job Completion
+
+Load and extract calls require permission to create BigQuery jobs, access to
+the source, permission to modify the load destination, and the relevant Cloud
+Storage access. The exact IAM set depends on the direction and source type;
+start with the project's [required permissions](../getting-started/required-permissions.md)
+and the operation-specific permissions in Google's
+[load](https://cloud.google.com/bigquery/docs/batch-loading-data) and
+[export](https://cloud.google.com/bigquery/docs/exporting-data)
+documentation.
+
+The BigQuery job location and Cloud Storage bucket location must be compatible
+with the dataset involved in the transfer. Pass `location` when it cannot be
+derived or when `bq_default_location` is not appropriate. A mismatched location
+can make an otherwise valid transfer fail.
+
+Both functions wait for BigQuery and return the remote job ID, project,
+location, status, and operation-specific statistics. A local `timeout_ms`
+stops waiting in DuckDB but does not guarantee cancellation: the remote job can
+continue reading, writing, or incurring charges. Use the returned `job_id`
+with [Executing & Monitoring Jobs](jobs-and-transfers.md#monitor-jobs) to
+inspect a timed-out or completed transfer.
+
+Google's [job management guide](https://cloud.google.com/bigquery/docs/managing-jobs)
+describes the BigQuery job lifecycle. Load and extract operations are also
+subject to BigQuery's current
+[quotas and limits](https://cloud.google.com/bigquery/quotas). Review
+[Billing and Costs](../index.md#billing-and-costs) before submitting large
+transfers.

--- a/docs/user-guide/geometry-support.md
+++ b/docs/user-guide/geometry-support.md
@@ -1,0 +1,319 @@
+# Working with Geometries
+
+Since DuckDB 1.5, [`GEOMETRY` is a built-in DuckDB
+type](https://duckdb.org/docs/current/sql/data_types/geometry). The BigQuery
+extension can therefore expose BigQuery `GEOGRAPHY` columns as native DuckDB
+geometry and write geometry values back without loading another extension or
+enabling a BigQuery-specific setting.
+
+The type itself is built in, but most functions for spatial analysis and CRS
+transformation still come from DuckDB's
+[`spatial` extension](https://duckdb.org/docs/stable/core_extensions/spatial/overview).
+Load `spatial` when those functions are needed; it is not required merely to
+read, store, or write a `GEOMETRY` value.
+
+!!! note "DuckDB versions before 1.5"
+
+    Older DuckDB versions obtained `GEOMETRY` from `spatial`, and older builds
+    of this extension used `bq_geography_as_geometry` to opt into the mapping.
+    That setting is no longer used; the current mapping is automatic.
+
+## Geometry and Geography
+
+DuckDB and BigQuery use different names because they model different
+semantics:
+
+| DuckDB `GEOMETRY` | BigQuery `GEOGRAPHY` |
+| --- | --- |
+| A general geometry in a Cartesian coordinate space | A point set on the surface of the Earth |
+| Can carry an optional coordinate reference system | Uses WGS84 longitude and latitude |
+| The execution engine treats coordinates as Cartesian | Edges are spherical geodesics between vertices |
+| Can represent data in geographic or projected CRSs | Does not represent arbitrary projected CRSs |
+
+BigQuery documents these semantics under
+[Working with geospatial data](https://cloud.google.com/bigquery/docs/geospatial-data#coordinate_systems_and_edges).
+They matter even when both systems display the same WKT. A line between two
+distant vertices is straight in Cartesian coordinates but follows a geodesic
+in BigQuery. Areas, lengths, distances, polygons crossing the antimeridian, and
+shapes near the poles can therefore produce different results.
+
+## Type Mapping
+
+The extension uses this bidirectional mapping:
+
+| Direction | Source | Destination |
+| --- | --- | --- |
+| Read | BigQuery `GEOGRAPHY` | DuckDB `GEOMETRY('OGC:CRS84')` |
+| Create or write | DuckDB `GEOMETRY` | BigQuery `GEOGRAPHY` |
+
+`OGC:CRS84` identifies WGS84 coordinates with `X` as longitude and `Y` as
+latitude. This matches BigQuery's coordinate order and makes the expected CRS
+visible in the DuckDB type.
+
+WKT is used at the API boundary. On reads, the extension receives the
+BigQuery geography representation as text, parses it into DuckDB's native
+geometry format, and assigns `OGC:CRS84`. On writes, it converts the DuckDB
+geometry to WKT and sends that text through the Storage Write API as the
+BigQuery `GEOGRAPHY` field value.
+
+The common Simple Features shapes can cross this boundary: `POINT`,
+`LINESTRING`, `POLYGON`, `MULTIPOINT`, `MULTILINESTRING`, `MULTIPOLYGON`, and
+`GEOMETRYCOLLECTION`.
+
+## Read Geography
+
+Both attached table scans and `bigquery_scan` return `GEOGRAPHY` columns as
+CRS-aware `GEOMETRY` values. The default `bigquery_query` path and its optional
+REST result path use the same logical type mapping.
+
+=== "Project ID"
+
+    ```sql
+    -- Read a BigQuery GEOGRAPHY column without creating a catalog.
+    SELECT
+          place_id,
+          ST_AsWKT(geom) AS wkt,
+          typeof(geom) AS duckdb_type,
+          ST_CRS(geom) AS crs
+      FROM bigquery_scan('my-gcp-project.my_dataset.places')
+      LIMIT 2;
+    ┌──────────┬──────────────────────────────┬───────────────────────────┬───────────┐
+    │ place_id │ wkt                          │ duckdb_type               │ crs       │
+    │ int64    │ varchar                      │ varchar                   │ varchar   │
+    ├──────────┼──────────────────────────────┼───────────────────────────┼───────────┤
+    │        1 │ POINT (-0.1276 51.5072)      │ GEOMETRY('OGC:CRS84')     │ OGC:CRS84 │
+    │        2 │ LINESTRING (-0.2 51.5, 0 52) │ GEOMETRY('OGC:CRS84')     │ OGC:CRS84 │
+    └──────────┴──────────────────────────────┴───────────────────────────┴───────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the dataset containing the GEOGRAPHY column.
+    ATTACH 'project=my-gcp-project dataset=my_dataset'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- Read the GEOGRAPHY column through the attached catalog.
+    SELECT
+          place_id,
+          ST_AsWKT(geom) AS wkt,
+          typeof(geom) AS duckdb_type,
+          ST_CRS(geom) AS crs
+      FROM bq.my_dataset.places
+      LIMIT 2;
+    ┌──────────┬──────────────────────────────┬───────────────────────────┬───────────┐
+    │ place_id │ wkt                          │ duckdb_type               │ crs       │
+    │ int64    │ varchar                      │ varchar                   │ varchar   │
+    ├──────────┼──────────────────────────────┼───────────────────────────┼───────────┤
+    │        1 │ POINT (-0.1276 51.5072)      │ GEOMETRY('OGC:CRS84')     │ OGC:CRS84 │
+    │        2 │ LINESTRING (-0.2 51.5, 0 52) │ GEOMETRY('OGC:CRS84')     │ OGC:CRS84 │
+    └──────────┴──────────────────────────────┴───────────────────────────┴───────────┘
+    ```
+
+`ST_AsWKT` and `ST_CRS` are built-in DuckDB geometry functions. This inspection
+therefore does not require `spatial`.
+
+## Write Geometry
+
+A DuckDB `GEOMETRY` column becomes a BigQuery `GEOGRAPHY` column when an
+attached table is created. Use `OGC:CRS84` values so the coordinates already
+have the semantics BigQuery expects:
+
+```sql
+-- Create a BigQuery table with a GEOGRAPHY destination column.
+CREATE TABLE bq.my_dataset.places (
+      place_id BIGINT,
+      geom GEOMETRY
+  );
+
+-- Write longitude first and latitude second.
+INSERT INTO bq.my_dataset.places
+VALUES (
+      1,
+      'POINT(-0.1276 51.5072)'::GEOMETRY('OGC:CRS84')
+  );
+```
+
+The attached `INSERT` completes without returning a result row. Query the
+destination table separately when the written geometry needs to be verified.
+
+The extension does not transform coordinates when writing. A value in a
+projected CRS such as `EPSG:3857` must be transformed to `OGC:CRS84` first;
+simply changing or omitting its CRS would leave the numeric coordinates
+unchanged and BigQuery would interpret them as longitude and latitude.
+
+Use `spatial` for an actual transformation:
+
+```sql
+-- Install and load spatial functions for CRS transformation.
+INSTALL spatial;
+LOAD spatial;
+
+-- Create projected source data with coordinates in EPSG:3857.
+CREATE TEMP TABLE local_projected_places AS
+SELECT
+      place_id,
+      ST_Transform(geom, 'EPSG:3857') AS geom
+  FROM (VALUES
+      (2, 'POINT(2.3522 48.8566)'::GEOMETRY('OGC:CRS84')),
+      (3, 'POINT(13.4050 52.5200)'::GEOMETRY('OGC:CRS84'))
+  ) AS places(place_id, geom);
+
+-- Transform projected coordinates before writing them to BigQuery.
+INSERT INTO bq.my_dataset.places
+SELECT
+      place_id,
+      ST_Transform(geom, 'OGC:CRS84')
+  FROM local_projected_places;
+
+-- Verify the rows after the INSERT completes without a result row.
+SELECT
+      place_id,
+      round(ST_X(geom), 4) AS longitude,
+      round(ST_Y(geom), 4) AS latitude
+  FROM bq.my_dataset.places
+  WHERE place_id IN (2, 3)
+  ORDER BY place_id;
+┌──────────┬───────────┬──────────┐
+│ place_id │ longitude │ latitude │
+│ int64    │ double    │ double   │
+├──────────┼───────────┼──────────┤
+│        2 │    2.3522 │  48.8566 │
+│        3 │    13.405 │    52.52 │
+└──────────┴───────────┴──────────┘
+```
+
+## Polygon Normalization
+
+Polygon orientation is more significant on a sphere than on a plane because a
+closed boundary can describe either side of the Earth. Before every Storage
+Write operation, the extension automatically normalizes `POLYGON` and
+`MULTIPOLYGON` values for the BigQuery write path:
+
+- exterior rings are oriented counterclockwise;
+- interior rings are oriented clockwise; and
+- touching hole rings that share boundary segments are merged when the result
+  is unambiguous.
+
+Other geometry shapes pass through the normalization step unchanged. Preview
+the normalized geometry locally with `bigquery_normalize_geography`:
+
+```sql
+-- Preview the polygon that the Storage Write path will serialize.
+SELECT bigquery_normalize_geography(
+      'POLYGON((0 0, 0 10, 10 10, 10 0, 0 0))'
+          ::GEOMETRY('OGC:CRS84')
+  ) AS normalized;
+┌──────────────────────────────────────────┐
+│                normalized                │
+│                 geometry                 │
+├──────────────────────────────────────────┤
+│ POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))  │
+└──────────────────────────────────────────┘
+```
+
+The function runs entirely in DuckDB and does not submit a BigQuery request.
+It is a targeted write normalization step, not a general geometry validator or
+repair tool. BigQuery can still reject self-intersections, invalid coordinates,
+ambiguous topology, and other invalid geography input. See the
+[`bigquery_normalize_geography` reference](../function-reference/bigquery-normalize-geography.md)
+for its contract.
+
+## Choose Where Spatial Operations Run
+
+Spatial expressions in ordinary DuckDB SQL execute locally after the geometry
+has been read. Load `spatial` for functions such as intersections, distances,
+areas, and transformations:
+
+```sql
+-- Install and load spatial functions for local predicates.
+INSTALL spatial;
+LOAD spatial;
+
+-- Evaluate the spatial predicate locally in DuckDB.
+SELECT place_id
+  FROM bq.my_dataset.places
+  WHERE ST_Intersects(
+      geom,
+      'POLYGON((-1 50, 1 50, 1 52, -1 52, -1 50))'
+          ::GEOMETRY('OGC:CRS84')
+  );
+┌──────────┐
+│ place_id │
+│ int64    │
+├──────────┤
+│        1 │
+└──────────┘
+```
+
+Use `bigquery_query` when BigQuery should evaluate its own geography functions
+with BigQuery's spherical semantics:
+
+=== "Project ID"
+
+    ```sql
+    -- Let BigQuery calculate a spherical distance in meters.
+    SELECT distance_m
+      FROM bigquery_query(
+          'my-gcp-project',
+          'SELECT ST_DISTANCE(
+               ST_GEOGPOINT(-0.1276, 51.5072),
+               ST_GEOGPOINT(2.3522, 48.8566)
+           ) AS distance_m'
+      );
+    ┌────────────────────┐
+    │ distance_m         │
+    │ double             │
+    ├────────────────────┤
+    │ 343556.06034104165 │
+    └────────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the project whose query configuration should be reused.
+    ATTACH 'project=my-gcp-project'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- Run the same geography calculation through the attached catalog.
+    SELECT distance_m
+      FROM bigquery_query(
+          'bq',
+          'SELECT ST_DISTANCE(
+               ST_GEOGPOINT(-0.1276, 51.5072),
+               ST_GEOGPOINT(2.3522, 48.8566)
+           ) AS distance_m'
+      );
+    ┌────────────────────┐
+    │ distance_m         │
+    │ double             │
+    ├────────────────────┤
+    │ 343556.06034104165 │
+    └────────────────────┘
+    ```
+
+The returned scalar is a regular DuckDB value. If the GoogleSQL result itself
+contains `GEOGRAPHY`, the extension maps it back to
+`GEOMETRY('OGC:CRS84')`.
+
+## Semantic Boundaries
+
+Keep these boundaries in mind when moving geometries between both systems:
+
+- WKT does not carry CRS metadata. The extension assigns `OGC:CRS84` when
+  reading BigQuery and assumes compatible longitude/latitude coordinates when
+  writing.
+- The extension does not tessellate long planar edges before BigQuery
+  interprets them as geodesics.
+- Local DuckDB geometry calculations use Cartesian execution semantics unless
+  a function explicitly provides different behavior. BigQuery geography
+  functions use their documented spherical or spheroidal semantics.
+- Automatic polygon normalization does not replace validation in BigQuery.
+  Large polygons, antimeridian crossings, polar data, and complex collections
+  should be checked after a round trip.
+
+For the other type mappings, see [Data Type Mapping](../concepts/data-types.md). Continue
+with [Writing & Modifying Data](writing.md) for insert and CTAS
+workflows, or [Additional Settings](configuration.md) for Storage Read and
+Storage Write configuration.

--- a/docs/user-guide/jobs-and-transfers.md
+++ b/docs/user-guide/jobs-and-transfers.md
@@ -1,0 +1,294 @@
+# Executing & Monitoring Jobs
+
+Use the job functions when BigQuery should execute a statement, estimate a
+query, or expose job metadata. These functions can accept a project ID or an
+attached catalog as documented in their individual references.
+
+- [`bigquery_execute`](#execute-googlesql): Run GoogleSQL as a query job and
+  return execution metadata.
+- [`bigquery_jobs`](#monitor-jobs): List or inspect jobs through the Jobs REST
+  API.
+
+For data transfers with `bigquery_load` and `bigquery_extract`, see
+[Extract & Load](extract-and-load.md).
+
+Use [`bigquery_query`](reading-and-queries.md#bigquery-query) when query rows are
+the desired result. Prefer attached
+[table and dataset management](managing-tables-and-schemas.md) or
+[Writing & Modifying Data](writing.md) when the attached DuckDB SQL
+surface is sufficient.
+
+## Execute GoogleSQL
+
+`bigquery_execute` returns execution metadata instead of query rows. Use it for
+GoogleSQL DDL, DML, scripts, or materializing a query into a destination table:
+
+=== "Project ID"
+
+    ```sql
+    -- Create a BigQuery table and return the DDL job metadata.
+    SELECT *
+      FROM bigquery_execute(
+          'my-gcp-project',
+          'CREATE TABLE IF NOT EXISTS
+           `my-gcp-project.my_dataset.example` (id INT64)'
+      );
+    ┌─────────┬─────────────────┬────────────────┬───┬───────────────────────┐
+    │ success │ job_id          │ project_id     │ … │ num_dml_affected_rows │
+    │ boolean │ varchar         │ varchar        │ … │ bigint                │
+    ├─────────┼─────────────────┼────────────────┼───┼───────────────────────┤
+    │ true    │ execute_job_123 │ my-gcp-project │ … │                     0 │
+    └─────────┴─────────────────┴────────────────┴───┴───────────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the writable dataset.
+    ATTACH 'project=my-gcp-project dataset=my_dataset'
+      AS bq (TYPE bigquery);
+
+    -- Run the same DDL job through the attached catalog.
+    SELECT *
+      FROM bigquery_execute(
+          'bq',
+          'CREATE TABLE IF NOT EXISTS
+           `my-gcp-project.my_dataset.example` (id INT64)'
+      );
+    ┌─────────┬─────────────────┬────────────────┬───┬───────────────────────┐
+    │ success │ job_id          │ project_id     │ … │ num_dml_affected_rows │
+    │ boolean │ varchar         │ varchar        │ … │ bigint                │
+    ├─────────┼─────────────────┼────────────────┼───┼───────────────────────┤
+    │ true    │ execute_job_234 │ my-gcp-project │ … │                     0 │
+    └─────────┴─────────────────┴────────────────┴───┴───────────────────────┘
+    ```
+
+Use `SELECT * FROM bigquery_execute(...)` when metadata such as the job ID or
+affected-row count is needed.
+
+Materialize a query result with destination options:
+
+=== "Project ID"
+
+    ```sql
+    -- Materialize an aggregated query result in a destination table.
+    SELECT *
+      FROM bigquery_execute(
+          'my-gcp-project',
+          'SELECT event_date, COUNT(*) AS event_count
+           FROM `my-gcp-project.my_dataset.events`
+           GROUP BY event_date',
+          destination_table := 'my_dataset.daily_event_counts',
+          write_disposition := 'WRITE_TRUNCATE'
+      );
+    ┌─────────┬─────────────────┬────────────────┬───┬────────────┬───────────────────────┐
+    │ success │ job_id          │ project_id     │ … │ total_rows │ num_dml_affected_rows │
+    │ boolean │ varchar         │ varchar        │ … │ uint64     │ bigint                │
+    ├─────────┼─────────────────┼────────────────┼───┼────────────┼───────────────────────┤
+    │ true    │ execute_job_345 │ my-gcp-project │ … │        365 │ NULL                  │
+    └─────────┴─────────────────┴────────────────┴───┴────────────┴───────────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the writable dataset.
+    ATTACH 'project=my-gcp-project dataset=my_dataset'
+      AS bq (TYPE bigquery);
+
+    -- Materialize the query result through the attached catalog.
+    SELECT *
+      FROM bigquery_execute(
+          'bq',
+          'SELECT event_date, COUNT(*) AS event_count
+           FROM `my-gcp-project.my_dataset.events`
+           GROUP BY event_date',
+          destination_table := 'my_dataset.daily_event_counts',
+          write_disposition := 'WRITE_TRUNCATE'
+      );
+    ┌─────────┬─────────────────┬────────────────┬───┬────────────┬───────────────────────┐
+    │ success │ job_id          │ project_id     │ … │ total_rows │ num_dml_affected_rows │
+    │ boolean │ varchar         │ varchar        │ … │ uint64     │ bigint                │
+    ├─────────┼─────────────────┼────────────────┼───┼────────────┼───────────────────────┤
+    │ true    │ execute_job_456 │ my-gcp-project │ … │        365 │ NULL                  │
+    └─────────┴─────────────────┴────────────────┴───┴────────────┴───────────────────────┘
+    ```
+
+Destination materialization and dry runs cannot be combined. See the
+[`bigquery_execute` reference](../function-reference/bigquery-execute.md) for
+dispositions, defaults, result columns, and validation rules.
+
+## Dry Runs
+
+`bigquery_query` and `bigquery_execute` accept `dry_run := true`:
+
+=== "Project ID"
+
+    ```sql
+    -- Estimate the bytes processed without executing the query.
+    SELECT *
+      FROM bigquery_query(
+          'my-gcp-project',
+          'SELECT * FROM `my-gcp-project.my_dataset.events`',
+          dry_run := true
+      );
+    ┌───────────────────────┬───────────┬──────────┐
+    │ total_bytes_processed │ cache_hit │ location │
+    │ bigint                │ boolean   │ varchar  │
+    ├───────────────────────┼───────────┼──────────┤
+    │               1048576 │ false     │ EU       │
+    └───────────────────────┴───────────┴──────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the dataset whose query should be estimated.
+    ATTACH 'project=my-gcp-project dataset=my_dataset'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- Reuse the attached catalog configuration for the dry run.
+    SELECT *
+      FROM bigquery_query(
+          'bq',
+          'SELECT * FROM `my-gcp-project.my_dataset.events`',
+          dry_run := true
+      );
+    ┌───────────────────────┬───────────┬──────────┐
+    │ total_bytes_processed │ cache_hit │ location │
+    │ bigint                │ boolean   │ varchar  │
+    ├───────────────────────┼───────────┼──────────┤
+    │               1048576 │ false     │ EU       │
+    └───────────────────────┴───────────┴──────────┘
+    ```
+
+The result reports BigQuery's processed-byte estimate, cache status, and job
+location. The estimate describes BigQuery query processing, not the result
+data later transferred to DuckDB.
+
+## Monitor Jobs
+
+List recent jobs:
+
+=== "Project ID"
+
+    ```sql
+    -- List the 100 most recent completed jobs.
+    SELECT
+          job_id,
+          state,
+          job_type,
+          creation_time,
+          bytes_processed
+      FROM bigquery_jobs(
+          'my-gcp-project',
+          stateFilter := 'DONE',
+          maxResults := 100
+      )
+      ORDER BY creation_time DESC;
+    ┌─────────────┬───────────┬──────────┬─────────────────────┬─────────────────┐
+    │ job_id      │ state     │ job_type │ creation_time       │ bytes_processed │
+    │ varchar     │ varchar   │ varchar  │ timestamp           │ bigint          │
+    ├─────────────┼───────────┼──────────┼─────────────────────┼─────────────────┤
+    │ query_job_1 │ Completed │ QUERY    │ 2026-07-01 12:00:00 │         1048576 │
+    └─────────────┴───────────┴──────────┴─────────────────────┴─────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the project whose jobs should be listed.
+    ATTACH 'project=my-gcp-project'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- List jobs using the attached catalog configuration.
+    SELECT
+          job_id,
+          state,
+          job_type,
+          creation_time,
+          bytes_processed
+      FROM bigquery_jobs(
+          'bq',
+          stateFilter := 'DONE',
+          maxResults := 100
+      )
+      ORDER BY creation_time DESC;
+    ┌─────────────┬───────────┬──────────┬─────────────────────┬─────────────────┐
+    │ job_id      │ state     │ job_type │ creation_time       │ bytes_processed │
+    │ varchar     │ varchar   │ varchar  │ timestamp           │ bigint          │
+    ├─────────────┼───────────┼──────────┼─────────────────────┼─────────────────┤
+    │ query_job_1 │ Completed │ QUERY    │ 2026-07-01 12:00:00 │         1048576 │
+    └─────────────┴───────────┴──────────┴─────────────────────┴─────────────────┘
+    ```
+
+Inspect one job:
+
+=== "Project ID"
+
+    ```sql
+    -- Inspect one BigQuery job by its ID.
+    SELECT
+          state,
+          job_id,
+          project,
+          location,
+          job_type,
+          status
+      FROM bigquery_jobs(
+          'my-gcp-project',
+          jobId := 'my_job_id'
+      );
+    ┌───────────┬───────────┬────────────────┬──────────┬──────────┬──────────────────┐
+    │ state     │ job_id    │ project        │ location │ job_type │ status           │
+    │ varchar   │ varchar   │ varchar        │ varchar  │ varchar  │ json             │
+    ├───────────┼───────────┼────────────────┼──────────┼──────────┼──────────────────┤
+    │ Completed │ my_job_id │ my-gcp-project │ EU       │ QUERY    │ {"state":"DONE"} │
+    └───────────┴───────────┴────────────────┴──────────┴──────────┴──────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the project that owns the job.
+    ATTACH 'project=my-gcp-project'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- Inspect the job using the attached catalog configuration.
+    SELECT
+          state,
+          job_id,
+          project,
+          location,
+          job_type,
+          status
+      FROM bigquery_jobs(
+          'bq',
+          jobId := 'my_job_id'
+      );
+    ┌───────────┬───────────┬────────────────┬──────────┬──────────┬──────────────────┐
+    │ state     │ job_id    │ project        │ location │ job_type │ status           │
+    │ varchar   │ varchar   │ varchar        │ varchar  │ varchar  │ json             │
+    ├───────────┼───────────┼────────────────┼──────────┼──────────┼──────────────────┤
+    │ Completed │ my_job_id │ my-gcp-project │ EU       │ QUERY    │ {"state":"DONE"} │
+    └───────────┴───────────┴────────────────┴──────────┴──────────┴──────────────────┘
+    ```
+
+Parameter names mirror the official `jobs.list` API and intentionally use
+camel case. See the
+[`bigquery_jobs` reference](../function-reference/bigquery-jobs.md) for filters,
+defaults, result columns, and endpoint rules.
+
+## Timeouts and Costs
+
+Function-level `timeout_ms` and `bq_query_timeout_ms` control local waiting.
+They do not guarantee cancellation: a timed-out query, load, or extract can
+continue running and incurring charges.
+
+The storage project identifies data, while the billing project consumes quota
+and receives applicable charges. Direct Storage Read and GoogleSQL query jobs
+have different cost models. Use restrictive predicates, dry runs,
+dataset-scoped attachments, and dedicated billing projects where appropriate.
+
+Review the canonical [Billing and Costs](../index.md#billing-and-costs) warning
+before submitting work.

--- a/docs/user-guide/managing-tables-and-schemas.md
+++ b/docs/user-guide/managing-tables-and-schemas.md
@@ -1,0 +1,420 @@
+# Managing Tables & Datasets
+
+BigQuery datasets appear as schemas in an attached DuckDB catalog. The
+attached DDL surface uses `SCHEMA` statements to create and delete BigQuery
+datasets, and `TABLE` statements to create, alter, and delete tables.
+
+The examples assume that `my-gcp-project` is attached as the writable catalog
+`bq`. See [Attaching Projects](attach.md) for attachment and
+access-mode configuration. The active identity also needs the corresponding
+[permissions](../getting-started/required-permissions.md).
+
+## Managing Datasets
+
+### Create a Dataset
+
+Use DuckDB's `CREATE SCHEMA` syntax to create a BigQuery dataset:
+
+```sql
+-- Create my-gcp-project.my_dataset.
+CREATE SCHEMA bq.my_dataset;
+```
+
+The dataset is created in `my-gcp-project`. Its location is controlled by
+`bq_default_location`. `CREATE OR REPLACE SCHEMA` and `ALTER SCHEMA` are not
+supported by the attached catalog.
+
+A project-scoped attachment is the most useful form for dataset management
+because the newly created dataset can then be discovered through the same
+catalog.
+
+### Create a Dataset with Options
+
+`CREATE SCHEMA ... OPTIONS` is supported only when the additional experimental
+flag `bq_experimental_enable_sql_parser` is enabled. BigQuery defines the
+available names, value types, and restrictions in its
+[schema option list](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#schema_option_list).
+
+The `OPTIONS` clause configures dataset properties as part of the
+`CREATE SCHEMA` statement. Specify each property as `name=value` and separate
+multiple properties with commas:
+
+```sql
+-- Run the DDL job in the same location as the new dataset.
+SET bq_default_location = 'EU';
+
+-- Enable BigQuery-specific CREATE SCHEMA clauses.
+SET bq_experimental_enable_sql_parser = true;
+
+-- Create a BigQuery dataset with several string-valued options.
+CREATE SCHEMA bq.my_options_dataset
+  OPTIONS (
+      location='EU',
+      friendly_name='DuckDB analytics',
+      description='Dataset managed through DuckDB',
+      default_rounding_mode='ROUND_HALF_EVEN',
+      storage_billing_model='LOGICAL'
+  );
+```
+
+The options in this example have these effects:
+
+| Option | Effect |
+| --- | --- |
+| `location` | Creates the dataset in `EU`. For attached DDL, keep this equal to `bq_default_location`, which controls the location of the query job. |
+| `friendly_name` | Sets a human-readable dataset name without changing the dataset ID used in SQL. |
+| `description` | Stores descriptive metadata for the dataset. |
+| `default_rounding_mode` | Sets the rounding mode inherited by supported numeric fields in newly created tables. It does not change existing tables. |
+| `storage_billing_model` | Selects logical or physical storage billing. This example keeps BigQuery's `LOGICAL` model. |
+
+The extension first extracts the `OPTIONS` clause so DuckDB can parse the
+remaining statement. It then attaches the parsed key-value pairs to the schema
+create operation, reconstructs a BigQuery `CREATE SCHEMA` statement, and sends
+it to the attached project. BigQuery performs the final validation and returns
+an error for an unknown option, an invalid value, a location mismatch, or
+insufficient permissions.
+
+The attached DDL parser currently represents option values as strings.
+Consequently, use this form for string-valued options such as those shown
+above. BigQuery also supports options with other value types, including numeric
+expiration periods, booleans, and arrays. Send those as unmodified GoogleSQL
+with [`bigquery_execute`](../function-reference/bigquery-execute.md):
+
+=== "Project ID"
+
+    ```sql
+    -- Use raw GoogleSQL when option values are not strings.
+    SELECT *
+      FROM bigquery_execute(
+          'my-gcp-project',
+          'CREATE SCHEMA `my-gcp-project.advanced_dataset`
+           OPTIONS (
+               location="EU",
+               default_table_expiration_days=30,
+               default_partition_expiration_days=7,
+               is_case_insensitive=TRUE,
+               labels=[
+                   ("environment", "development"),
+                   ("owner", "data_team")
+               ]
+           )'
+      );
+    ┌─────────┬─────────────────┬────────────────┬───┬───────────────────────┐
+    │ success │ job_id          │ project_id     │ … │ num_dml_affected_rows │
+    │ boolean │ varchar         │ varchar        │ … │ bigint                │
+    ├─────────┼─────────────────┼────────────────┼───┼───────────────────────┤
+    │ true    │ execute_job_123 │ my-gcp-project │ … │                     0 │
+    └─────────┴─────────────────┴────────────────┴───┴───────────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Forward the same GoogleSQL through the attached catalog.
+    SELECT *
+      FROM bigquery_execute(
+          'bq',
+          'CREATE SCHEMA `my-gcp-project.advanced_dataset`
+           OPTIONS (
+               location="EU",
+               default_table_expiration_days=30,
+               default_partition_expiration_days=7,
+               is_case_insensitive=TRUE,
+               labels=[
+                   ("environment", "development"),
+                   ("owner", "data_team")
+               ]
+           )'
+      );
+    ┌─────────┬─────────────────┬────────────────┬───┬───────────────────────┐
+    │ success │ job_id          │ project_id     │ … │ num_dml_affected_rows │
+    │ boolean │ varchar         │ varchar        │ … │ bigint                │
+    ├─────────┼─────────────────┼────────────────┼───┼───────────────────────┤
+    │ true    │ execute_job_234 │ my-gcp-project │ … │                     0 │
+    └─────────┴─────────────────┴────────────────┴───┴───────────────────────┘
+    ```
+
+`bigquery_execute` forwards the SQL string without interpreting its
+`OPTIONS` clause, so BigQuery receives the numeric, boolean, and array values
+with their original types.
+
+### Delete a Dataset
+
+By default, dropping a schema uses `RESTRICT` and fails while the dataset still
+contains tables or other objects:
+
+```sql
+-- Delete only an empty dataset.
+DROP SCHEMA bq.my_dataset RESTRICT;
+```
+
+Use `CASCADE` only when the dataset and all of its contents should be removed:
+
+```sql
+-- Delete the dataset and all of its contents.
+DROP SCHEMA IF EXISTS bq.my_dataset CASCADE;
+```
+
+`CASCADE` is destructive and cannot be undone by DuckDB.
+
+## Managing Tables
+
+### Create a Table
+
+Create an empty table when its columns should be defined explicitly:
+
+```sql
+-- Create an empty BigQuery table with an explicit schema.
+CREATE TABLE bq.my_dataset.events (
+      event_id BIGINT NOT NULL,
+      event_name VARCHAR DEFAULT 'unknown',
+      event_date DATE,
+      created_at TIMESTAMP
+  );
+
+-- Inspect the created table's columns.
+DESCRIBE TABLE bq.my_dataset.events;
+┌─────────────┬─────────────┬──────┬──────┬───────────┬───────┐
+│ column_name │ column_type │ null │ key  │  default  │ extra │
+├─────────────┼─────────────┼──────┼──────┼───────────┼───────┤
+│ event_id    │ BIGINT      │ NO   │ NULL │ NULL      │ NULL  │
+│ event_name  │ VARCHAR     │ YES  │ NULL │ 'unknown' │ NULL  │
+│ event_date  │ DATE        │ YES  │ NULL │ NULL      │ NULL  │
+│ created_at  │ TIMESTAMP   │ YES  │ NULL │ NULL      │ NULL  │
+└─────────────┴─────────────┴──────┴──────┴───────────┴───────┘
+```
+
+The supported conflict forms are:
+
+```sql
+-- Keep the existing table when it already exists.
+CREATE TABLE IF NOT EXISTS bq.my_dataset.events (
+      event_id BIGINT
+  );
+
+-- Drop the existing table and create its replacement.
+CREATE OR REPLACE TABLE bq.my_dataset.events (
+      event_id BIGINT,
+      event_name VARCHAR
+  );
+```
+
+`CREATE OR REPLACE TABLE` first drops the existing table and then creates the
+replacement. Existing rows are deleted, and the two remote operations are not
+atomic. Use `IF NOT EXISTS` when an existing table should be retained.
+
+Column defaults and `NOT NULL` are supported. `PRIMARY KEY`, foreign keys,
+`UNIQUE`, `CHECK`, indexes, and other DuckDB constraint forms are not part of
+the attached table creation surface. Review
+[Data Type Mapping](../concepts/data-types.md) before creating columns with nested,
+unsigned, high-precision, or geography types.
+
+To create a table and write a query result in one operation, use
+[CTAS](writing.md#write-a-query-result-with-ctas).
+
+### Create a Table with Options
+
+`CREATE TABLE ... OPTIONS` is supported only when the additional experimental
+flag `bq_experimental_enable_sql_parser` is enabled. BigQuery defines the
+available names, value types, and restrictions in its
+[table option list](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-definition-language#table_option_list).
+
+The `OPTIONS` clause configures table properties as part of the
+`CREATE TABLE` statement. Specify each property as `name=value` and separate
+multiple properties with commas:
+
+```sql
+-- Enable BigQuery-specific CREATE TABLE options.
+SET bq_experimental_enable_sql_parser = true;
+
+-- Create a table with descriptive metadata.
+CREATE TABLE bq.my_dataset.events_with_options (
+      event_id BIGINT,
+      event_name VARCHAR,
+      created_at TIMESTAMP
+  )
+  OPTIONS (
+      friendly_name='DuckDB events',
+      description='Events created through DuckDB'
+  );
+```
+
+The extension extracts the `OPTIONS` clause before DuckDB parses the remaining
+statement, reattaches the parsed key-value pairs, and sends the reconstructed
+`CREATE TABLE` statement to BigQuery. BigQuery validates every option and
+value.
+
+As with schema options, the attached DDL parser currently represents option
+values as strings. Use it for string-valued options such as `friendly_name`,
+`description`, and `kms_key_name`. Use
+[`bigquery_execute`](../function-reference/bigquery-execute.md) when an option
+requires a timestamp expression, number, boolean, or array so that BigQuery
+receives the original GoogleSQL value type.
+
+### Partition and Cluster a Table
+
+`PARTITION BY` and `CLUSTER BY` are also supported through the additional
+experimental flag `bq_experimental_enable_sql_parser`. They control how
+BigQuery organizes table data rather than setting table metadata:
+
+```sql
+-- Enable BigQuery-specific CREATE TABLE clauses.
+SET bq_experimental_enable_sql_parser = true;
+
+-- Partition events by date and cluster each partition by customer.
+CREATE TABLE bq.my_dataset.partitioned_events (
+      event_date DATE,
+      customer_id BIGINT,
+      event_name VARCHAR
+  )
+  PARTITION BY event_date
+  CLUSTER BY customer_id;
+
+```
+
+Verify the resulting metadata through either connection form:
+
+=== "Project ID"
+
+    ```sql
+    -- Query the table metadata using a project ID.
+    SELECT
+          column_name,
+          is_partitioning_column,
+          clustering_ordinal_position
+      FROM bigquery_query(
+          'my-gcp-project',
+          'SELECT
+             column_name,
+             is_partitioning_column,
+             clustering_ordinal_position
+           FROM
+             `my-gcp-project.my_dataset.INFORMATION_SCHEMA.COLUMNS`
+           WHERE table_name = "partitioned_events"
+           ORDER BY column_name'
+      );
+    ┌─────────────┬────────────────────────┬─────────────────────────────┐
+    │ column_name │ is_partitioning_column │ clustering_ordinal_position │
+    │ varchar     │ varchar                │ int64                       │
+    ├─────────────┼────────────────────────┼─────────────────────────────┤
+    │ customer_id │ NO                     │                           1 │
+    │ event_date  │ YES                    │                        NULL │
+    │ event_name  │ NO                     │                        NULL │
+    └─────────────┴────────────────────────┴─────────────────────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Query the same metadata through the attached catalog.
+    SELECT
+          column_name,
+          is_partitioning_column,
+          clustering_ordinal_position
+      FROM bigquery_query(
+          'bq',
+          'SELECT
+             column_name,
+             is_partitioning_column,
+             clustering_ordinal_position
+           FROM
+             `my-gcp-project.my_dataset.INFORMATION_SCHEMA.COLUMNS`
+           WHERE table_name = "partitioned_events"
+           ORDER BY column_name'
+      );
+    ┌─────────────┬────────────────────────┬─────────────────────────────┐
+    │ column_name │ is_partitioning_column │ clustering_ordinal_position │
+    │ varchar     │ varchar                │ int64                       │
+    ├─────────────┼────────────────────────┼─────────────────────────────┤
+    │ customer_id │ NO                     │                           1 │
+    │ event_date  │ YES                    │                        NULL │
+    │ event_name  │ NO                     │                        NULL │
+    └─────────────┴────────────────────────┴─────────────────────────────┘
+    ```
+
+The parser extracts both clauses and adds them to the BigQuery-targeted
+`CREATE TABLE` or CTAS statement after DuckDB has parsed the remaining SQL.
+BigQuery performs the final validation of the partition expression and
+clustering columns. Ingestion-time partitioning with `_PARTITIONDATE` is also
+accepted.
+
+### Alter a Table
+
+The attached catalog supports these `ALTER TABLE` forms:
+
+| Form | Effect |
+| --- | --- |
+| `RENAME COLUMN old TO new` | Rename one column |
+| `RENAME TO new_table` | Rename the table within its dataset |
+| `ADD COLUMN [IF NOT EXISTS] name type` | Add one column |
+| `DROP COLUMN [IF EXISTS] name` | Remove one column |
+| `ALTER COLUMN name TYPE type` | Change the type when BigQuery considers it assignment-compatible |
+| `ALTER COLUMN name SET DEFAULT expression` | Set the column default |
+| `ALTER COLUMN name DROP NOT NULL` | Relax a required column |
+
+The operations can be applied sequentially:
+
+```sql
+-- Rename a column.
+ALTER TABLE bq.my_dataset.events
+  RENAME COLUMN event_name TO event_type;
+
+-- Add a nullable column.
+ALTER TABLE bq.my_dataset.events
+  ADD COLUMN source VARCHAR;
+
+-- Change to an assignment-compatible type.
+ALTER TABLE bq.my_dataset.events
+  ALTER COLUMN event_id TYPE DOUBLE;
+
+-- Define a new default for future inserts.
+ALTER TABLE bq.my_dataset.events
+  ALTER COLUMN event_type SET DEFAULT 'unknown';
+
+-- Remove a column.
+ALTER TABLE bq.my_dataset.events
+  DROP COLUMN source;
+
+-- Rename the table within my_dataset.
+ALTER TABLE bq.my_dataset.events
+  RENAME TO archived_events;
+
+-- Inspect the altered table's columns.
+DESCRIBE TABLE bq.my_dataset.archived_events;
+┌─────────────┬─────────────┬──────┬──────┬───────────┬───────┐
+│ column_name │ column_type │ null │ key  │  default  │ extra │
+├─────────────┼─────────────┼──────┼──────┼───────────┼───────┤
+│ event_id    │ DOUBLE      │ NO   │ NULL │ NULL      │ NULL  │
+│ event_type  │ VARCHAR     │ YES  │ NULL │ 'unknown' │ NULL  │
+│ event_date  │ DATE        │ YES  │ NULL │ NULL      │ NULL  │
+│ created_at  │ TIMESTAMP   │ YES  │ NULL │ NULL      │ NULL  │
+└─────────────┴─────────────┴──────┴──────┴───────────┴───────┘
+```
+
+BigQuery rejects incompatible type changes. Other DuckDB `ALTER TABLE` forms
+raise an unsupported-operation error instead of being translated.
+
+### Delete a Table
+
+Drop a table to permanently remove it and its rows. `IF EXISTS` suppresses the
+error when the table is already absent:
+
+```sql
+-- Fail when the table does not exist.
+DROP TABLE bq.my_dataset.archived_events;
+
+-- Do nothing when the table does not exist.
+DROP TABLE IF EXISTS bq.my_dataset.archived_events;
+```
+
+## Metadata and Execution Boundaries
+
+Successful creates and drops update the corresponding local catalog entry.
+After `ALTER TABLE`, the extension invalidates table metadata for the schema so
+that later lookups retrieve the changed definition. If a table or dataset was
+changed outside DuckDB and remains stale, use
+[`bigquery_clear_cache`](attach.md#refresh-metadata-and-detach).
+
+Each DDL statement runs as a remote BigQuery operation. A later DuckDB
+`ROLLBACK` does not undo a completed create, alter, or drop. `READ_ONLY`
+attachments reject every operation in this chapter.

--- a/docs/user-guide/reading-and-queries.md
+++ b/docs/user-guide/reading-and-queries.md
@@ -1,0 +1,437 @@
+# Reading and Queries
+
+The extension provides three ways to read data from BigQuery:
+
+- [`bigquery_scan`](#bigquery-scan): Direct, one-off reads from native BigQuery
+  tables through the BigQuery Storage Read API.
+- [`bigquery_query`](#bigquery-query): Custom GoogleSQL queries executed by
+  BigQuery, including queries over views, materialized views, and external
+  tables.
+- [Attached project](#select-from-an-attached-project): Reusable BigQuery
+  catalogs whose native tables can be queried with regular DuckDB SQL.
+
+`bigquery_scan` and attached table reads share the same Storage Read execution
+model. `bigquery_query` submits a query to BigQuery and returns its result rows.
+There is no automatic switch between these execution models.
+
+For inserts, updates, deletes, and query-result writes, continue with
+[Writing & Modifying Data](writing.md). Table management and job-based
+transfers are documented separately under
+[Managing Tables & Datasets](managing-tables-and-schemas.md) and
+[Extract & Load](extract-and-load.md), as well as
+[Executing & Monitoring Jobs](jobs-and-transfers.md).
+
+## Read a Native Table with `bigquery_scan` {#bigquery-scan}
+
+`bigquery_scan` targets one fully qualified native BigQuery table without
+creating a persistent catalog:
+
+```sql
+-- Read selected columns from one native BigQuery table.
+SELECT
+      a,
+      b,
+      c
+  FROM bigquery_scan('my-gcp-project.my_dataset.function_scan_test')
+  ORDER BY a;
+┌───────┬───────┬─────────┐
+│ a     │ b     │ c       │
+│ int64 │ int64 │ varchar │
+├───────┼───────┼─────────┤
+│     1 │     2 │ alpha   │
+│     3 │     4 │ beta    │
+└───────┴───────┴─────────┘
+```
+
+DuckDB executes the surrounding SQL and reads the table through the BigQuery
+Storage Read API. Projected columns are pushed into the read session.
+Eligible DuckDB filters can be pushed down with
+`bq_experimental_filter_pushdown`. The function also accepts an explicit
+trusted Storage Read `filter` string:
+
+```sql
+-- Apply an explicit Storage Read row restriction.
+SELECT
+      a,
+      c
+  FROM bigquery_scan(
+      'my-gcp-project.my_dataset.function_scan_test',
+      filter := 'b = 4'
+  );
+┌───────┬─────────┐
+│ a     │ c       │
+│ int64 │ varchar │
+├───────┼─────────┤
+│     3 │ beta    │
+└───────┴─────────┘
+```
+
+The explicit filter is
+[`TableReadOptions.row_restriction`](https://cloud.google.com/bigquery/docs/reference/storage/rpc/google.cloud.bigquery.storage.v1#google.cloud.bigquery.storage.v1.ReadSession.TableReadOptions)
+text, not a parameterized DuckDB expression. Do not construct it from
+untrusted input.
+
+Choose `bigquery_scan` when a one-off native table is the only remote object
+needed and connection reuse, catalog discovery, DDL, or writes are irrelevant.
+It does not execute GoogleSQL or read view-like relations; use
+`bigquery_query` for that. The complete parameters and error behavior are
+listed in the
+[`bigquery_scan` reference](../function-reference/bigquery-scan.md).
+
+## Run GoogleSQL with `bigquery_query` {#bigquery-query}
+
+`bigquery_query` is the standard query function when BigQuery should execute a
+[GoogleSQL](https://cloud.google.com/bigquery/docs/introduction-sql)
+statement. It supports BigQuery syntax and functions, resolves logical views,
+materialized views, and external tables, and can aggregate or join data inside
+BigQuery before transferring the result. This example queries a logical view:
+
+=== "Project ID"
+
+    ```sql
+    -- Run GoogleSQL against a BigQuery view.
+    SELECT *
+      FROM bigquery_query(
+          'my-gcp-project',
+          'SELECT name
+           FROM `my-gcp-project.my_dataset.test_cities_view`
+           ORDER BY name
+           LIMIT 1'
+      );
+    ┌───────────┐
+    │   name    │
+    │  varchar  │
+    ├───────────┤
+    │ Amsterdam │
+    └───────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the dataset containing the view.
+    ATTACH 'project=my-gcp-project dataset=my_dataset'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- Run the same GoogleSQL using the attached configuration.
+    SELECT *
+      FROM bigquery_query(
+          'bq',
+          'SELECT name
+           FROM `my-gcp-project.my_dataset.test_cities_view`
+           ORDER BY name
+           LIMIT 1'
+      );
+    ┌───────────┐
+    │   name    │
+    │  varchar  │
+    ├───────────┤
+    │ Amsterdam │
+    └───────────┘
+    ```
+
+The SQL string is GoogleSQL, not DuckDB SQL. The outer `SELECT` is DuckDB SQL
+and can continue processing the returned rows. Passing an attached catalog
+name instead of a project ID reuses all connection configuration.
+
+For a catalog call, the attachment supplies its project, credentials, billing
+project, access mode, and transaction context. Conflicting per-call billing
+options are rejected.
+
+Bind values with `?` placeholders rather than interpolating them into the SQL
+text:
+
+=== "Project ID"
+
+    ```sql
+    -- Bind values to GoogleSQL parameters.
+    SELECT *
+      FROM bigquery_query(
+          'my-gcp-project',
+          'SELECT ? AS x, ? AS y',
+          42,
+          'abc'
+      );
+    ┌───────┬─────────┐
+    │ x     │ y       │
+    │ int64 │ varchar │
+    ├───────┼─────────┤
+    │    42 │ abc     │
+    └───────┴─────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the project whose configuration should be reused.
+    ATTACH 'project=my-gcp-project'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- Bind the same values through the attached catalog.
+    SELECT *
+      FROM bigquery_query(
+          'bq',
+          'SELECT ? AS x, ? AS y',
+          42,
+          'abc'
+      );
+    ┌───────┬─────────┐
+    │ x     │ y       │
+    │ int64 │ varchar │
+    ├───────┼─────────┤
+    │    42 │ abc     │
+    └───────┴─────────┘
+    ```
+
+Cast `NULL` to a concrete type. List values are not supported as query
+parameters. The
+[`bigquery_query` reference](../function-reference/bigquery-query.md) contains
+the complete signature, named options, defaults, dry-run result, and validation
+rules.
+
+By default, `bigquery_query` determines the result schema, creates a BigQuery
+query job, materializes its result, and streams that result to DuckDB through
+the Storage Read API. This is the normal path and supports large or complex
+results. `use_rest_api := true` is an optional inline REST result path for small,
+simple result sets:
+
+=== "Project ID"
+
+    ```sql
+    -- Return a small, simple result through the REST API.
+    SELECT *
+      FROM bigquery_query(
+          'my-gcp-project',
+          'SELECT 42 AS x',
+          use_rest_api := true
+      );
+    ┌───────┐
+    │ x     │
+    │ int64 │
+    ├───────┤
+    │    42 │
+    └───────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the project whose REST configuration should be reused.
+    ATTACH 'project=my-gcp-project'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- Return the same result through the attached catalog.
+    SELECT *
+      FROM bigquery_query(
+          'bq',
+          'SELECT 42 AS x',
+          use_rest_api := true
+      );
+    ┌───────┐
+    │ x     │
+    │ int64 │
+    ├───────┤
+    │    42 │
+    └───────┘
+    ```
+
+The REST path decodes BigQuery `ARRAY` and `STRUCT` results recursively as
+DuckDB `LIST` and `STRUCT` values. BigQuery does not expose native `MAP` or
+union result types, and it rejects final query results whose arrays contain
+`NULL` elements. With `JOB_CREATION_OPTIONAL`, BigQuery prioritizes returning
+results inline but may still create a job, for example for long-running
+queries or large results. A local timeout stops waiting in DuckDB but does not
+guarantee remote cancellation. Inspect submitted work with `bigquery_jobs` as
+described under
+[Executing & Monitoring Jobs](jobs-and-transfers.md#monitor-jobs), and review
+[Billing and Costs](../index.md#billing-and-costs) before running expensive
+GoogleSQL.
+
+## SELECT from an Attached Project
+
+After [attaching a project or dataset](attach.md), native BigQuery tables
+behave like remote DuckDB relations in a reusable catalog:
+
+```sql
+-- Attach one dataset as a read-only catalog.
+ATTACH 'project=my-gcp-project dataset=my_dataset'
+  AS bq (TYPE bigquery, READ_ONLY);
+
+-- Query a native table through the attached catalog.
+SELECT
+      c,
+      a,
+      b
+  FROM bq.my_dataset.function_scan_test
+  ORDER BY a;
+┌─────────┬───────┬───────┐
+│ c       │ a     │ b     │
+│ varchar │ int64 │ int64 │
+├─────────┼───────┼───────┤
+│ alpha   │     1 │     2 │
+│ beta    │     3 │     4 │
+└─────────┴───────┴───────┘
+```
+
+DuckDB binds and plans this as DuckDB SQL. The extension obtains the table
+schema from the attached catalog, requests the necessary columns through the
+Storage Read API, and translates eligible predicates into BigQuery row
+restrictions. DuckDB evaluates the remaining expressions and performs local
+joins, sorting, grouping, and aggregation. This makes attached reads a good
+fit when BigQuery tables need to participate in a larger DuckDB query.
+
+Projection pushdown is automatic. Filter pushdown is controlled by
+`bq_experimental_filter_pushdown`; filters that cannot be represented as
+Storage Read row restrictions remain in DuckDB. Parallel reads and other
+Storage Read settings are documented under
+[Additional Settings](configuration.md#settings).
+
+The direct Storage Read boundary matters: attached scans support native
+BigQuery tables, but they do not transparently execute logical views,
+materialized views, or ordinary external tables. If a relation needs BigQuery
+query semantics, express the operation as GoogleSQL with `bigquery_query`.
+
+### Filter Pushdown
+
+Attached native-table reads can translate supported DuckDB filters to BigQuery
+Storage Read row restrictions. This reduces the number of rows transferred to
+DuckDB. Filter pushdown is enabled by default through
+`bq_experimental_filter_pushdown`:
+
+```sql
+-- Inspect whether the filter is pushed into the BigQuery scan.
+EXPLAIN
+  SELECT i
+  FROM bq.my_dataset.filter_pushdown
+  WHERE i > 5000 AND i <= 5006;
+┌───────────────────────────┐
+│       BIGQUERY_SCAN       │
+│    ────────────────────   │
+│           Table:          │
+│      my-gcp-project.      │
+│        my_dataset.        │
+│      filter_pushdown      │
+│                           │
+│         Read Mode:        │
+│        Storage Read       │
+│                           │
+│      Projections: i       │
+│                           │
+│          Filters:         │
+│   i>5000 AND i<=5006      │
+└───────────────────────────┘
+```
+
+The `Filters:` entry inside `BIGQUERY_SCAN` confirms that the condition is sent
+to BigQuery. A separate `FILTER` operator means that DuckDB still evaluates
+that part locally. Supported filters include:
+
+- Comparisons with Boolean, numeric, string, `DATE`, `TIME`, or `TIMESTAMP`
+  literals: `=`, `!=`, `<`, `<=`, `>`, and `>=`
+- `IN (...)`
+- `IS NULL` and `IS NOT NULL`
+- Combinations with `AND` and `OR`
+- Comparisons on nested `STRUCT` fields
+
+### Experimental Aggregate Pushdown
+
+The `bq_enable_aggregate_pushdown` setting enables an experimental optimizer
+rewrite for supported aggregate queries over BigQuery sources.
+
+Instead of reading all source rows through the Storage Read API and aggregating
+them in DuckDB, the optimizer can translate supported aggregates, filters, and
+grouping expressions to GoogleSQL and execute them through `bigquery_query`.
+Use `EXPLAIN` to check the execution path for a particular query:
+
+```sql
+-- Enable experimental aggregate pushdown.
+SET bq_enable_aggregate_pushdown = true;
+
+-- Inspect where the aggregation will be executed.
+EXPLAIN
+  SELECT i, COUNT(*)
+  FROM bq.my_dataset.aggregate_pushdown
+  GROUP BY i;
+┌───────────────────────────┐
+│       BIGQUERY_QUERY      │
+│    ────────────────────   │
+│           Query:          │
+│  SELECT `i` AS            │
+│  __duckdb_bq_group_0,     │
+│  COUNT(*) AS              │
+│  __duckdb_bq_aggr_0 FROM  │
+│  `my-gcp-project.         │
+│  my_dataset.              │
+│  aggregate_pushdown`      │
+│  GROUP BY `i`             │
+│                           │
+│         Type: REST        │
+│                           │
+│           ~1 row          │
+└───────────────────────────┘
+```
+
+When pushdown succeeds, the physical plan contains a `BIGQUERY_QUERY` operator
+and shows the generated GoogleSQL. The corresponding `BIGQUERY_SCAN` and local
+`GROUP_BY` operators are absent because BigQuery performs the aggregation.
+If the query shape is unsupported, the optimizer leaves the local DuckDB plan
+in place before starting a remote query.
+
+The setting is disabled by default. Runtime errors from a started BigQuery job
+are not retried with a local plan, and GoogleSQL expression semantics can
+differ from DuckDB semantics. See
+[Additional Settings](configuration.md#settings) for the
+setting reference.
+
+## Reading from Public and External Datasets
+
+Public datasets and datasets owned by another Google Cloud project separate
+the storage project from the project that supplies quota and receives
+applicable charges. In an attachment, `project` identifies where the data
+lives, while `billing_project` identifies the project used for billing and
+quota:
+
+=== "Project ID"
+
+    ```sql
+    -- Read the public table directly and bill the configured project.
+    SELECT count(*)
+      FROM bigquery_scan(
+          'bigquery-public-data.geo_us_boundaries.cnecta',
+          billing_project := 'my-gcp-project'
+      );
+    ┌──────────────┐
+    │ count_star() │
+    │ int64        │
+    ├──────────────┤
+    │            7 │
+    └──────────────┘
+    ```
+
+=== "Attached catalog"
+
+    ```sql
+    -- Attach the public dataset and specify the billing project.
+    ATTACH 'project=bigquery-public-data dataset=geo_us_boundaries billing_project=my-gcp-project'
+      AS bq (TYPE bigquery, READ_ONLY);
+
+    -- Query the public dataset through the attached catalog.
+    SELECT count(*)
+      FROM bq.geo_us_boundaries.cnecta;
+    ┌──────────────┐
+    │ count_star() │
+    │ int64        │
+    ├──────────────┤
+    │            7 │
+    └──────────────┘
+    ```
+
+The attachment stores this configuration, so subsequent reads through
+`bq` reuse the same billing project. For a one-off
+`bigquery_scan`, pass the same value with the `billing_project` named
+parameter. `billing_project` does not grant access: the active credentials
+still need the required IAM permissions.
+
+Here, “external” means a dataset in another project. Ordinary BigQuery
+external tables are not supported by direct Storage Read scans; query them
+with `bigquery_query`.

--- a/docs/user-guide/reading-and-queries.md
+++ b/docs/user-guide/reading-and-queries.md
@@ -2,13 +2,17 @@
 
 The extension provides three ways to read data from BigQuery:
 
-- [`bigquery_scan`](#bigquery-scan): Direct, one-off reads from native BigQuery
-  tables through the BigQuery Storage Read API.
-- [`bigquery_query`](#bigquery-query): Custom GoogleSQL queries executed by
-  BigQuery, including queries over views, materialized views, and external
-  tables.
-- [Attached project](#select-from-an-attached-project): Reusable BigQuery
-  catalogs whose native tables can be queried with regular DuckDB SQL.
+- **[`bigquery_scan`](#bigquery-scan)**<br>
+  Read one native BigQuery table directly through the BigQuery Storage Read
+  API without creating a catalog.
+
+- **[`bigquery_query`](#bigquery-query)**<br>
+  Run custom GoogleSQL in BigQuery, including queries over views, materialized
+  views, and external tables.
+
+- **[Attached project](#select-from-an-attached-project)**<br>
+  Reuse a BigQuery catalog whose native tables can be queried with regular
+  DuckDB SQL.
 
 `bigquery_scan` and attached table reads share the same Storage Read execution
 model. `bigquery_query` submits a query to BigQuery and returns its result rows.
@@ -28,10 +32,7 @@ creating a persistent catalog:
 
 ```sql
 -- Read selected columns from one native BigQuery table.
-SELECT
-      a,
-      b,
-      c
+SELECT a, b, c
   FROM bigquery_scan('my-gcp-project.my_dataset.function_scan_test')
   ORDER BY a;
 ┌───────┬───────┬─────────┐
@@ -51,9 +52,7 @@ trusted Storage Read `filter` string:
 
 ```sql
 -- Apply an explicit Storage Read row restriction.
-SELECT
-      a,
-      c
+SELECT a, c
   FROM bigquery_scan(
       'my-gcp-project.my_dataset.function_scan_test',
       filter := 'b = 4'
@@ -258,10 +257,7 @@ ATTACH 'project=my-gcp-project dataset=my_dataset'
   AS bq (TYPE bigquery, READ_ONLY);
 
 -- Query a native table through the attached catalog.
-SELECT
-      c,
-      a,
-      b
+SELECT c, a, b
   FROM bq.my_dataset.function_scan_test
   ORDER BY a;
 ┌─────────┬───────┬───────┐

--- a/docs/user-guide/writing.md
+++ b/docs/user-guide/writing.md
@@ -1,0 +1,234 @@
+# Writing & Modifying Data
+
+Use regular DuckDB SQL against a writable BigQuery attachment to add, change,
+or remove rows. `INSERT` appends rows, `UPDATE` changes existing rows, and
+`DELETE` removes rows. CTAS (`CREATE TABLE ... AS SELECT`) creates or replaces
+a table from a query result.
+
+The execution path depends on the operation:
+
+- [`INSERT`](#insert) and CTAS stream DuckDB rows through the BigQuery Storage
+  Write API. The extension finalizes and commits the write before the statement
+  returns.
+- [`UPDATE`](#update) and [`DELETE`](#delete) are translated to GoogleSQL and
+  submitted as BigQuery query jobs. Matching rows stay in BigQuery, and DuckDB
+  receives the affected-row count when the job completes.
+
+The examples assume that `my-gcp-project.my_dataset` is already attached as
+the writable catalog `bq`. See [Attaching Projects](attach.md) for
+attachment and access-mode configuration. Attachments created with `READ_ONLY`
+reject every operation on this page.
+
+## INSERT
+
+### Insert Values
+
+Use `INSERT ... VALUES` to append literal rows:
+
+```sql
+-- Append two events to an existing BigQuery table.
+INSERT INTO bq.my_dataset.events (
+      event_id,
+      event_name,
+      event_date
+  )
+  VALUES
+      (10001, 'signup', DATE '2026-07-01'),
+      (10002, 'purchase', DATE '2026-07-01');
+
+-- Verify the inserted rows.
+SELECT
+      event_id,
+      event_name,
+      event_date
+  FROM bq.my_dataset.events
+  WHERE event_id >= 10001
+  ORDER BY event_id;
+┌──────────┬────────────┬────────────┐
+│ event_id │ event_name │ event_date │
+│  int64   │  varchar   │    date    │
+├──────────┼────────────┼────────────┤
+│    10001 │ signup     │ 2026-07-01 │
+│    10002 │ purchase   │ 2026-07-01 │
+└──────────┴────────────┴────────────┘
+```
+
+An explicit column list makes the mapping clear and allows columns with
+defaults to be omitted. A successful attached `INSERT` does not emit a result
+row. Run a separate query, as shown above, when the written data or row count
+needs to be verified.
+
+### Insert a Query Result
+
+`INSERT ... SELECT` appends the result of a DuckDB query:
+
+```sql
+-- Read local Parquet files and append their rows to BigQuery.
+INSERT INTO bq.my_dataset.events
+  SELECT
+      event_id::BIGINT,
+      event_name::VARCHAR,
+      event_date::DATE
+  FROM read_parquet('/absolute/path/events/new/*.parquet')
+  WHERE event_date = DATE '2026-07-02';
+
+-- Count the rows written for that date.
+SELECT count(*) AS written_rows
+  FROM bq.my_dataset.events
+  WHERE event_date = DATE '2026-07-02';
+┌──────────────┐
+│ written_rows │
+│    int64     │
+├──────────────┤
+│          250 │
+└──────────────┘
+```
+
+Source and destination columns are matched by position unless an explicit
+target column list is provided. Their types must be compatible.
+
+## UPDATE
+
+Use `UPDATE` to change values in existing rows:
+
+```sql
+-- Rename signup events.
+UPDATE bq.my_dataset.events
+  SET event_name = 'registered'
+  WHERE event_name = 'signup';
+┌───────┐
+│ Count │
+│ int64 │
+├───────┤
+│     1 │
+└───────┘
+```
+
+The statement returns the number of updated rows as a `BIGINT`. Assignments,
+scalar predicates, and supported nested struct paths are translated to
+GoogleSQL:
+
+```sql
+-- Mark customers whose nested address contains New York.
+UPDATE bq.my_dataset.customers
+  SET marker = 9
+  WHERE customer_info.address.city = 'New York';
+┌───────┐
+│ Count │
+│ int64 │
+├───────┤
+│     2 │
+└───────┘
+```
+
+An `UPDATE` without a `WHERE` clause applies to every row. The generated
+GoogleSQL uses `WHERE true` because BigQuery requires an explicit condition.
+
+## DELETE
+
+Use `DELETE` to remove rows:
+
+```sql
+-- Remove events older than 2025.
+DELETE FROM bq.my_dataset.events
+  WHERE created_at < TIMESTAMP '2025-01-01';
+┌───────┐
+│ Count │
+│ int64 │
+├───────┤
+│    42 │
+└───────┘
+```
+
+The statement returns the number of deleted rows as a `BIGINT`. A `DELETE`
+without a `WHERE` clause removes every row; the generated GoogleSQL again uses
+`WHERE true`.
+
+## Write a Query Result with CTAS
+
+CTAS combines table creation with `INSERT ... SELECT` and infers the
+destination schema from the query result.
+
+For example, read Parquet files with DuckDB, select the required columns, and
+write the result directly to BigQuery:
+
+```sql
+-- Create or replace a BigQuery table from local Parquet files.
+CREATE OR REPLACE TABLE bq.my_dataset.events AS
+  SELECT
+      event_id::BIGINT AS event_id,
+      event_name::VARCHAR AS event_name,
+      event_date::DATE AS event_date
+  FROM read_parquet('/absolute/path/events/*.parquet')
+  WHERE event_date >= DATE '2026-01-01';
+
+-- Count all rows written to the destination table.
+SELECT count(*) AS written_rows
+  FROM bq.my_dataset.events;
+┌──────────────┐
+│ written_rows │
+│    int64     │
+├──────────────┤
+│        10000 │
+└──────────────┘
+```
+
+The source is a regular DuckDB query. It can read local tables, files, attached
+catalogs, or a combination of them, and can filter, join, aggregate, or cast
+the rows before they are written.
+
+Both `CREATE TABLE ... AS` and `CREATE OR REPLACE TABLE ... AS` are supported.
+The latter replaces an existing destination, so use it only when overwriting
+the table is intentional. BigQuery-specific
+[table options](managing-tables-and-schemas.md#create-a-table-with-options) and
+[partitioning and clustering](managing-tables-and-schemas.md#partition-and-cluster-a-table)
+are documented under [Managing Tables & Datasets](managing-tables-and-schemas.md).
+
+## Type Conversion
+
+CTAS derives the BigQuery schema from the DuckDB result types. `INSERT`
+converts each source column to the corresponding destination type. Cast source
+columns explicitly when inference would produce an unsupported or unintended
+type.
+
+For example, DuckDB returns `HUGEINT` for `sum(INTEGER)`, while attached
+BigQuery table creation does not support `HUGEINT`:
+
+```sql
+-- Cast an aggregate to a supported destination type.
+CREATE OR REPLACE TABLE bq.my_dataset.daily_totals AS
+  SELECT
+      event_date,
+      sum(event_count)::BIGINT AS event_count
+  FROM local_event_counts
+  GROUP BY event_date;
+```
+
+Common scalar types, lists, structs, and geography values are supported. See
+[Data Type Mapping](../concepts/data-types.md) for the complete mappings and
+[Working with Geometries](geometry-support.md) for CRS and spherical-geography
+considerations.
+
+## Limitations and Safety
+
+The attached write surface does not support:
+
+- `RETURNING` on `INSERT`, `UPDATE`, or `DELETE`;
+- `INSERT ... ON CONFLICT`;
+- complex `UPDATE` or `DELETE` filters that cannot be translated without
+  changing their meaning;
+- incompatible `INSERT` source and destination columns;
+- unsupported DuckDB write types such as `HUGEINT`, `UHUGEINT`, `UBIGINT`,
+  `TIMESTAMP_TZ`, and `TIMESTAMP_NS`.
+
+Use [`bigquery_execute`](jobs-and-transfers.md#execute-googlesql) for
+compatible BigQuery operations that are not represented by the attached
+catalog. Use [`bigquery_load`](extract-and-load.md#load-data) for a BigQuery
+load job from local files, Cloud Storage objects, or a DuckDB table.
+
+Remote writes are not part of a multi-statement transaction that can be rolled
+back in DuckDB. Use explicit, selective conditions for updates and deletes,
+and review [Billing and Costs](../index.md#billing-and-costs) before running
+broad operations. See
+[Required Permissions](../getting-started/required-permissions.md) for IAM
+guidance.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,105 @@
+site_name: DuckDB BigQuery Extension
+site_url: https://hafenkran.github.io/duckdb-bigquery/
+site_description: Query, read, and write Google BigQuery data from DuckDB
+site_author: duckdb-bigquery contributors
+repo_name: hafenkran/duckdb-bigquery
+repo_url: https://github.com/hafenkran/duckdb-bigquery
+edit_uri: edit/main/docs/
+docs_dir: docs
+site_dir: build/docs-site
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/link
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      accent: indigo
+      toggle:
+        icon: material/toggle-switch-off
+        name: Switch to system preference
+  font:
+    text: Roboto
+    code: Roboto Mono
+  features:
+    - navigation.footer
+    - navigation.expand
+    - navigation.indexes
+    - navigation.tracking
+    - content.code.copy
+    - content.action.edit
+    - content.tooltips
+    - search.highlight
+    - search.share
+    - search.suggest
+    - toc.follow
+
+plugins:
+  - search:
+      separator: '[\s\-,:!=\[\]()"/_]+'
+
+markdown_extensions:
+  - attr_list
+  - admonition
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets:
+      base_path:
+        - .
+        - docs
+      check_paths: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Install, Attach, and Query: getting-started/install-attach-and-query.md
+      - Authentication & Secrets: getting-started/authentication-and-secrets.md
+      - Required Permissions: getting-started/required-permissions.md
+  - User Guide:
+      - Attaching Projects: user-guide/attach.md
+      - "Managing Tables & Datasets": user-guide/managing-tables-and-schemas.md
+      - Reading & Queries: user-guide/reading-and-queries.md
+      - "Writing & Modifying Data": user-guide/writing.md
+      - Extract & Load: user-guide/extract-and-load.md
+      - "Executing & Monitoring Jobs": user-guide/jobs-and-transfers.md
+      - Working with Geometries: user-guide/geometry-support.md
+      - Additional Settings: user-guide/configuration.md
+  - Concepts:
+      - concepts/index.md
+      - Architecture: concepts/architecture.md
+      - Data Type Mapping: concepts/data-types.md
+  - Function Reference:
+      - function-reference/index.md
+      - bigquery_scan: function-reference/bigquery-scan.md
+      - bigquery_query: function-reference/bigquery-query.md
+      - bigquery_execute: function-reference/bigquery-execute.md
+      - bigquery_load: function-reference/bigquery-load.md
+      - bigquery_extract: function-reference/bigquery-extract.md
+      - bigquery_jobs: function-reference/bigquery-jobs.md
+      - bigquery_attach: function-reference/bigquery-attach.md
+      - bigquery_clear_cache: function-reference/bigquery-clear-cache.md
+      - bigquery_normalize_geography: function-reference/bigquery-normalize-geography.md
+  - Troubleshooting: troubleshooting.md
+  - Changelog: changelog.md
+  - License: license.md

--- a/scripts/check_docs.py
+++ b/scripts/check_docs.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Check documentation conventions that MkDocs does not validate."""
+
+from pathlib import Path
+import re
+import sys
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCS = ROOT / "docs"
+MKDOCS = ROOT / "mkdocs.yml"
+
+FORBIDDEN = {
+    "my_gcp_project": "use the valid project ID my-gcp-project",
+    "my_billing_project": "use the valid project ID my-billing-project",
+    "localhost:8000": "use a relative documentation link",
+    'title="DuckDB CLI"': "use an ordinary commented SQL block",
+}
+
+
+def markdown_files() -> list[Path]:
+    return sorted(DOCS.rglob("*.md"))
+
+
+def navigation_targets(value: object):
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from navigation_targets(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from navigation_targets(item)
+
+
+def main() -> int:
+    errors: list[str] = []
+
+    for path in markdown_files():
+        relative = path.relative_to(ROOT)
+        for line_number, line in enumerate(path.read_text().splitlines(), 1):
+            for text, guidance in FORBIDDEN.items():
+                if text in line:
+                    errors.append(f"{relative}:{line_number}: {guidance}")
+            if re.match(r"^\s*D(?: |$)", line):
+                errors.append(f"{relative}:{line_number}: remove the DuckDB CLI prompt")
+            if re.match(r"^#{1,6} .*\s+$", line):
+                errors.append(f"{relative}:{line_number}: heading has trailing whitespace")
+
+    config = yaml.safe_load(MKDOCS.read_text())
+    for target in navigation_targets(config.get("nav", [])):
+        page = DOCS / target
+        if not page.is_file():
+            errors.append(f"mkdocs.yml: navigation target does not exist: {target}")
+
+    if errors:
+        print("Documentation checks failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+
+    print("Documentation conventions and navigation are valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds a complete MkDocs Material documentation site for the extension, including structured guides, function references, consistent SQL examples, and automated validation and deployment through GitHub Pages.

- Add a comprehensive MkDocs Material documentation site for the DuckDB BigQuery extension.
- Organize installation, authentication, permissions, user guides, concepts, function references, troubleshooting, changelog, and license documentation.
- Standardize SQL examples, terminology, outputs, and cross-references.
- Add project, release, build, and license badges.
- Add a GitHub Pages workflow that validates pull requests and deploys the from `main`.
- Configure the project URL for publication at https://hafenkran.github.io/duckdb-bigquery/`.

