### PR TITLE
Support best-effort certificate revocation checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,9 +665,23 @@ D CREATE TABLE bq.my_dataset.partition_tbl (i BIGINT)
 | `bq_experimental_use_info_schema`      | [EXPERIMENTAL] - Use information schema to fetch catalog info (often faster than REST API)                                                                                                                                                           | `true`  |
 | `bq_experimental_enable_sql_parser`    | [EXPERIMENTAL] - Enable BigQuery CREATE TABLE clause parsing extensions (PARTITION BY / CLUSTER BY / OPTIONS)                                                                                                                                        | `false` |
 | `bq_curl_ca_bundle_path`               | Path to the CA certificates used by cURL for SSL certificate verification                                                                                                                                                                            |         |
+| `bq_curl_ssl_revoke_best_effort`       | On Windows with Schannel, allow cURL requests to continue when certificate revocation distribution points are missing or offline. Known revoked certificates are still rejected.                                                                    | `false` |
 | `bq_max_read_streams`                  | Maximum number of read streams requested for BigQuery Storage Read. Set to 0 to match the number of DuckDB threads. Requires `SET preserve_insertion_order=FALSE` for parallelization to work, and BigQuery may return fewer streams than requested. | `0`     |
 | `bq_enable_inflight_request_windowing` | Whether to keep multiple BigQuery Storage Write `AppendRows` requests in flight before waiting for acknowledgements. Usually faster, but slightly less memory efficient. Set to `false` to fall back to synchronous write/read lockstep.             | `true`  |
 | `bq_arrow_compression`                 | Compression codec for BigQuery Storage Read API. Options: `UNSPECIFIED`, `LZ4_FRAME`, `ZSTD`                                                                                                                                                         | `ZSTD`  |
+
+On Windows builds using Schannel, certificate verification can fail if the CRL
+or OCSP distribution point cannot be reached. To tolerate only missing or
+offline revocation endpoints for cURL-based BigQuery REST and authentication
+requests, enable:
+
+```sql
+SET bq_curl_ssl_revoke_best_effort = true;
+```
+
+This setting does not disable certificate verification and does not accept a
+certificate that Windows can identify as revoked. It does not affect the gRPC
+transport used by the BigQuery Storage APIs.
 
 ### Experimental Aggregate Pushdown
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -57,7 +57,9 @@ ExternalProject_Add(
     gcp
     URL ${CMAKE_CURRENT_SOURCE_DIR}/vendor/google-cloud-cpp-2.47.1.zip
     URL_HASH SHA256=3e82f5594c54c795b4fc6117f78e1bd5de98f435229e0f0ed4a6be45153485ad
-    PATCH_COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patches/google-cloud-cpp-2.47.1-bigquery-load-and-auth.patch
+    PATCH_COMMAND
+        patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patches/google-cloud-cpp-2.47.1-bigquery-load-and-auth.patch
+        COMMAND patch -p1 -i ${CMAKE_CURRENT_SOURCE_DIR}/patches/google-cloud-cpp-2.47.1-curl-ssl-options.patch
     # CONFIGURE_HANDLED_BY_BUILD TRUE
     CMAKE_ARGS ${GCP_CMAKE_ARGS}
                -DBUILD_TESTING=OFF

--- a/external/patches/google-cloud-cpp-2.47.1-curl-ssl-options.patch
+++ b/external/patches/google-cloud-cpp-2.47.1-curl-ssl-options.patch
@@ -1,0 +1,207 @@
+diff --git a/google/cloud/rest_options.h b/google/cloud/rest_options.h
+index 38a9e09d..0a9b9387 100644
+--- a/google/cloud/rest_options.h
++++ b/google/cloud/rest_options.h
+@@ -66,6 +66,17 @@ struct SslCtxCallbackOption {
+   using Type = SslCtxCallback;
+ };
+
++/**
++ * Set the CURLOPT_SSL_OPTIONS bitmask on libcurl handles.
++ *
++ * Values are backend-specific combinations of CURLSSLOPT_* constants. This is
++ * an advanced option and should only be used when the corresponding libcurl
++ * backend behavior is understood.
++ */
++struct CurlSslOptionsOption {
++  using Type = long;
++};
++
+ }  // namespace experimental
+
+ /**
+@@ -105,7 +116,8 @@ struct Interface {
+ using RestOptionList =
+     ::google::cloud::OptionList<QuotaUserOption, RestTracingOptionsOption,
+                                 ServerTimeoutOption, UserIpOption, Interface,
+-                                experimental::SslCtxCallbackOption>;
++                                experimental::SslCtxCallbackOption,
++                                experimental::CurlSslOptionsOption>;
+
+ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+ }  // namespace cloud
+diff --git a/google/cloud/internal/curl_handle_factory.h b/google/cloud/internal/curl_handle_factory.h
+index d6b49beb..428ce7a2 100644
+--- a/google/cloud/internal/curl_handle_factory.h
++++ b/google/cloud/internal/curl_handle_factory.h
+@@ -64,6 +64,8 @@ class CurlHandleFactory {
+   // Only virtual for testing purposes.
+   virtual void SetCurlStringOption(CURL* handle, CURLoption option_tag,
+                                    char const* value);
++  virtual void SetCurlLongOption(CURL* handle, CURLoption option_tag,
++                                 long value);
+ };
+
+ std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory(
+@@ -111,6 +113,7 @@ class DefaultCurlHandleFactory : public CurlHandleFactory {
+   absl::optional<std::string> capath_;
+   std::vector<absl::string_view> ca_certs_;
+   experimental::SslCtxCallback ssl_ctx_callback_;
++  absl::optional<long> curl_ssl_options_;
+ };
+
+ /**
+@@ -166,6 +169,7 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
+   absl::optional<std::string> capath_;
+   std::vector<absl::string_view> ca_certs_;
+   experimental::SslCtxCallback ssl_ctx_callback_;
++  absl::optional<long> curl_ssl_options_;
+
+   mutable std::mutex handles_mu_;
+   std::deque<CurlPtr> handles_;
+diff --git a/google/cloud/internal/curl_handle_factory.cc b/google/cloud/internal/curl_handle_factory.cc
+index fd501423..9ff5b200 100644
+--- a/google/cloud/internal/curl_handle_factory.cc
++++ b/google/cloud/internal/curl_handle_factory.cc
+@@ -118,6 +118,11 @@ void CurlHandleFactory::SetCurlStringOption(CURL* handle, CURLoption option_tag,
+   curl_easy_setopt(handle, option_tag, value);
+ }
+
++void CurlHandleFactory::SetCurlLongOption(CURL* handle, CURLoption option_tag,
++                                          long value) {
++  curl_easy_setopt(handle, option_tag, value);
++}
++
+ std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory() {
+   static auto const* const kFactory =
+       new auto(std::make_shared<DefaultCurlHandleFactory>());
+@@ -127,7 +132,8 @@ std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory() {
+ std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory(
+     Options const& options) {
+   if (!options.get<CARootsFilePathOption>().empty() ||
+-      !options.get<experimental::CAInMemoryOption>().empty()) {
++      !options.get<experimental::CAInMemoryOption>().empty() ||
++      options.has<experimental::CurlSslOptionsOption>()) {
+     return std::make_shared<DefaultCurlHandleFactory>(options);
+   }
+
+@@ -135,6 +141,10 @@ std::shared_ptr<CurlHandleFactory> GetDefaultCurlHandleFactory(
+ }
+
+ DefaultCurlHandleFactory::DefaultCurlHandleFactory(Options const& o) {
++  if (o.has<experimental::CurlSslOptionsOption>()) {
++    curl_ssl_options_ = o.get<experimental::CurlSslOptionsOption>();
++  }
++
+   if (o.has<experimental::SslCtxCallbackOption>()) {
+     ssl_ctx_callback_ = o.get<experimental::SslCtxCallbackOption>();
+     return;
+@@ -182,6 +192,10 @@ void DefaultCurlHandleFactory::CleanupMultiHandle(CurlMulti m,
+ }
+
+ void DefaultCurlHandleFactory::SetCurlOptions(CURL* handle) {
++  if (curl_ssl_options_) {
++    SetCurlLongOption(handle, CURLOPT_SSL_OPTIONS, *curl_ssl_options_);
++  }
++
+   if (ssl_ctx_callback_) {
+     SetCurlStringOption(handle, CURLOPT_CAINFO, nullptr);
+     SetCurlStringOption(handle, CURLOPT_CAPATH, nullptr);
+@@ -227,6 +241,10 @@ void DefaultCurlHandleFactory::SetCurlOptions(CURL* handle) {
+ PooledCurlHandleFactory::PooledCurlHandleFactory(std::size_t maximum_size,
+                                                  Options const& o)
+     : maximum_size_(maximum_size) {
++  if (o.has<experimental::CurlSslOptionsOption>()) {
++    curl_ssl_options_ = o.get<experimental::CurlSslOptionsOption>();
++  }
++
+   if (o.has<experimental::SslCtxCallbackOption>()) {
+     ssl_ctx_callback_ = o.get<experimental::SslCtxCallbackOption>();
+     return;
+@@ -353,6 +371,10 @@ void PooledCurlHandleFactory::CleanupMultiHandle(CurlMulti m,
+ }
+
+ void PooledCurlHandleFactory::SetCurlOptions(CURL* handle) {
++  if (curl_ssl_options_) {
++    SetCurlLongOption(handle, CURLOPT_SSL_OPTIONS, *curl_ssl_options_);
++  }
++
+   if (ssl_ctx_callback_) {
+     SetCurlStringOption(handle, CURLOPT_CAINFO, nullptr);
+     SetCurlStringOption(handle, CURLOPT_CAPATH, nullptr);
+diff --git a/google/cloud/internal/curl_handle_factory_test.cc b/google/cloud/internal/curl_handle_factory_test.cc
+index 6f37a844..29fbf1a9 100644
+--- a/google/cloud/internal/curl_handle_factory_test.cc
++++ b/google/cloud/internal/curl_handle_factory_test.cc
+@@ -41,9 +41,15 @@ class OverriddenDefaultCurlHandleFactory : public DefaultCurlHandleFactory {
+     set_options_[option_tag] = value;
+     DefaultCurlHandleFactory::SetCurlStringOption(handle, option_tag, value);
+   }
++  void SetCurlLongOption(CURL* handle, CURLoption option_tag,
++                         long value) override {
++    set_long_options_[option_tag] = value;
++    DefaultCurlHandleFactory::SetCurlLongOption(handle, option_tag, value);
++  }
+
+  public:
+   std::map<int, std::string> set_options_;
++  std::map<int, long> set_long_options_;
+ };
+
+ // Version of DefaultCurlHandleFactory that keeps track of what calls have been
+@@ -62,9 +68,15 @@ class OverriddenPooledCurlHandleFactory : public PooledCurlHandleFactory {
+     set_options_[option_tag] = value;
+     PooledCurlHandleFactory::SetCurlStringOption(handle, option_tag, value);
+   }
++  void SetCurlLongOption(CURL* handle, CURLoption option_tag,
++                         long value) override {
++    set_long_options_[option_tag] = value;
++    PooledCurlHandleFactory::SetCurlLongOption(handle, option_tag, value);
++  }
+
+  public:
+   std::map<int, std::string> set_options_;
++  std::map<int, long> set_long_options_;
+ };
+
+ TEST(CurlHandleFactoryTest,
+@@ -85,6 +97,16 @@ TEST(CurlHandleFactoryTest, DefaultFactoryChannelOptionsCallsSetOptions) {
+   EXPECT_THAT(object_under_test.set_options_, ElementsAre(expected));
+ }
+
++TEST(CurlHandleFactoryTest, DefaultFactorySslOptionsCallsSetOptions) {
++  auto options = Options{}.set<experimental::CurlSslOptionsOption>(4L);
++  OverriddenDefaultCurlHandleFactory object_under_test(options);
++
++  auto const expected = std::make_pair(CURLOPT_SSL_OPTIONS, 4L);
++
++  object_under_test.CreateHandle();
++  EXPECT_THAT(object_under_test.set_long_options_, ElementsAre(expected));
++}
++
+ TEST(CurlHandleFactoryTest, PooledFactoryNoChannelOptionsDoesntCallSetOptions) {
+   OverriddenPooledCurlHandleFactory object_under_test(2);
+
+@@ -110,6 +132,22 @@ TEST(CurlHandleFactoryTest, PooledFactoryChannelOptionsCallsSetOptions) {
+   EXPECT_THAT(object_under_test.set_options_, ElementsAre(expected));
+ }
+
++TEST(CurlHandleFactoryTest, PooledFactorySslOptionsCallsSetOptions) {
++  auto options = Options{}.set<experimental::CurlSslOptionsOption>(4L);
++  OverriddenPooledCurlHandleFactory object_under_test(2, options);
++
++  auto const expected = std::make_pair(CURLOPT_SSL_OPTIONS, 4L);
++
++  {
++    object_under_test.CreateHandle();
++    EXPECT_THAT(object_under_test.set_long_options_, ElementsAre(expected));
++  }
++  object_under_test.set_long_options_.clear();
++
++  object_under_test.CreateHandle();
++  EXPECT_THAT(object_under_test.set_long_options_, ElementsAre(expected));
++}
++
+ TEST(CurlHandleFactoryTest, Bug14132Regression) {
+   auto constexpr kPoolSize = 32;
+   PooledCurlHandleFactory pool(kPoolSize);

--- a/src/bigquery_client.cpp
+++ b/src/bigquery_client.cpp
@@ -42,11 +42,13 @@
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/internal/unified_rest_credentials.h"
+#include "google/cloud/rest_options.h"
 
 #include "arrow/api.h"
 #include "arrow/io/api.h"
 #include "arrow/ipc/api.h"
 #include "arrow/ipc/writer.h"
+#include <curl/curl.h>
 #include "grpcpp/grpcpp.h"
 
 #include <chrono>
@@ -60,6 +62,18 @@ namespace duckdb {
 namespace bigquery {
 namespace {
 
+static void ApplyCurlTransportOptions(google::cloud::Options &options) {
+    auto ca_path = BigquerySettings::CurlCaBundlePath();
+    if (!ca_path.empty()) {
+        options.set<google::cloud::CARootsFilePathOption>(ca_path);
+    }
+
+    if (BigquerySettings::CurlSslRevokeBestEffort()) {
+        options.set<google::cloud::experimental::CurlSslOptionsOption>(
+            static_cast<long>(CURLSSLOPT_REVOKE_BEST_EFFORT));
+    }
+}
+
 static google::cloud::Options BigqueryAuthOptions() {
     auto options = google::cloud::Options{};
     auto auth_timeout = BigquerySettings::GetAuthTimeoutSeconds();
@@ -70,10 +84,7 @@ static google::cloud::Options BigqueryAuthOptions() {
         options.set<google::cloud::rest_internal::DownloadStallMinimumRateOption>(1);
     }
 
-    auto ca_path = BigquerySettings::CurlCaBundlePath();
-    if (!ca_path.empty()) {
-        options.set<google::cloud::CARootsFilePathOption>(ca_path);
-    }
+    ApplyCurlTransportOptions(options);
     return options;
 }
 
@@ -417,11 +428,7 @@ google::cloud::Options BigqueryClient::OptionsAPI() {
         }
     }
 
-    // Set CA bundle path if provided
-    auto ca_path = BigquerySettings::CurlCaBundlePath();
-    if (!ca_path.empty()) {
-        options.set<google::cloud::CARootsFilePathOption>(ca_path);
-    }
+    ApplyCurlTransportOptions(options);
 
     // Set default credentials if no secret credentials were set
     if (!credentials_set) {

--- a/src/bigquery_extension.cpp
+++ b/src/bigquery_extension.cpp
@@ -179,6 +179,12 @@ static void LoadInternal(ExtensionLoader &loader) {
                               LogicalType::VARCHAR,
                               Value(bigquery::BigquerySettings::CurlCaBundlePath()),
                               bigquery::BigquerySettings::SetCurlCaBundlePath);
+    config.AddExtensionOption("bq_curl_ssl_revoke_best_effort",
+                              "On Windows with Schannel, ignore certificate revocation failures caused by missing or "
+                              "offline distribution points",
+                              LogicalType::BOOLEAN,
+                              Value(bigquery::BigquerySettings::CurlSslRevokeBestEffort()),
+                              bigquery::BigquerySettings::SetCurlSslRevokeBestEffort);
     config.AddExtensionOption("bq_max_read_streams",
                               "Maximum number of read streams requested for BigQuery Storage Read. Set to 0 to match "
                               "the number of DuckDB threads. `preserve_insertion_order` must be false for "

--- a/src/include/bigquery_settings.hpp
+++ b/src/include/bigquery_settings.hpp
@@ -115,6 +115,15 @@ public:
         CurlCaBundlePath() = path;
     }
 
+    static bool &CurlSslRevokeBestEffort() {
+        static bool CURL_SSL_REVOKE_BEST_EFFORT = false;
+        return CURL_SSL_REVOKE_BEST_EFFORT;
+    }
+
+    static void SetCurlSslRevokeBestEffort(ClientContext &context, SetScope scope, Value &parameter) {
+        CurlSslRevokeBestEffort() = BooleanValue::Get(parameter);
+    }
+
     static void TryDetectCurlCaBundlePath() {
         string path = DetectCAPath();
         if (path.empty()) {


### PR DESCRIPTION
> Note: This MR is just for testing purposes.

This adds the opt-in `bq_curl_ssl_revoke_best_effort` setting, which is disabled by default.
When enabled, it forwards `CURLSSLOPT_REVOKE_BEST_EFFORT` to google-cloud-cpp’s default and pooled cURL handle factories. The option applies to cURL-based BigQuery REST and authentication requests, but not to the gRPC transport used by the BigQuery Storage APIs.

On Windows builds using Schannel, TLS connections can fail when a certificate’s CRL or OCSP distribution point is missing or unreachable. This option allows such connections to continue without disabling certificate verification completely. Certificates already known to be revoked are still rejected.

The cleanest solution remains to make the CRL endpoint reachable from the machine running the application. This setting is intended as an explicit fallback for environments where that is not currently possible.

